### PR TITLE
fix overzealous replace in wrappers pathnames

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,7 +454,7 @@ set(WRAPPEDS
 
 #set(WRAPPEDS_HEAD "${BOX64_ROOT}/src/wrapped/wrappedd3dadapter9_gen.h")
 foreach(A ${WRAPPEDS})
-    string(REPLACE ".c" "_private.h" B ${A})
+    string(REGEX REPLACE ".c$" "_private.h" B ${A})
     set(WRAPPEDS_HEAD ${WRAPPEDS_HEAD} ${B})
     set_source_files_properties(${A} PROPERTIES OBJECT_DEPENDS ${B})
 endforeach()


### PR DESCRIPTION
Wrapper filenames were generated by replacing ".c" with "_private.h". Unfortunately this matched anywhere in the string, causing problems if the path contained a directory containing the substring ".c". For instance, if box64 is compiled in a '.cache' directory (as AUR helpers like to do, see #144), the directory name was inadvertently mangled into '_private.hache'.

Fix this by restricting the match to the end of the string.