### PR TITLE
Enable 64k page size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ option(LD80BITS "Set to ON if host device have 80bits long double (i.e. i386)" $
 option(NOALIGN "Set to ON if host device doesn't need re-align (i.e. i386)" ${NOALIGN})
 option(ARM_DYNAREC "Set to ON to use ARM Dynamic Recompilation" ${ARM_DYNAREC})
 option(PAGE16K "Set to ON if host device have PageSize of 16K (instead of 4K)" ${PAGE16K})
+option(PAGE64K "Set to ON if host device have PageSize of 64K (instead of 4K)" ${PAGE64K})
 option(STATICBUILD "Set to ON to have a static build (Warning, not working)" ${STATICBUILD})
 
 if(${CMAKE_VERSION} VERSION_LESS "3.12.2")
@@ -135,6 +136,10 @@ endif()
 
 if(PAGE16K)
     add_definitions(-DPAGE16K)
+endif()
+
+if(PAGE64K)
+    add_definitions(-DPAGE64K)
 endif()
 
 if(NOGIT)

--- a/src/custommem.c
+++ b/src/custommem.c
@@ -42,7 +42,10 @@ static uintptr_t*          box64_jmptbldefault1[1<<JMPTABL_SHIFT];
 static uintptr_t           box64_jmptbldefault0[1<<JMPTABL_SHIFT];
 #endif
 static pthread_mutex_t     mutex_prot;
-#if defined(PAGE16K)
+#if defined(PAGE64K)
+#define MEMPROT_SHIFT 16
+#define MEMPROT_SHIFT2 (16+16)
+#elif defined(PAGE16K)
 #define MEMPROT_SHIFT 14
 #define MEMPROT_SHIFT2 (16+14)
 #else


### PR DESCRIPTION
Minimal edits to allow building box64 with page size of 64k, I have not reviewed code to see if this change could cause side effects elsewhere. Happy to dig further if necessary, hints welcome.

Tested with build:

$ cmake .. -DRPI4ARM64=1 -DPAGE64K=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo

Then execution of a simple hello world program in C, compiled with default compiler:

$ file ../../hello/hello
../../hello/hello: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, BuildID[sha1]=84ad46c4690c1fe8443641401de8c3536bf0c6b8, not stripped

$ ./box64 ../../hello/hello
Dynarec for ARM64, with extension: ASIMD AES CRC32 PMULL ATOMICS PageSize:65536
Box64 with Dynarec v0.1.9 826f9cf built on Jun 30 2022 10:09:17
Using default BOX64_LD_LIBRARY_PATH: ./:lib/:lib64/:x86_64/:bin64/:libs64/
Using default BOX64_PATH: ./:bin/
Counted 21 Env var
Looking for ../../hello/hello
Rename process to "hello"
Using native(wrapped) libc.so.6
Using native(wrapped) ld-linux-x86-64.so.2
Using native(wrapped) libpthread.so.0
Using native(wrapped) librt.so.1
hello world
