### PR TITLE
Enable test for RV64 and ARM64 in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,10 +92,20 @@ jobs:
           make -j$(nproc) VERBOSE=1
 
       - name: "Test Box64"
-        if: ${{ matrix.platform == 'X64' }}
+        if: ${{ matrix.platform != 'TEGRAX1' }}
         run: |
+          if [[ ${{ matrix.platform }} != 'X64' ]]; then
+            sudo apt-get -y install qemu-user
+          fi
+
+          if [[ ${{ matrix.platform }} == 'RISCV' ]]; then
+            sudo cp -r /usr/riscv64-linux-gnu/lib/* /lib/
+          elif [[ ${{ matrix.platform }} != 'X64' ]]; then
+            sudo cp -r /usr/aarch64-linux-gnu/lib/* /lib/
+          fi
+
           cd build
-          ctest -j$(nproc)
+          ctest -j$(nproc) --rerun-failed --output-on-failure
 
       - name: "Upload Artifact"
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
If we can pass the environment variable `QEMU_LD_PREFIX=/usr/{riscv64,aarch64}-linux-gnu/lib/`
to ctest, it should also work and be cleaner, but I don't know how to do it as
I am not familiar with cmake.

Note that TEGRAX1 is not currently working because of a mismatch in GLIBC version.
Therefore, we skipped this platform.