### PR TITLE
Update x64runf30f.c

### DIFF
--- a/src/emu/x64runf30f.c
+++ b/src/emu/x64runf30f.c
@@ -309,6 +309,11 @@ int RunF30F(x64emu_t *emu, rex_t rex)
         GX->d[0] = EX->sd[0];
         break;
 
+    case 0x1E:  /* NOP (multi-byte), endbr64 */
+		nextop = F8;
+		GETED(0);
+        break;            
+            
     default:
         return 1;
     }


### PR DESCRIPTION
For opcodes:
1688|0x40ee00: Unimplemented Opcode (90) F3 0F 1E FA 31 ED 49 89 D1 5E 48 89 E2 48 83
1688|0x40eeb0: Unimplemented Opcode (00) F3 0F 1E FA 80 3D A5 FA EE 00 00 75 13 55 48
1688|0x9ca7d8: Unimplemented Opcode (00) F3 0F 1E FA 48 83 EC 08 48 83 C4 08 C3 00 00