### PR TITLE
Map bricks below first 2GB of address space

### DIFF
--- a/src/tools/bridge.c
+++ b/src/tools/bridge.c
@@ -35,6 +35,10 @@ typedef struct bridge_s {
     kh_bridgemap_t  *bridgemap;
 } bridge_t;
 
+// from src/wrapped/wrappedlibc.c
+void* my_mmap(x64emu_t* emu, void* addr, unsigned long length, int prot, int flags, int fd, int64_t offset);
+int my_munmap(x64emu_t* emu, void* addr, unsigned long length);
+
 brick_t* NewBrick()
 {
     brick_t* ret = (brick_t*)calloc(1, sizeof(brick_t));


### PR DESCRIPTION
This fixes an issue with mono where JIT compiled code would near-call wrapped libraries, but fail because the difference between PC and the call address did not fit into an imm32.

This was fixed by replacing posix_memalign with my_mmap and providing the MAP_32BIT flag.

Fixes #131