### PR TITLE
ensure uc_link is properly initialized in getcontext(), fixes ppc64le

### DIFF
--- a/src/libtools/signals.c
+++ b/src/libtools/signals.c
@@ -1210,6 +1210,8 @@ EXPORT int my_getcontext(x64emu_t* emu, void* ucp)
     // get FloatPoint status
     // get signal mask
     sigprocmask(SIG_SETMASK, NULL, (sigset_t*)&u->uc_sigmask);
+    // ensure uc_link is properly initialized
+    u->uc_link = emu->uc_link;
 
     return 0;
 }


### PR DESCRIPTION
uc_link isn't initialized by getcontext(). This may not matter depending on what was previously there, but on ppc64le this is garbage, and test 13 invariably fails. This is a good idea on all platforms anyway and better matches the functional description in the man page.