### PR TITLE
[GDBSTUB] Added preliminary GDBSTUB support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,7 @@ set(ELFLOADER_SRC
     "${BOX64_ROOT}/src/emu/x64syscall.c"
     "${BOX64_ROOT}/src/emu/x64tls.c"
     "${BOX64_ROOT}/src/emu/x64trace.c"
+    "${BOX64_ROOT}/src/gdbstub/gdbstub.c"
     "${BOX64_ROOT}/src/librarian/librarian.c"
     "${BOX64_ROOT}/src/librarian/library.c"
     "${BOX64_ROOT}/src/librarian/dictionnary.c"
@@ -671,6 +672,8 @@ if(DYNAREC)
     set_target_properties(native_pass3 PROPERTIES COMPILE_FLAGS "-DSTEP=3")
     add_library(test_interpreter OBJECT ${INTERPRETER})
     set_target_properties(test_interpreter PROPERTIES COMPILE_FLAGS "-DTEST_INTERPRETER")
+    add_library(gdbstub OBJECT ${INTERPRETER})
+    set_target_properties(gdbstub PROPERTIES COMPILE_FLAGS "-DGDBSTUB")
     add_dependencies(native_pass0 WRAPPERS)
     add_dependencies(native_pass1 WRAPPERS)
     add_dependencies(native_pass2 WRAPPERS)
@@ -683,6 +686,7 @@ if(DYNAREC)
         $<TARGET_OBJECTS:native_pass2>
         $<TARGET_OBJECTS:native_pass3>
         $<TARGET_OBJECTS:test_interpreter>
+        $<TARGET_OBJECTS:gdbstub>
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -672,8 +672,6 @@ if(DYNAREC)
     set_target_properties(native_pass3 PROPERTIES COMPILE_FLAGS "-DSTEP=3")
     add_library(test_interpreter OBJECT ${INTERPRETER})
     set_target_properties(test_interpreter PROPERTIES COMPILE_FLAGS "-DTEST_INTERPRETER")
-    add_library(gdbstub OBJECT ${INTERPRETER})
-    set_target_properties(gdbstub PROPERTIES COMPILE_FLAGS "-DGDBSTUB")
     add_dependencies(native_pass0 WRAPPERS)
     add_dependencies(native_pass1 WRAPPERS)
     add_dependencies(native_pass2 WRAPPERS)
@@ -686,7 +684,6 @@ if(DYNAREC)
         $<TARGET_OBJECTS:native_pass2>
         $<TARGET_OBJECTS:native_pass3>
         $<TARGET_OBJECTS:test_interpreter>
-        $<TARGET_OBJECTS:gdbstub>
     )
 endif()
 
@@ -705,7 +702,13 @@ else()
         VERBATIM)
 endif()
 
-add_library(interpreter OBJECT ${INTERPRETER})
+add_library(gdbstub OBJECT ${INTERPRETER})
+set_target_properties(gdbstub PROPERTIES COMPILE_FLAGS "-DGDBSTUB")
+
+add_library(interpreter STATIC 
+        ${INTERPRETER}
+        $<TARGET_OBJECTS:gdbstub>
+    )
 
 add_executable(${BOX64} ${ELFLOADER_SRC} ${WRAPPEDS} "${BOX64_ROOT}/src/git_head.h")
 set_target_properties(${BOX64} PROPERTIES ENABLE_EXPORTS ON)

--- a/src/box64context.c
+++ b/src/box64context.c
@@ -334,6 +334,9 @@ void FreeBox64Context(box64context_t** context)
 
     freeCycleLog(ctx);
 
+    if (ctx->gdbstub)
+        box_free(ctx->gdbstub);
+
     box_free(ctx);
 }
 

--- a/src/box64context.c
+++ b/src/box64context.c
@@ -334,8 +334,10 @@ void FreeBox64Context(box64context_t** context)
 
     freeCycleLog(ctx);
 
-    if (ctx->gdbstub)
+    if (ctx->gdbstub) {
+        GdbStubDestroy(ctx->gdbstub);
         box_free(ctx->gdbstub);
+    }
 
     box_free(ctx);
 }

--- a/src/emu/x64run.c
+++ b/src/emu/x64run.c
@@ -83,6 +83,8 @@ x64emurun:
                 goto fini;
             default: break;
         }
+
+        GdbStubCheckBp(emu->context->gdbstub, addr);
 #else
     while(1) {
 #endif

--- a/src/emu/x64run.c
+++ b/src/emu/x64run.c
@@ -76,7 +76,13 @@ x64emurun:
 #elif GDBSTUB
     while(1) {
         gdbstub_action_t action = GdbStubStep(emu->context->gdbstub);
-        if (action == GDBSTUB_ACTION_NONE) continue;
+        switch (action) {
+            case GDBSTUB_ACTION_NONE: continue;
+            case GDBSTUB_ACTION_DETACH:
+                printf_log(LOG_INFO, "Gdbstub detected detach from client, exiting...\n");
+                goto fini;
+            default: break;
+        }
 #else
     while(1) {
 #endif

--- a/src/gdbstub/gdbstub.c
+++ b/src/gdbstub/gdbstub.c
@@ -201,8 +201,8 @@ static gdbstub_action_t GdbStubHandlePkt(gdbstub_t *stub) {
 
     switch (req) {
     case 'c': // continue
-        // TODO
-        GdbStubSendPkt(stub, "");
+        stub->cont = true;
+        GdbStubSendPkt(stub, "OK");
         break;
     case 'g':
         GdbStubHandleRegsRead(stub, payload);
@@ -263,6 +263,7 @@ static gdbstub_action_t GdbStubHandlePkt(gdbstub_t *stub) {
 
 // Step forward gdbstub, handles one packet a time. returns an action.
 gdbstub_action_t GdbStubStep(gdbstub_t *stub) {
+    if (stub->cont) return GDBSTUB_ACTION_STEP;
     GdbStubRecvPkt(stub);
     return GdbStubHandlePkt(stub);
 }

--- a/src/gdbstub/gdbstub.c
+++ b/src/gdbstub/gdbstub.c
@@ -1,0 +1,268 @@
+#include <arpa/inet.h>
+#include <assert.h>
+#include <poll.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "regs.h"
+#include "debug.h"
+#include "gdbstub.h"
+#include "gdbstub_private.h"
+#include "box64context.h"
+#include "emu/x64emu_private.h"
+
+#define GDBSTUB_PKT_PREFIX '$'
+#define GDBSTUB_PKT_SUFFIX '#'
+#define GDBSTUB_PKT_ACK    "+"
+
+static uint8_t ComputeCheckSum(uint8_t *buf, size_t len) {
+    uint8_t cs = 0;
+    for (size_t i = 0; i < len; ++i)
+        cs += buf[i];
+    return cs;
+}
+
+static void HexToStr(uint8_t *num, char *str, int bytes) {
+    static char hexchars[] = "0123456789abcdef";
+
+    for (int i = 0; i < bytes; i++) {
+        uint8_t c = *(num + i);
+        *(str + i * 2) = hexchars[c>>4];
+        *(str + i * 2 + 1) = hexchars[c&0xf];
+    }
+    str[bytes * 2] = '\0';
+}
+
+static uint8_t CharToHex(char ch) {
+    uint8_t letter = ch & 0x40;
+    uint8_t offset = (letter >> 3) | (letter >> 6);
+    return (ch + offset) & 0xf;
+}
+
+static uint8_t ConvertCheckSumToHex(char l, char h) {
+    return (CharToHex(l)<<4) | CharToHex(h);
+}
+
+static bool SocketPoll(int socket_fd, int timeout, int events)
+{
+    struct pollfd pfd = (struct pollfd) {
+        .fd = socket_fd,
+        .events = events,
+    };
+
+    return (poll(&pfd, 1, timeout) > 0) && (pfd.revents & events);
+}
+
+static bool ConnInit(struct conn_s *conn, char *addr_str, int port) {
+    int fd, fd2, optval = 1;
+    struct sockaddr_in addr = {
+        .sin_family = AF_INET,
+        .sin_addr.s_addr = inet_addr(addr_str),
+        .sin_port = htons(port)
+    };
+
+    if ((fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) return false;
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) < 0) goto fail;
+    if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) goto fail;
+    if (listen(fd, 1) < 0) goto fail;
+    if ((fd2 = accept(fd, NULL, NULL)) < 0) goto fail;
+
+    conn->listen_fd = fd;
+    conn->socket_fd = fd2;
+
+    return true;
+fail:
+    close(fd);
+    return false;
+}
+
+static uint8_t ConnGetchar(struct conn_s *conn) {
+    static uint8_t c;
+    read(conn->socket_fd, &c, 1);
+    return c;
+}
+
+bool GdbStubInit(x64emu_t *emu, char *addr_str, int port) {
+    emu->context->gdbstub = (gdbstub_t *)box_calloc(1, sizeof(gdbstub_t));
+    emu->context->gdbstub->emu = emu;
+    if (!ConnInit(&emu->context->gdbstub->conn, addr_str, port)) {
+        return false;
+    }
+
+    return true;
+}
+
+static void GdbStubSendStr(gdbstub_t *stub, char *str)
+{
+    size_t len = strlen(str);
+
+    while (len > 0 && SocketPoll(stub->conn.socket_fd, -1, POLLOUT)) {
+        ssize_t nwrite = write(stub->conn.socket_fd, str, len);
+        if (nwrite == -1)
+            break;
+        len -= nwrite;
+    }
+}
+
+static void GdbStubRecvPkt(gdbstub_t *stub) {
+    static uint8_t c;
+    int offset = 0;
+
+    // Step forward until the packet prefix.
+    while (true) {
+        c = ConnGetchar(&stub->conn);
+        if (c == GDBSTUB_PKT_PREFIX) break;
+    }
+
+    while (true) {
+        c = ConnGetchar(&stub->conn);
+        if (c == GDBSTUB_PKT_SUFFIX) {
+            char l = ConnGetchar(&stub->conn), h = ConnGetchar(&stub->conn);
+            assert(ConvertCheckSumToHex(l, h) == ComputeCheckSum(stub->pktbuf, offset));
+
+            stub->pktbuf[offset] = '\0';
+            break;
+        }
+        stub->pktbuf[offset++] = c;
+    }
+
+    printf_log(LOG_DEBUG, "[GDBSTUB] Recv packet: %s\n", (char *)stub->pktbuf);
+    GdbStubSendStr(stub, GDBSTUB_PKT_ACK);
+}
+
+static void GdbStubSendPkt(gdbstub_t *stub, char *raw) {
+    static char packet[GDBSTUB_MAX_PKT_SIZE];
+    static char checksumbuf[4];
+    uint8_t checksum;
+    size_t len = strlen(raw);
+
+    // 2: prefix '$' and suffix '#'
+    // 2: checksum
+    // 1: NUL
+    assert(len + 2 + 2 + 1 < GDBSTUB_MAX_PKT_SIZE);
+
+    packet[0] = '$';
+    memcpy(packet + 1, raw, len);
+    packet[len + 1] = '#';
+    checksum = ComputeCheckSum(raw, len);
+    snprintf(checksumbuf, 3, "%02x", checksum);
+    memcpy(packet + len + 2, checksumbuf, 2);
+    packet[len + 2 + 2] = '\0';
+
+    GdbStubSendStr(stub, packet);
+    printf_log(LOG_DEBUG, "[GDBSTUB] Send packet: %s\n", packet);
+}
+
+static void GdbStubHandleQuery(gdbstub_t *stub, char *payload) {
+    if (strstr(payload, "Supported")) {
+        GdbStubSendPkt(stub, "");
+    } else if (strstr(payload, "Attached")) {
+        GdbStubSendPkt(stub, "1");
+    } else if (strstr(payload, "Symbol")) {
+        GdbStubSendPkt(stub, "OK");
+    } else {
+        GdbStubSendPkt(stub, "");
+    }
+}
+
+static void GdbStubHandleVCont(gdbstub_t *stub, char *payload) {
+    static char buf[32];
+    if (strstr("Cont?", payload)) {
+        GdbStubSendPkt(stub, "vCont;s;c;");
+    } else {
+        GdbStubSendPkt(stub, "");
+    }
+}
+
+static void GdbStubHandleRegsRead(gdbstub_t *stub, char *payload) {
+    static char packet[GDBSTUB_MAX_PKT_SIZE] = {0};
+    // rax -> r15
+    for (int i = 0; i < 16; i++) {
+        HexToStr((uint8_t *)&stub->emu->regs[i].q[0], &packet[i*sizeof(uint64_t)*2], sizeof(uint64_t));
+    }
+    // rip
+    HexToStr((uint8_t *)&stub->emu->ip.q[0], &packet[16*sizeof(uint64_t)*2], sizeof(uint64_t));
+    // eflags, 32bit
+    HexToStr((uint8_t *)&stub->emu->eflags, &packet[17*sizeof(uint64_t)*2], sizeof(uint32_t));
+    // cs -> gs, 32bit
+    for (int i = 0; i < 6; i++) {
+        HexToStr((uint8_t *)&stub->emu->segs[i], &packet[(35+i)*sizeof(uint32_t)*2], sizeof(uint32_t));
+    }
+    GdbStubSendPkt(stub, packet);
+}
+
+static gdbstub_action_t GdbStubHandlePkt(gdbstub_t *stub) {
+    uint8_t req = stub->pktbuf[0];
+    char *payload = (char *)&stub->pktbuf[1];
+
+    switch (req) {
+    case 'c': // continue
+        // TODO
+        GdbStubSendPkt(stub, "");
+        break;
+    case 'g':
+        GdbStubHandleRegsRead(stub, payload);
+        break;
+    case 'm': // read mem
+        // TODO
+        GdbStubSendPkt(stub, "");
+        break;
+    case 'p': // read reg
+        // TODO
+        GdbStubSendPkt(stub, "");
+        break;
+    case 'q':
+        GdbStubHandleQuery(stub, payload);
+        break;
+    case 's':
+        GdbStubSendPkt(stub, "S05");
+        return GDBSTUB_ACTION_STEP;
+    case 'v':
+        GdbStubHandleVCont(stub, payload);
+        break;
+    case 'z': // delete bp
+        // TODO
+        GdbStubSendPkt(stub, "");
+        break;
+    case '?': // why halted?
+        GdbStubSendPkt(stub, "S05");
+        break;
+    case 'D':
+        return GDBSTUB_ACTION_DETACH;
+    case 'G': // regs write
+        // TODO
+        GdbStubSendPkt(stub, "");
+        break;
+    case 'M': // mem write
+        // TODO
+        GdbStubSendPkt(stub, "");
+        break;
+    case 'P': // reg write
+        // TODO
+        GdbStubSendPkt(stub, "");
+        break;
+    case 'X': // mem xwrite (binary)
+        // TODO
+        GdbStubSendPkt(stub, "");
+        break;
+    case 'Z': // set bp
+        // TODO
+        GdbStubSendPkt(stub, "");
+        break;
+    default:
+        GdbStubSendPkt(stub, "");
+        break;
+    }
+
+    return GDBSTUB_ACTION_NONE;
+}
+
+// Step forward gdbstub, handles one packet a time. returns an action.
+gdbstub_action_t GdbStubStep(gdbstub_t *stub) {
+    GdbStubRecvPkt(stub);
+    return GdbStubHandlePkt(stub);
+}

--- a/src/gdbstub/gdbstub_private.h
+++ b/src/gdbstub/gdbstub_private.h
@@ -15,6 +15,7 @@ struct conn_s {
 typedef struct gdbstub_s {
     struct conn_s conn;
     x64emu_t* emu;
+    bool cont;
 
     // Packet buffer, should be enough, replace this with a dynamic buffer maybe.
     uint8_t pktbuf[GDBSTUB_MAX_PKT_SIZE];

--- a/src/gdbstub/gdbstub_private.h
+++ b/src/gdbstub/gdbstub_private.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 
 #include "x64emu.h"
+#include "khash.h"
 
 #define GDBSTUB_MAX_PKT_SIZE 1024
 
@@ -12,10 +13,13 @@ struct conn_s {
     int socket_fd;
 };
 
+KHASH_MAP_INIT_INT64(bps, bool);
+
 typedef struct gdbstub_s {
     struct conn_s conn;
     x64emu_t* emu;
     bool cont;
+    kh_bps_t *bps; // breakpoints
 
     // Packet buffer, should be enough, replace this with a dynamic buffer maybe.
     uint8_t pktbuf[GDBSTUB_MAX_PKT_SIZE];

--- a/src/gdbstub/gdbstub_private.h
+++ b/src/gdbstub/gdbstub_private.h
@@ -1,0 +1,23 @@
+#ifndef __GDBSTUB_PRIVATE_H_
+#define __GDBSTUB_PRIVATE_H_
+
+#include <stdint.h>
+
+#include "x64emu.h"
+
+#define GDBSTUB_MAX_PKT_SIZE 1024
+
+struct conn_s {
+    int listen_fd;
+    int socket_fd;
+};
+
+typedef struct gdbstub_s {
+    struct conn_s conn;
+    x64emu_t* emu;
+
+    // Packet buffer, should be enough, replace this with a dynamic buffer maybe.
+    uint8_t pktbuf[GDBSTUB_MAX_PKT_SIZE];
+} gdbstub_t;
+
+#endif // __GDBSTUB_PRIVATE_H_

--- a/src/include/box64context.h
+++ b/src/include/box64context.h
@@ -4,6 +4,7 @@
 #include <pthread.h>
 #include "pathcoll.h"
 #include "dictionnary.h"
+#include "gdbstub.h"
 #ifdef DYNAREC
 #include "dynarec/native_lock.h"
 #endif
@@ -190,6 +191,7 @@ typedef struct box64context_s {
     char*               *log_ret;
     int                 current_line;
 
+    gdbstub_t           *gdbstub;
 } box64context_t;
 
 #ifndef DYNAREC

--- a/src/include/debug.h
+++ b/src/include/debug.h
@@ -9,6 +9,7 @@ extern int box64_dynarec_log;
 extern int box64_dynarec;
 extern uintptr_t box64_pagesize;
 extern uintptr_t box64_load_addr;
+extern int box64_gdbstub;
 #ifdef DYNAREC
 extern int box64_dynarec_dump;
 extern int box64_dynarec_trace;

--- a/src/include/gdbstub.h
+++ b/src/include/gdbstub.h
@@ -1,0 +1,21 @@
+#ifndef __GDBSTUB_H_
+#define __GDBSTUB_H_
+
+#include <stdbool.h>
+
+#include "emu/x64emu_private.h"
+
+typedef enum gdbstub_action_s {
+    GDBSTUB_ACTION_NONE,
+    GDBSTUB_ACTION_STEP,
+    GDBSTUB_ACTION_DETACH,
+} gdbstub_action_t;
+
+typedef struct box64context_s  box64context_t;
+typedef enum gdbstub_action_s gdbstub_action_t;
+typedef struct gdbstub_s gdbstub_t;
+
+bool GdbStubInit(x64emu_t *emu, char *addr_str, int port);
+gdbstub_action_t GdbStubStep(gdbstub_t *stub);
+
+#endif // __GDBSTUB_H_

--- a/src/include/gdbstub.h
+++ b/src/include/gdbstub.h
@@ -9,6 +9,7 @@ typedef enum gdbstub_action_s {
     GDBSTUB_ACTION_NONE,
     GDBSTUB_ACTION_STEP,
     GDBSTUB_ACTION_DETACH,
+    GDBSTUB_ACTION_CONTINUE,
 } gdbstub_action_t;
 
 typedef struct box64context_s  box64context_t;

--- a/src/include/gdbstub.h
+++ b/src/include/gdbstub.h
@@ -18,5 +18,7 @@ typedef struct gdbstub_s gdbstub_t;
 
 bool GdbStubInit(x64emu_t *emu, char *addr_str, int port);
 gdbstub_action_t GdbStubStep(gdbstub_t *stub);
+void GdbStubCheckBp(gdbstub_t *stub, uintptr_t addr);
+void GdbStubDestroy(gdbstub_t *stub);
 
 #endif // __GDBSTUB_H_

--- a/src/include/x64run.h
+++ b/src/include/x64run.h
@@ -6,6 +6,7 @@ typedef struct x64emu_s x64emu_t;
 typedef struct x64test_s x64test_t;
 int Run(x64emu_t *emu, int step); // 0 if run was successfull, 1 if error in x86 world
 int RunTest(x64test_t *test);
+int RunGdbStub(x64emu_t *emu);
 int DynaRun(x64emu_t *emu);
 
 uint32_t LibSyscall(x64emu_t *emu);

--- a/src/main.c
+++ b/src/main.c
@@ -1778,11 +1778,12 @@ int main(int argc, const char **argv, char **env) {
     if (box64_gdbstub) {
         if (box64_dynarec) {
             printf_log(LOG_INFO, "Gdbstub cannot be used with Dynarec, cancelling\n");
+            Run(emu, 0);
         } else {
             printf_log(LOG_INFO, "Starting gdbstub on 0.0.0.0:1234\n");
             GdbStubInit(emu, "0.0.0.0", 1234);
+            RunGdbStub(emu);
         }
-        RunGdbStub(emu);
     } else Run(emu, 0);
     // Get EAX
     int ret = GetEAX(emu);


### PR DESCRIPTION
It's far from usable, but I want to know if this patch is generally in good shape.

It is already possible to connect to the GDB client without attaching the binary, `info registers` and `stepi` directives are working.

Usage:
```
BOX64_DYNAREC=0 BOX64_GDBSTUB=1 BOX64_LOG=2 ./box64 ../tests/test01
```

```
gdb
(gdb) set architecture i386:x86-64
(gdb) target remote :1234
(gdb) i r
(gdb) si
```