### PR TITLE
Minor changes to allow box64 to build and run on 64-bit PowerPC.

### DIFF
--- a/src/include/myalign.h
+++ b/src/include/myalign.h
@@ -90,17 +90,7 @@ typedef struct  va_list {
     memcpy(&p[6], emu->xmm, 8*16);                                      \
   }
 
-#elif defined(__powerpc64__)
-// TODO, is this correct?
-#define CREATE_SYSV_VALIST(A) \
-  va_list sysv_varargs; \
-  sysv_varargs->gpr=8; \
-  sysv_varargs->fpr=8; \
-  sysv_varargs->overflow_arg_area=A;
-
-#define CONVERT_VALIST(A) \
-  #error TODO!
-#elif defined(__loongarch64)
+#elif defined(__loongarch64) || defined(__powerpc64__)
 #define CREATE_SYSV_VALIST(A) \
   va_list sysv_varargs = (va_list)A
 // not creating CONVERT_VALIST(A) on purpose

--- a/src/libtools/signals.c
+++ b/src/libtools/signals.c
@@ -733,7 +733,7 @@ void my_box64signalhandler(int32_t sig, siginfo_t* info, void * ucntx)
 #elif defined __x86_64__
     void * pc = (void*)p->uc_mcontext.gregs[X64_RIP];
 #elif defined __powerpc64__
-    void * pc = (void*)p->uc_mcontext.uc_regs->gregs[PT_NIP];
+    void * pc = (void*)p->uc_mcontext.gp_regs[PT_NIP];
 #else
     void * pc = NULL;    // unknow arch...
     #warning Unhandled architecture


### PR DESCRIPTION
ppc64le/ELFv2 appears to use the same varargs type as LoongArch64. I changed the loongarch varargs macros to apply to powerpc64 as well, and it builds and appears to work correctly.

The only other change is a small difference in structs between 32 and 64 bit powerpc uc_mcontext.