### PR TITLE
Correct package name in Debian changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-box86 (0.1.6) unstable; urgency=low
+box64 (0.1.6) unstable; urgency=low
 
   * Introduce "HotPage", to temporarily disable Dynarec on a page were writing is also occuring (can help speed up C# code)
   * Some work on Dynarec to limit the number of mutex use, and also allow smaller block to be built (for JIT'd programs)


### PR DESCRIPTION
The package name is "box86" in changelog and it prevents building .deb packages.