### PR TITLE
[ELF] Fixed a use-after-free issue

### DIFF
--- a/src/elfs/elfloader.c
+++ b/src/elfs/elfloader.c
@@ -80,8 +80,6 @@ void FreeElfHeader(elfheader_t** head)
     if(my_context)
         RemoveElfHeader(my_context, h);
 
-    box_free(h->name);
-    box_free(h->path);
     box_free(h->PHEntries);
     box_free(h->SHEntries);
     box_free(h->SHStrTab);
@@ -98,6 +96,9 @@ void FreeElfHeader(elfheader_t** head)
     FreeDefaultVersion(&h->weakdefver);
     
     FreeElfMemory(h);
+
+    box_free(h->name);
+    box_free(h->path);
     box_free(h);
 
     *head = NULL;


### PR DESCRIPTION
`head->path` is used by `FreeElfMemory` when Dyanrec is on. I also moved `h->name` because it looks better.