### PR TITLE
[RV64] Enable test for riscv64 in CI

### DIFF
--- a/.github/runtests.sh
+++ b/.github/runtests.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+run_test() {
+  id=$1
+  append=$2
+
+  echo "Test $id"
+  ./box64 ../tests/test$id $append > /tmp/test$id.log
+  if [ $? -ne 0 ]; then
+    echo "Test $id exited with non-zero status"
+    exit 1
+  fi
+  diff /tmp/test$id.log ../tests/ref$id.txt
+  if [ $? -ne 0 ]; then
+    echo "Test $id output mismatch"
+    exit 1
+  fi
+  echo "Test $id passed"
+}
+
+plain_tests=(01 02 03 06 07 08 09 11 12 13 15 18 19 20 21 22)
+for i in ${plain_tests[@]}; do
+  run_test $i
+done
+
+run_test 04 "yeah"
+run_test 05 "7"
+
+LD_LIBRARY_PATH=../x64lib run_test 10
+BOX64_DYNAREC_FASTROUND=0 run_test 16
+BOX64_DYNAREC_FASTNAN=0 BOX64_DYNAREC_FASTROUND=0 run_test 17

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,23 @@ jobs:
           cd build
           ctest -j$(nproc)
 
+      - name: "Test Box64 on rv64"
+        if: ${{ matrix.platform == 'RISCV' }}
+        run: |
+          sudo apt-get -y install qemu-user-static systemd-container
+          wget https://archriscv.felixc.at/images/archriscv-20220727.tar.zst -O archriscv.tar.zst -q
+          mkdir /tmp/archriscv
+          sudo tar xf archriscv.tar.zst -C /tmp/archriscv
+          sudo cp -pr . /tmp/archriscv/root/
+          sudo systemd-nspawn -D /tmp/archriscv -a -U sh -c '
+          pacman -Syu --noconfirm -q
+          echo "Server = https://riscv.mirror.pkgbuild.com/repo/\$repo" >> /etc/pacman.d/mirrorlist
+          pacman -S diffutils --noconfirm -q
+          cd /root/build
+          # failed to make ctest happy, so test manually
+          bash ../.github/runtests.sh
+          '
+
       - name: "Upload Artifact"
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Box64 works inside qemu-user, so we can actually run the test in github action. I tried to use ctest in the container, but it failed for unknown reason (and I can't reproduce on my machine), so I wrote a script (translated from CMakeLists.txt) to do the tests.