### PR TITLE
src: asm: Rename lr & fp registers to their x-equivalents

### DIFF
--- a/src/dynarec/arm64/arm64_epilog.S
+++ b/src/dynarec/arm64/arm64_epilog.S
@@ -30,7 +30,7 @@ arm64_epilog:
     ldp     d12, d13, [sp, (8 *14)]
     ldp     d14, d15, [sp, (8 *16)]
     add     sp,  sp, (8 * 18)
-    ldp     lr, fp, [sp], 16  // saved lr
+    ldp     x30, x29, [sp], 16  // saved lr
     //end, return...
     ret
 
@@ -49,6 +49,6 @@ arm64_epilog_fast:
     ldp     d12, d13, [sp, (8 *14)]
     ldp     d14, d15, [sp, (8 *16)]
     add     sp,  sp, (8 * 18)
-    ldp     lr, fp, [sp], 16  // saved lr
+    ldp     x30, x29, [sp], 16  // saved lr
     //end, return...
     ret

--- a/src/dynarec/arm64/arm64_next.S
+++ b/src/dynarec/arm64/arm64_next.S
@@ -20,7 +20,7 @@ arm64_next:
     stp     x16, x17, [sp, (8 *  8)]
     stp     x18, x27, [sp, (8 * 10)]    // also save x27(rip) to allow change in LinkNext
 
-    mov     x2, lr      // "from" is in lr, so put in x2
+    mov     x2, x30      // "from" is in lr, so put in x2
     add     x3, sp, 8*11    // x3 is address to change rip
     // call the function
     bl      LinkNext

--- a/src/dynarec/arm64/arm64_prolog.S
+++ b/src/dynarec/arm64/arm64_prolog.S
@@ -9,7 +9,7 @@
 .global arm64_prolog
 arm64_prolog:
     //save all 18 used register
-    stp     lr, fp, [sp, -16]!  // save lr
+    stp     x30, x29, [sp, -16]!  // save lr
     sub     sp,  sp, (8 * 18)
     stp     x19, x20, [sp, (8 * 0)]
     stp     x21, x22, [sp, (8 * 2)]


### PR DESCRIPTION
Older GCC versions (like on Ubuntu Touch 16.04) don't recognize the aliases.

Allows building box64 with older toolchains.
Fixes: https://github.com/ptitSeb/box64/issues/82