### PR TITLE
wrap _XAsyncErrorHandler

### DIFF
--- a/src/wrapped/wrappedlibx11_private.h
+++ b/src/wrapped/wrappedlibx11_private.h
@@ -41,7 +41,7 @@ GO(XAllocSizeHints, pFv)
 GO(XAllocWMHints, pFv)
 GO(XAllowEvents, iFpiL)
 GO(XAllPlanes, LFv)
-// _XAsyncErrorHandler
+GO(_XAsyncErrorHandler, iFppip)
 GO(XAutoRepeatOff, iFp)
 GO(XAutoRepeatOn, iFp)
 GO(XBaseFontNameListOfFontSet, pFp)


### PR DESCRIPTION
Hit this using libGLX.so from the FEX rootfs.