### PR TITLE
[WRAPPER] Fixed mpg123 wrapper

### DIFF
--- a/src/wrapped/generated/functions_list.txt
+++ b/src/wrapped/generated/functions_list.txt
@@ -1640,7 +1640,6 @@
 #() iFppdidd
 #() iFpplppi
 #() iFppLupp
-#() iFppLpLp
 #() iFpppiuu
 #() iFpppipi
 #() iFpppipp
@@ -3919,7 +3918,6 @@ wrappedlzma:
 wrappedmpg123:
 - iFpppp:
   - mpg123_replace_reader_handle
-  - mpg123_replace_reader_handle_32
   - mpg123_replace_reader_handle_64
 wrappednotify:
 wrappednsl:

--- a/src/wrapped/generated/wrappedmpg123types.h
+++ b/src/wrapped/generated/wrappedmpg123types.h
@@ -15,7 +15,6 @@ typedef int32_t (*iFpppp_t)(void*, void*, void*, void*);
 
 #define SUPER() ADDED_FUNCTIONS() \
 	GO(mpg123_replace_reader_handle, iFpppp_t) \
-	GO(mpg123_replace_reader_handle_32, iFpppp_t) \
 	GO(mpg123_replace_reader_handle_64, iFpppp_t)
 
 #endif // __wrappedmpg123TYPES_H_

--- a/src/wrapped/generated/wrapper.c
+++ b/src/wrapped/generated/wrapper.c
@@ -1676,7 +1676,6 @@ typedef int32_t (*iFppUUup_t)(void*, void*, uint64_t, uint64_t, uint32_t, void*)
 typedef int32_t (*iFppdidd_t)(void*, void*, double, int32_t, double, double);
 typedef int32_t (*iFpplppi_t)(void*, void*, intptr_t, void*, void*, int32_t);
 typedef int32_t (*iFppLupp_t)(void*, void*, uintptr_t, uint32_t, void*, void*);
-typedef int32_t (*iFppLpLp_t)(void*, void*, uintptr_t, void*, uintptr_t, void*);
 typedef int32_t (*iFpppiuu_t)(void*, void*, void*, int32_t, uint32_t, uint32_t);
 typedef int32_t (*iFpppipi_t)(void*, void*, void*, int32_t, void*, int32_t);
 typedef int32_t (*iFpppipp_t)(void*, void*, void*, int32_t, void*, void*);
@@ -4081,7 +4080,6 @@ void iFppUUup(x64emu_t *emu, uintptr_t fcn) { iFppUUup_t fn = (iFppUUup_t)fcn; R
 void iFppdidd(x64emu_t *emu, uintptr_t fcn) { iFppdidd_t fn = (iFppdidd_t)fcn; R_RAX=(int32_t)fn((void*)R_RDI, (void*)R_RSI, emu->xmm[0].d[0], (int32_t)R_RDX, emu->xmm[1].d[0], emu->xmm[2].d[0]); }
 void iFpplppi(x64emu_t *emu, uintptr_t fcn) { iFpplppi_t fn = (iFpplppi_t)fcn; R_RAX=(int32_t)fn((void*)R_RDI, (void*)R_RSI, (intptr_t)R_RDX, (void*)R_RCX, (void*)R_R8, (int32_t)R_R9); }
 void iFppLupp(x64emu_t *emu, uintptr_t fcn) { iFppLupp_t fn = (iFppLupp_t)fcn; R_RAX=(int32_t)fn((void*)R_RDI, (void*)R_RSI, (uintptr_t)R_RDX, (uint32_t)R_RCX, (void*)R_R8, (void*)R_R9); }
-void iFppLpLp(x64emu_t *emu, uintptr_t fcn) { iFppLpLp_t fn = (iFppLpLp_t)fcn; R_RAX=(int32_t)fn((void*)R_RDI, (void*)R_RSI, (uintptr_t)R_RDX, (void*)R_RCX, (uintptr_t)R_R8, (void*)R_R9); }
 void iFpppiuu(x64emu_t *emu, uintptr_t fcn) { iFpppiuu_t fn = (iFpppiuu_t)fcn; R_RAX=(int32_t)fn((void*)R_RDI, (void*)R_RSI, (void*)R_RDX, (int32_t)R_RCX, (uint32_t)R_R8, (uint32_t)R_R9); }
 void iFpppipi(x64emu_t *emu, uintptr_t fcn) { iFpppipi_t fn = (iFpppipi_t)fcn; R_RAX=(int32_t)fn((void*)R_RDI, (void*)R_RSI, (void*)R_RDX, (int32_t)R_RCX, (void*)R_R8, (int32_t)R_R9); }
 void iFpppipp(x64emu_t *emu, uintptr_t fcn) { iFpppipp_t fn = (iFpppipp_t)fcn; R_RAX=(int32_t)fn((void*)R_RDI, (void*)R_RSI, (void*)R_RDX, (int32_t)R_RCX, (void*)R_R8, (void*)R_R9); }
@@ -6207,7 +6205,6 @@ int isSimpleWrapper(wrapper_t fun) {
 	if (fun == &iFppdidd) return 4;
 	if (fun == &iFpplppi) return 1;
 	if (fun == &iFppLupp) return 1;
-	if (fun == &iFppLpLp) return 1;
 	if (fun == &iFpppiuu) return 1;
 	if (fun == &iFpppipi) return 1;
 	if (fun == &iFpppipp) return 1;

--- a/src/wrapped/generated/wrapper.h
+++ b/src/wrapped/generated/wrapper.h
@@ -1677,7 +1677,6 @@ void iFppUUup(x64emu_t *emu, uintptr_t fnc);
 void iFppdidd(x64emu_t *emu, uintptr_t fnc);
 void iFpplppi(x64emu_t *emu, uintptr_t fnc);
 void iFppLupp(x64emu_t *emu, uintptr_t fnc);
-void iFppLpLp(x64emu_t *emu, uintptr_t fnc);
 void iFpppiuu(x64emu_t *emu, uintptr_t fnc);
 void iFpppipi(x64emu_t *emu, uintptr_t fnc);
 void iFpppipp(x64emu_t *emu, uintptr_t fnc);

--- a/src/wrapped/wrappedmpg123.c
+++ b/src/wrapped/wrappedmpg123.c
@@ -107,11 +107,6 @@ EXPORT int my_mpg123_replace_reader_handle(x64emu_t* emu, void* mh, void* r_read
     return my->mpg123_replace_reader_handle(mh, find_r_read_Fct(r_read), find_r_lseek_Fct(r_lseek), find_cleanup_Fct(cleanup));
 }
 
-EXPORT int my_mpg123_replace_reader_handle_32(x64emu_t* emu, void* mh, void* r_read, void* r_lseek, void* cleanup)
-{
-    return my->mpg123_replace_reader_handle_32(mh, find_r_read_Fct(r_read), find_r_lseek_Fct(r_lseek), find_cleanup_Fct(cleanup));
-}
-
 EXPORT int my_mpg123_replace_reader_handle_64(x64emu_t* emu, void* mh, void* r_read, void* r_lseek, void* cleanup)
 {
     return my->mpg123_replace_reader_handle_64(mh, find_r_read_Fct(r_read), find_r_lseek_Fct(r_lseek), find_cleanup_Fct(cleanup));

--- a/src/wrapped/wrappedmpg123_private.h
+++ b/src/wrapped/wrappedmpg123_private.h
@@ -11,9 +11,8 @@ GO(mpg123_close, iFp)
 //GO(mpg123_current_decoder, 
 //GO(mpg123_decode, 
 GO(mpg123_decode_frame, iFpppp)
-GO(mpg123_decode_frame_32, iFpppp)
 GO(mpg123_decode_frame_64, iFpppp)
-GO(mpg123_decoder, iFppLpLp)
+GO(mpg123_decoder, iFpp)
 //GO(mpg123_decoders, 
 GO(mpg123_delete, vFp)
 //GO(mpg123_delete_pars, 
@@ -25,8 +24,7 @@ GO(mpg123_errcode, iFp)
 GO(mpg123_exit, vFv)
 GO(mpg123_feature, iFi)
 GO(mpg123_feed, iFppL)
-GO(mpg123_feedseek, IFpIip)             // Warning, off_t is 64bits!
-GO(mpg123_feedseek_32, IFpIip)
+GO(mpg123_feedseek, IFpIip)
 GO(mpg123_feedseek_64, IFpIip)
 //GO(mpg123_fmt, 
 //GO(mpg123_fmt_all, 
@@ -37,15 +35,12 @@ GO(mpg123_format_all, iFp)
 GO(mpg123_format_none, iFp)
 GO(mpg123_format_support, iFpli)
 GO(mpg123_framebyframe_decode, iFpppp)
-GO(mpg123_framebyframe_decode_32, iFpppp)
 GO(mpg123_framebyframe_decode_64, iFpppp)
 GO(mpg123_framebyframe_next, iFp)
 GO(mpg123_framedata, iFpppp)
 GO(mpg123_framelength, IFp)
-GO(mpg123_framelength_32, IFp)
 GO(mpg123_framelength_64, IFp)
 GO(mpg123_framepos, IFp)
-GO(mpg123_framepos_32, IFp)
 GO(mpg123_framepos_64, IFp)
 //GO(mpg123_free_string, 
 //GO(mpg123_geteq, 
@@ -60,27 +55,22 @@ GO(mpg123_getparam, iFpipp)
 //GO(mpg123_icy2utf8, 
 //GO(mpg123_id3, 
 GO(mpg123_index, iFpppp)
-GO(mpg123_index_32, iFpppp)
 GO(mpg123_index_64, iFpppp)
 //GO(mpg123_info, 
 GO(mpg123_init, iFv)
 //GO(mpg123_init_string, 
 GO(mpg123_length, IFp)
-GO(mpg123_length_32, IFp)
 GO(mpg123_length_64, IFp)
 //GO(mpg123_meta_check, 
 //GO(mpg123_meta_free, 
 GO(mpg123_new, pFpp)
 //GO(mpg123_new_pars, 
 GO(mpg123_open, iFpp)
-GO(mpg123_open_32, iFpp)
 GO(mpg123_open_64, iFpp)
 GO(mpg123_open_fd, iFpi)
-GO(mpg123_open_fd_32, iFpi)
 GO(mpg123_open_fd_64, iFpi)
 GO(mpg123_open_feed, iFp)
 GO(mpg123_open_handle, iFpp)
-GO(mpg123_open_handle_32, iFpp)
 GO(mpg123_open_handle_64, iFpp)
 //GO(mpg123_outblock, 
 //GO(mpg123_par, 
@@ -88,32 +78,25 @@ GO(mpg123_param, iFpild)
 //GO(mpg123_parnew, 
 GO(mpg123_plain_strerror, pFi)
 GO(mpg123_position, iFpIIpppp)
-GO(mpg123_position_32, iFpIIpppp)
 GO(mpg123_position_64, iFpIIpppp)
 GO(mpg123_rates, vFpp)
-GO(mpg123_read, iFppp)
+GO(mpg123_read, iFppLp)
 //GO(mpg123_replace_buffer, 
 //GO(mpg123_replace_reader, 
-//GO(mpg123_replace_reader_32, 
 //GO(mpg123_replace_reader_64, 
 GOM(mpg123_replace_reader_handle, iFEpppp)
-GOM(mpg123_replace_reader_handle_32, iFEpppp)
 GOM(mpg123_replace_reader_handle_64, iFEpppp)
 //GO(mpg123_reset_eq, 
 //GO(mpg123_resize_string, 
 //GO(mpg123_safe_buffer, 
 //GO(mpg123_scan, 
 GO(mpg123_seek, IFpIi)
-GO(mpg123_seek_32, IFpIi)
 GO(mpg123_seek_64, IFpIi)
 GO(mpg123_seek_frame, IFpIi)
-GO(mpg123_seek_frame_32, IFpIi)
 GO(mpg123_seek_frame_64, IFpIi)
 GO(mpg123_set_filesize, iFpI)
-GO(mpg123_set_filesize_32, iFpI)
 GO(mpg123_set_filesize_64, iFpI)
 GO(mpg123_set_index, iFppIL)
-GO(mpg123_set_index_32, iFppIL)
 GO(mpg123_set_index_64, iFppIL)
 //GO(mpg123_set_string, 
 //GO(mpg123_set_substring, 
@@ -123,16 +106,12 @@ GO(mpg123_strerror, pFp)
 //GO(mpg123_strlen, 
 //GO(mpg123_supported_decoders, 
 GO(mpg123_tell, IFp)
-GO(mpg123_tell_32, IFp)
 GO(mpg123_tell_64, IFp)
 GO(mpg123_tellframe, IFp)
-GO(mpg123_tellframe_32, IFp)
 GO(mpg123_tellframe_64, IFp)
 GO(mpg123_tell_stream, IFp)
-GO(mpg123_tell_stream_32, IFp)
 GO(mpg123_tell_stream_64, IFp)
 GO(mpg123_timeframe, IFpd)
-GO(mpg123_timeframe_32, IFpd)
 GO(mpg123_timeframe_64, IFpd)
 //GO(mpg123_tpf, 
 //GO(mpg123_volume, 


### PR DESCRIPTION
Also deleted all the `_32` ones, I believe it's copied from box86, and it does not appear in the 64-bit shared library.