### PR TITLE
more swap for rpi3

### DIFF
--- a/docs/COMPILE.md
+++ b/docs/COMPILE.md
@@ -31,9 +31,9 @@ sudo systemctl restart systemd-binfmt
 
 Warning, you need a 64bit OS:
 
-If building on the Pi, you will also need a large swap (2 GB+)
-and reduce GPU memory to a minimum (e.g. 16 MB) using `raspi-config`
-(and reboot) before starting the build:
+If building on the Pi, you will also need a large swap (3 GB+)
+[optionally reduce GPU memory to a minimum (e.g. 16 MB) using `raspi-config`
+(and reboot) before starting the build]:
 
 You can use e.g. '`make -j4`' to speed up the build, but on a Pi 3 with 1GB memory you will likely
 run out of memory at some point and need to run the build again.


### PR DESCRIPTION
How did you built with only 2GB swap?

Here at a file 'dynarec_arm64_00.c' at pass3 is:
               total        used        free      shared  buff/cache   available
Mem:          931460      840392       60032          20       31036       50928
Swap:        3135484     2312704      822780

This is at console, on desktop will be worse. Here is not working with only 2GB swap. I don't think GPU memory from 64 MB to 16 MB will make a difference.