### PR TITLE
Fix missing CONFIG_64BIT kernel for older kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,6 +432,11 @@ endif()
 
 string(COMPARE EQUAL "${CMAKE_HOST_SYSTEM_PROCESSOR}" "i686"  _x86)
 string(COMPARE EQUAL "${CMAKE_HOST_SYSTEM_PROCESSOR}" "x86_64"  _x86_64)
+string(COMPARE EQUAL "${CMAKE_HOST_SYSTEM_PROCESSOR}" "aarch64"  _aarch64)
+
+if(_x86_64 OR _aarch64)
+  add_definitions(-DCONFIG_64BIT)
+endif()
 
 if(NOT _x86 AND NOT _x86_64)
   install(TARGETS ${BOX64}


### PR DESCRIPTION
On older kernel < 5.X sigcontext.h defines this flag `#ifdef CONFIG_64BIT` which prevents building on some platforms.

Tests where made on Fedora 34 - Nintendo Switch using https://gitlab.com/l4t-community/l4t-kernel-4.9 ( an up to date fork of https://gitlab.com/switchroot/kernel/l4t-kernel-4.9 )

Issue log :
```
/run/media/azkali/SHARE/Workspace/box64/src/libtools/signals.c: In function ‘my_box64signalhandler’:
/run/media/azkali/SHARE/Workspace/box64/src/libtools/signals.c:714:18: error: invalid use of undefined type ‘struct _aarch64_ctx’
  714 |         while (ff->magic && !fpsimd) {
      |                  ^~
/run/media/azkali/SHARE/Workspace/box64/src/libtools/signals.c:715:18: error: invalid use of undefined type ‘struct _aarch64_ctx’
  715 |             if(ff->magic==FPSIMD_MAGIC)
      |                  ^~
/run/media/azkali/SHARE/Workspace/box64/src/libtools/signals.c:715:27: error: ‘FPSIMD_MAGIC’ undeclared (first use in this function)
  715 |             if(ff->magic==FPSIMD_MAGIC)
      |                           ^~~~~~~~~~~~
/run/media/azkali/SHARE/Workspace/box64/src/libtools/signals.c:715:27: note: each undeclared identifier is reported only once for each function it appears in
/run/media/azkali/SHARE/Workspace/box64/src/libtools/signals.c:718:63: error: invalid use of undefined type ‘struct _aarch64_ctx’
  718 |                 ff = (struct _aarch64_ctx*)((uintptr_t)ff + ff->size);
      |                                                               ^~
/run/media/azkali/SHARE/Workspace/box64/src/libtools/signals.c:762:51: error: invalid use of undefined type ‘struct fpsimd_context’
  762 |                     ejb->emu->xmm[0].u128 = fpsimd->vregs[0];
      |                                                   ^~
/run/media/azkali/SHARE/Workspace/box64/src/libtools/signals.c:763:51: error: invalid use of undefined type ‘struct fpsimd_context’
  763 |                     ejb->emu->xmm[1].u128 = fpsimd->vregs[1];
      |                                                   ^~
/run/media/azkali/SHARE/Workspace/box64/src/libtools/signals.c:764:51: error: invalid use of undefined type ‘struct fpsimd_context’
  764 |                     ejb->emu->xmm[2].u128 = fpsimd->vregs[2];
      |                                                   ^~
/run/media/azkali/SHARE/Workspace/box64/src/libtools/signals.c:765:51: error: invalid use of undefined type ‘struct fpsimd_context’
  765 |                     ejb->emu->xmm[3].u128 = fpsimd->vregs[3];
````