### PR TITLE
exclude libstdc++.so.5 in dh_shlibdeps

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -10,4 +10,4 @@ override_dh_auto_configure:
 		  -DNOGIT=1
 
 override_dh_shlibdeps:
-	dh_shlibdeps --exclude=libgcc_s.so.1 --exclude=libpng12.so.0 --exclude=libstdc++.so.6 
+	dh_shlibdeps --exclude=libgcc_s.so.1 --exclude=libpng12.so.0 --exclude=libstdc++.so.5 --exclude=libstdc++.so.6


### PR DESCRIPTION
I encountered error when building deb on armbian jammy. After excluding libstdc++.so.5 like [box86](https://github.com/ptitSeb/box86/blob/master/debian/rules#L13) there is no issue when building deb.