### PR TITLE
[ARM64] Fixed a typo in arm64_lock_incif0

### DIFF
--- a/src/dynarec/arm64/arm64_lock.S
+++ b/src/dynarec/arm64/arm64_lock.S
@@ -229,7 +229,7 @@ arm64_lock_incif0:
 arm64_lock_incif0_0:
     ldaxr   w1, [x0]
     cmp     w1, #0
-    beq     arm64_lock_incif0_exit
+    bne     arm64_lock_incif0_exit
     add     w3, w1, #1
     stlxr   w2, w3, [x0]
     cbnz    w2, arm64_lock_incif0_0


### PR DESCRIPTION
ref: https://github.com/ptitSeb/box64/commit/3f1c37aa76ff13d90e60eb66c4516f8feebaf3f5#r103714224