### PR TITLE
Add alignment wrapper to pthread_getattr_np.

### DIFF
--- a/src/libtools/threads.c
+++ b/src/libtools/threads.c
@@ -417,6 +417,11 @@ EXPORT int my_pthread_attr_setstackaddr(x64emu_t* emu, pthread_attr_t* attr, voi
 	return pthread_attr_setstack(getAlignedAttr(attr), addr, size);
 	//return pthread_attr_setstackaddr(getAlignedAttr(attr), addr);
 }
+EXPORT int my_pthread_getattr_np(x64emu_t* emu, pthread_t thread_id, pthread_attr_t* attr)
+{
+	(void)emu;
+	return pthread_getattr_np(thread_id, getAlignedAttrWithInit(attr, 0));
+}
 #endif
 
 EXPORT int my_pthread_create(x64emu_t *emu, void* t, void* attr, void* start_routine, void* arg)

--- a/src/wrapped/generated/functions_list.txt
+++ b/src/wrapped/generated/functions_list.txt
@@ -1864,6 +1864,7 @@
 #!defined(HAVE_LD80BITS) KFKp
 #!defined(HAVE_LD80BITS) vFppippKKC
 #defined(NOALIGN) iFipiip
+#!defined(NOALIGN) iFELp
 #!defined(NOALIGN) iFEppu
 #!defined(NOALIGN) iFEiiip
 #!defined(NOALIGN) iFEipii
@@ -2730,6 +2731,8 @@ wrappedlibpthread:
 - vFpi:
   - _pthread_cleanup_pop
   - _pthread_cleanup_pop_restore
+- iFLp:
+  - pthread_getattr_np
 - iFpi:
   - __pthread_mutexattr_settype
   - pthread_attr_setdetachstate

--- a/src/wrapped/generated/wrappedlibpthreadtypes.h
+++ b/src/wrapped/generated/wrappedlibpthreadtypes.h
@@ -14,6 +14,7 @@
 typedef void (*vFp_t)(void*);
 typedef int64_t (*iFp_t)(void*);
 typedef void (*vFpi_t)(void*, int64_t);
+typedef int64_t (*iFLp_t)(uintptr_t, void*);
 typedef int64_t (*iFpi_t)(void*, int64_t);
 typedef int64_t (*iFpL_t)(void*, uintptr_t);
 typedef int64_t (*iFpp_t)(void*, void*);
@@ -48,6 +49,7 @@ typedef int64_t (*iFpppp_t)(void*, void*, void*, void*);
 	GO(pthread_mutexattr_init, iFp_t) \
 	GO(_pthread_cleanup_pop, vFpi_t) \
 	GO(_pthread_cleanup_pop_restore, vFpi_t) \
+	GO(pthread_getattr_np, iFLp_t) \
 	GO(__pthread_mutexattr_settype, iFpi_t) \
 	GO(pthread_attr_setdetachstate, iFpi_t) \
 	GO(pthread_attr_setinheritsched, iFpi_t) \

--- a/src/wrapped/generated/wrapper.c
+++ b/src/wrapped/generated/wrapper.c
@@ -1909,6 +1909,7 @@ typedef int64_t (*iFipiip_t)(int64_t, void*, int64_t, int64_t, void*);
 #endif
 
 #if !defined(NOALIGN)
+typedef int64_t (*iFELp_t)(x64emu_t*, uintptr_t, void*);
 typedef int64_t (*iFEppu_t)(x64emu_t*, void*, void*, uint64_t);
 typedef int64_t (*iFEiiip_t)(x64emu_t*, int64_t, int64_t, int64_t, void*);
 typedef int64_t (*iFEipii_t)(x64emu_t*, int64_t, void*, int64_t, int64_t);
@@ -3792,6 +3793,7 @@ void iFipiip(x64emu_t *emu, uintptr_t fcn) { iFipiip_t fn = (iFipiip_t)fcn; R_RA
 #endif
 
 #if !defined(NOALIGN)
+void iFELp(x64emu_t *emu, uintptr_t fcn) { iFELp_t fn = (iFELp_t)fcn; R_RAX=(int64_t)fn(emu, (uintptr_t)R_RDI, (void*)R_RSI); }
 void iFEppu(x64emu_t *emu, uintptr_t fcn) { iFEppu_t fn = (iFEppu_t)fcn; R_RAX=(int64_t)fn(emu, (void*)R_RDI, (void*)R_RSI, (uint64_t)R_RDX); }
 void iFEiiip(x64emu_t *emu, uintptr_t fcn) { iFEiiip_t fn = (iFEiiip_t)fcn; R_RAX=(int64_t)fn(emu, (int64_t)R_RDI, (int64_t)R_RSI, (int64_t)R_RDX, (void*)R_RCX); }
 void iFEipii(x64emu_t *emu, uintptr_t fcn) { iFEipii_t fn = (iFEipii_t)fcn; R_RAX=(int64_t)fn(emu, (int64_t)R_RDI, (void*)R_RSI, (int64_t)R_RDX, (int64_t)R_RCX); }

--- a/src/wrapped/generated/wrapper.h
+++ b/src/wrapped/generated/wrapper.h
@@ -1908,6 +1908,7 @@ void iFipiip(x64emu_t *emu, uintptr_t fnc);
 #endif
 
 #if !defined(NOALIGN)
+void iFELp(x64emu_t *emu, uintptr_t fnc);
 void iFEppu(x64emu_t *emu, uintptr_t fnc);
 void iFEiiip(x64emu_t *emu, uintptr_t fnc);
 void iFEipii(x64emu_t *emu, uintptr_t fnc);

--- a/src/wrapped/wrappedlibpthread_private.h
+++ b/src/wrapped/wrappedlibpthread_private.h
@@ -116,7 +116,11 @@ GO(pthread_detach, iFL)
 GO(pthread_equal, iFLL)
 GO(pthread_exit, vFp)
 GOM(pthread_getaffinity_np, iFEpLp)
+#ifdef NOALIGN
 GO(pthread_getattr_np, iFLp)
+#else
+GOM(pthread_getattr_np, iFELp)
+#endif
 //GO(pthread_getconcurrency, iFv)
 //GO(pthread_getcpuclockid, iFup)
 GO(pthread_getschedparam, iFLpp)


### PR DESCRIPTION
This fixes stack corruption when using `pthread_getattr_np` on hirsute (Ubuntu 21.04) and libc >=2.33 by adding a wrapper with `getAlignedAttrWithInit(attr, 0)`.

This should also fix #130, but I'm still waiting for verification.