### PR TITLE
Fixed parameter order for BOX64_DYNAREC_HOTPAGE env parsing.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -517,7 +517,7 @@ void LoadLogEnv()
     p = getenv("BOX64_DYNAREC_HOTPAGE");
     if(p) {
         int val = -1;
-        if(sscanf("%d", p, &val)==1) {
+        if(sscanf(p, "%d", &val)==1) {
             if(val>=0)
                 box64_dynarec_hotpage = val;
         }


### PR DESCRIPTION
The `sscanf()` needed the first two params swapped to correctly parse the env var.