### PR TITLE
Added some mpg123 wrapped functions

### DIFF
--- a/src/wrapped/generated/functions_list.txt
+++ b/src/wrapped/generated/functions_list.txt
@@ -569,6 +569,7 @@
 #() dFuud
 #() dFddd
 #() dFddp
+#() dFpii
 #() dFpdd
 #() dFppi
 #() dFppu

--- a/src/wrapped/generated/wrapper.c
+++ b/src/wrapped/generated/wrapper.c
@@ -605,6 +605,7 @@ typedef float (*fFppp_t)(void*, void*, void*);
 typedef double (*dFuud_t)(uint32_t, uint32_t, double);
 typedef double (*dFddd_t)(double, double, double);
 typedef double (*dFddp_t)(double, double, void*);
+typedef double (*dFpii_t)(void*, int32_t, int32_t);
 typedef double (*dFpdd_t)(void*, double, double);
 typedef double (*dFppi_t)(void*, void*, int32_t);
 typedef double (*dFppu_t)(void*, void*, uint32_t);
@@ -3401,6 +3402,7 @@ void fFppp(x64emu_t *emu, uintptr_t fcn) { fFppp_t fn = (fFppp_t)fcn; emu->xmm[0
 void dFuud(x64emu_t *emu, uintptr_t fcn) { dFuud_t fn = (dFuud_t)fcn; emu->xmm[0].d[0]=fn((uint32_t)R_RDI, (uint32_t)R_RSI, emu->xmm[0].d[0]); }
 void dFddd(x64emu_t *emu, uintptr_t fcn) { dFddd_t fn = (dFddd_t)fcn; emu->xmm[0].d[0]=fn(emu->xmm[0].d[0], emu->xmm[1].d[0], emu->xmm[2].d[0]); }
 void dFddp(x64emu_t *emu, uintptr_t fcn) { dFddp_t fn = (dFddp_t)fcn; emu->xmm[0].d[0]=fn(emu->xmm[0].d[0], emu->xmm[1].d[0], (void*)R_RDI); }
+void dFpii(x64emu_t *emu, uintptr_t fcn) { dFpii_t fn = (dFpii_t)fcn; emu->xmm[0].d[0]=fn((void*)R_RDI, (int32_t)R_RSI, (int32_t)R_RDX); }
 void dFpdd(x64emu_t *emu, uintptr_t fcn) { dFpdd_t fn = (dFpdd_t)fcn; emu->xmm[0].d[0]=fn((void*)R_RDI, emu->xmm[0].d[0], emu->xmm[1].d[0]); }
 void dFppi(x64emu_t *emu, uintptr_t fcn) { dFppi_t fn = (dFppi_t)fcn; emu->xmm[0].d[0]=fn((void*)R_RDI, (void*)R_RSI, (int32_t)R_RDX); }
 void dFppu(x64emu_t *emu, uintptr_t fcn) { dFppu_t fn = (dFppu_t)fcn; emu->xmm[0].d[0]=fn((void*)R_RDI, (void*)R_RSI, (uint32_t)R_RDX); }
@@ -6125,6 +6127,7 @@ int isSimpleWrapper(wrapper_t fun) {
 	if (fun == &dFuud) return -2;
 	if (fun == &dFddd) return -4;
 	if (fun == &dFddp) return -3;
+	if (fun == &dFpii) return -1;
 	if (fun == &dFpdd) return -3;
 	if (fun == &dFppi) return -1;
 	if (fun == &dFppu) return -1;

--- a/src/wrapped/generated/wrapper.h
+++ b/src/wrapped/generated/wrapper.h
@@ -606,6 +606,7 @@ void fFppp(x64emu_t *emu, uintptr_t fnc);
 void dFuud(x64emu_t *emu, uintptr_t fnc);
 void dFddd(x64emu_t *emu, uintptr_t fnc);
 void dFddp(x64emu_t *emu, uintptr_t fnc);
+void dFpii(x64emu_t *emu, uintptr_t fnc);
 void dFpdd(x64emu_t *emu, uintptr_t fnc);
 void dFppi(x64emu_t *emu, uintptr_t fnc);
 void dFppu(x64emu_t *emu, uintptr_t fnc);

--- a/src/wrapped/wrappedmpg123_private.h
+++ b/src/wrapped/wrappedmpg123_private.h
@@ -16,19 +16,19 @@ GO(mpg123_decoder, iFpp)
 //GO(mpg123_decoders, 
 GO(mpg123_delete, vFp)
 GO(mpg123_delete_pars, vFp)
-//GO(mpg123_enc_from_id3, 
+GO(mpg123_enc_from_id3, iFC)
 GO(mpg123_encodings, vFpp)
 GO(mpg123_encsize, iFi)
-//GO(mpg123_eq, 
+GO(mpg123_eq, iFpiid)
 GO(mpg123_errcode, iFp)
 GO(mpg123_exit, vFv)
 GO(mpg123_feature, iFi)
 GO(mpg123_feed, iFppL)
 GO(mpg123_feedseek, lFplip)
 GO(mpg123_feedseek_64, IFpIip)
-//GO(mpg123_fmt, 
+GO(mpg123_fmt, iFplii)
 GO(mpg123_fmt_all, iFp)
-//GO(mpg123_fmt_none, 
+GO(mpg123_fmt_none, iFp)
 GO(mpg123_fmt_support, iFpli)
 GO(mpg123_format, iFplii)
 GO(mpg123_format_all, iFp)
@@ -43,12 +43,12 @@ GO(mpg123_framelength_64, IFp)
 GO(mpg123_framepos, IFp)
 GO(mpg123_framepos_64, IFp)
 GO(mpg123_free_string, vFp)
-//GO(mpg123_geteq, 
+GO(mpg123_geteq, dFpii)
 GO(mpg123_getformat, iFpppp)
 GO(mpg123_getformat2, iFppppi)
-//GO(mpg123_getpar, 
+GO(mpg123_getpar, iFpipp)
 GO(mpg123_getparam, iFpipp)
-//GO(mpg123_getstate, 
+GO(mpg123_getstate, iFpipp)
 GO(mpg123_getvolume, iFpppp)
 GO(mpg123_grow_string, iFpL)
 GO(mpg123_icy, iFpp)
@@ -56,7 +56,7 @@ GO(mpg123_icy2utf8, pFp)
 GO(mpg123_id3, iFppp)
 GO(mpg123_index, iFpppp)
 GO(mpg123_index_64, iFpppp)
-//GO(mpg123_info, 
+GO(mpg123_info, iFpp)
 GO(mpg123_init, iFv)
 //GO(mpg123_init_string, 
 GO(mpg123_length, lFp)
@@ -73,7 +73,7 @@ GO(mpg123_open_feed, iFp)
 GO(mpg123_open_handle, iFpp)
 GO(mpg123_open_handle_64, iFpp)
 GO(mpg123_outblock, LFp)
-//GO(mpg123_par, 
+GO(mpg123_par, iFpild)
 GO(mpg123_param, iFpild)
 GO(mpg123_parnew, pFppp)
 GO(mpg123_plain_strerror, pFi)
@@ -101,7 +101,7 @@ GO(mpg123_set_index_64, iFppIL)
 GO(mpg123_set_string, iFpp)
 GO(mpg123_set_substring, iFppLL)
 //GO(mpg123_spf, 
-//GO(mpg123_store_utf8, 
+GO(mpg123_store_utf8, iFpipL)
 GO(mpg123_strerror, pFp)
 GO(mpg123_strlen, LFpi)
 GO(mpg123_supported_decoders, pFv)
@@ -115,4 +115,4 @@ GO(mpg123_timeframe, lFpd)
 GO(mpg123_timeframe_64, IFpd)
 GO(mpg123_tpf, dFp)
 //GO(mpg123_volume, 
-//GO(mpg123_volume_change, 
+GO(mpg123_volume_change, iFpd)

--- a/wrapperhelper/README.md
+++ b/wrapperhelper/README.md
@@ -10,6 +10,15 @@ etc. Of course, this cannot completely automate everything, it can only be used 
 
 At the same time, this tool is also quite rough, and may even have errors.
 
+## Build
+
+```
+sudo apt install libclang-14-dev
+cd wrapperhelper
+mkdir build; cd build; cmake ..
+make
+```
+
 ## Usage:
 
     helper <filename> <libname> [guest_triple] [host_triple] -- <clang_flags>

--- a/wrapperhelper/README.md
+++ b/wrapperhelper/README.md
@@ -1,5 +1,8 @@
 # Wrapper helper
 
+**WARNING: There are still many problems with this tool. Please do NOT submit code generated directly by the tool, you should only use it as a preliminary reference.**
+
+
 This tool is based on libclangtooling.
 
 It parses the AST of the library header files, generating the required structures of the wrapping library, including:


### PR DESCRIPTION
Added for this game: https://cyfo.itch.io/katkoot, only `mpg123_info` is needed, by I added others anyway.

I used wrapperhelper, with this command under x86-64: `./helper /usr/include/mpg123.h libmpg123 x64 x64 --`

It throws me a bunch of errors, and some mpg123 function wrappers are missing, don't know what's wrong.

```
--------------- Libclangtooling parse complete -----------------
input.cc:2:25: error: brackets are not allowed here; to declare an array, place the brackets after the name
    double[2][576] xr[2];
          ~~~~~~~~      ^
                        [2][576]
input.cc:3:25: error: brackets are not allowed here; to declare an array, place the brackets after the name
    double[2][22] sfb[2];
          ~~~~~~~       ^
                        [2][22]
input.cc:4:27: error: brackets are not allowed here; to declare an array, place the brackets after the name
    double[2][39] sfb_s[2];
          ~~~~~~~         ^
                          [2][39]
input.cc:5:18: error: brackets are not allowed here; to declare an array, place the brackets after the name
    int[2] qss[2];
       ~~~       ^
                 [2]
input.cc:6:25: error: brackets are not allowed here; to declare an array, place the brackets after the name
    int[2] big_values[2];
       ~~~              ^
                        [2]
input.cc:7:26: error: brackets are not allowed here; to declare an array, place the brackets after the name
    int[2][3] sub_gain[2];
       ~~~~~~            ^
                         [2][3]
input.cc:8:29: error: brackets are not allowed here; to declare an array, place the brackets after the name
    int[2] scalefac_scale[2];
       ~~~                  ^
                            [2]
input.cc:9:22: error: brackets are not allowed here; to declare an array, place the brackets after the name
    int[2] preflag[2];
       ~~~           ^
                     [2]
input.cc:10:24: error: brackets are not allowed here; to declare an array, place the brackets after the name
    int[2] blocktype[2];
       ~~~             ^
                       [2]
input.cc:11:20: error: brackets are not allowed here; to declare an array, place the brackets after the name
    int[2] mixed[2];
       ~~~         ^
                   [2]
input.cc:12:23: error: brackets are not allowed here; to declare an array, place the brackets after the name
    int[2] mainbits[2];
       ~~~            ^
                      [2]
input.cc:13:21: error: brackets are not allowed here; to declare an array, place the brackets after the name
    int[2] sfbits[2];
       ~~~          ^
                    [2]
input.cc:2:25: error: brackets are not allowed here; to declare an array, place the brackets after the name
    double[2][576] xr[2];
          ~~~~~~~~      ^
                        [2][576]
input.cc:3:25: error: brackets are not allowed here; to declare an array, place the brackets after the name
    double[2][22] sfb[2];
          ~~~~~~~       ^
                        [2][22]
input.cc:4:27: error: brackets are not allowed here; to declare an array, place the brackets after the name
    double[2][39] sfb_s[2];
          ~~~~~~~         ^
                          [2][39]
input.cc:5:18: error: brackets are not allowed here; to declare an array, place the brackets after the name
    int[2] qss[2];
       ~~~       ^
                 [2]
input.cc:6:25: error: brackets are not allowed here; to declare an array, place the brackets after the name
    int[2] big_values[2];
       ~~~              ^
                        [2]
input.cc:7:26: error: brackets are not allowed here; to declare an array, place the brackets after the name
    int[2][3] sub_gain[2];
       ~~~~~~            ^
                         [2][3]
input.cc:8:29: error: brackets are not allowed here; to declare an array, place the brackets after the name
    int[2] scalefac_scale[2];
       ~~~                  ^
                            [2]
input.cc:9:22: error: brackets are not allowed here; to declare an array, place the brackets after the name
    int[2] preflag[2];
       ~~~           ^
                     [2]
input.cc:10:24: error: brackets are not allowed here; to declare an array, place the brackets after the name
    int[2] blocktype[2];
       ~~~             ^
                       [2]
input.cc:11:20: error: brackets are not allowed here; to declare an array, place the brackets after the name
    int[2] mixed[2];
       ~~~         ^
                   [2]
input.cc:12:23: error: brackets are not allowed here; to declare an array, place the brackets after the name
    int[2] mainbits[2];
       ~~~            ^
                      [2]
input.cc:13:21: error: brackets are not allowed here; to declare an array, place the brackets after the name
    int[2] sfbits[2];
       ~~~          ^
                    [2]
--------------- Generator prepare complete -----------------
Unsupported Type: div_t
Unsupported Type: ldiv_t
Unsupported Type: lldiv_t
Unsupported Type: div_t
Unsupported Type: ldiv_t
Unsupported Type: lldiv_t
--------------- Generator gen complete -----------------
```