### PR TITLE
[WRAPPER] Added more fontconfig wrapped functions

### DIFF
--- a/src/wrapped/wrappedfontconfig_private.h
+++ b/src/wrapped/wrappedfontconfig_private.h
@@ -60,7 +60,7 @@ GO(FcConfigGetSysRoot, pFp)
 //GO(FcConfigParseAndLoad, 
 GO(FcConfigReference, pFp)
 //GO(FcConfigSetCurrent, 
-//GO(FcConfigSetRescanInterval, 
+GO(FcConfigSetRescanInterval, iFpi)
 //GO(FcConfigSetRescanInverval, 
 GO(FcConfigSubstitute, iFppi)
 GO(FcConfigSubstituteWithPat, iFpppi)
@@ -162,7 +162,7 @@ GO(FcPatternGetMatrix, iFppip)
 GO(FcPatternGetString, iFppip)
 GO(FcPatternHash, iFp)
 //GO(FcPatternPrint, 
-//GO(FcPatternReference, 
+GO(FcPatternReference, vFp)
 //GO(FcPatternRemove, 
 GO(FcPatternVaBuild, pFpp)
 GO(FcStrBasename, pFp)


### PR DESCRIPTION
I'm trying to run Tencent Meeting (a Zoom-like app popular in China), and these functions are used by it. I also fixed some libxcb/libxcbrandr wrapper functions in https://github.com/ksco/box64/commit/fb5aab53b8f461cf99a7635c2ff6aed5bfe49ce8, but Tencent Meeting still fails to run and I can't find why, so I excluded this commit as it's not verified.