### PR TITLE
docs/COMPILE.md: Use trusted.gpg.d

### DIFF
--- a/docs/COMPILE.md
+++ b/docs/COMPILE.md
@@ -6,7 +6,7 @@ You can use [@ryanfortner](https://github.com/ryanfortner)'s apt repository to i
 
 ```
 sudo wget https://ryanfortner.github.io/box64-debs/box64.list -O /etc/apt/sources.list.d/box64.list
-wget -O- https://ryanfortner.github.io/box64-debs/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/box64-debs-archive-keyring.gpg 
+wget -qO- https://ryanfortner.github.io/box64-debs/KEY.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/box64-debs-archive-keyring.gpg
 sudo apt update && sudo apt install box64 -y
 ```
 


### PR DESCRIPTION
Installing the keys in the system location will likely cause fallout in upgrades. Install into /etc/apt/trusted.gpg.d where it's commonly expected.