### PR TITLE
Fix broken link and a typo in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Because Box64 uses the native versions of some "system" libraries, like libc, li
 
 Box64 integrates a DynaRec (dynamic recompiler) for the ARM64 platform, providing a speed boost between 5 to 10 times faster than only using the interpreter. Some high level information on how the Dynarec work can be found [here](https://box86.org/2021/07/inner-workings-a-high%e2%80%91level-view-of-box86-and-a-low%e2%80%91level-view-of-the-dynarec/).
 
-Some x86 internal opcodes use parts of "Realmode X86 Emulator Library", see [x64primop.c](src/emu/x64primop.c) for copyright details
+Some x64 internal opcodes use parts of "Realmode X86 Emulator Library", see [x64primop.c](src/emu/x64primop.c) for copyright details
 
 <img src="Box64Icon.png" width="96" height="96">
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Because Box64 uses the native versions of some "system" libraries, like libc, li
 
 Box64 integrates a DynaRec (dynamic recompiler) for the ARM64 platform, providing a speed boost between 5 to 10 times faster than only using the interpreter. Some high level information on how the Dynarec work can be found [here](https://box86.org/2021/07/inner-workings-a-high%e2%80%91level-view-of-box86-and-a-low%e2%80%91level-view-of-the-dynarec/).
 
-Some x86 internal opcodes use parts of "Realmode X86 Emulator Library", see [x86primop.c](src/emu/x86primop.c) for copyright details
+Some x86 internal opcodes use parts of "Realmode X86 Emulator Library", see [x64primop.c](src/emu/x64primop.c) for copyright details
 
 <img src="Box64Icon.png" width="96" height="96">
 


### PR DESCRIPTION
Fix broken link and a typo in Readme.md regarding the x64primop.c