### PR TITLE
Added 1 libx11 symbol for #758

### DIFF
--- a/src/wrapped/wrappedlibx11_private.h
+++ b/src/wrapped/wrappedlibx11_private.h
@@ -583,7 +583,7 @@ DATA(_XkbGetAtomNameFunc, sizeof(void*))
 GO(XkbGetAutoResetControls, iFppp)
 //GO(_XkbGetCharset, 
 //GO(XkbGetCompatMap
-//GO(XkbGetControls
+GO(XkbGetControls, iFpLp)
 //GO(_XkbGetConverters, 
 GO(XkbGetDetectableAutoRepeat, iFpp)
 GO(XkbGetDeviceButtonActions, iFppiuu)


### PR DESCRIPTION
It's the only 1 symbol that is missing for Cassette Beasts to work.