### PR TITLE
[RV64_DYNAREC] Fixed 66 0F 38 2B PACKUSDW opcode

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_660f.c
+++ b/src/dynarec/rv64/dynarec_rv64_660f.c
@@ -463,9 +463,9 @@ uintptr_t dynarec64_660F(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                             MIN(x3, x3, x5);
                             MAX(x3, x3, xZR);
                         } else {
-                            BLT(x3, xZR, 4+4);
+                            BGE(x3, xZR, 4+4);
                             MV(x3, xZR);
-                            BGE(x3, x5, 4+4);
+                            BLT(x3, x5, 4+4);
                             MV(x3, x5);
                         }
                         SH(x3, gback, i*2);
@@ -479,9 +479,9 @@ uintptr_t dynarec64_660F(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                             MIN(x3, x3, x5);
                             MAX(x3, x3, xZR);
                         } else {
-                            BLT(x3, xZR, 4+4);
+                            BGE(x3, xZR, 4+4);
                             MV(x3, xZR);
-                            BGE(x3, x5, 4+4);
+                            BLT(x3, x5, 4+4);
                             MV(x3, x5);
                         }
                         SH(x3, gback, 8+i*2);

--- a/system/box64.box64rc
+++ b/system/box64.box64rc
@@ -7,7 +7,6 @@
 # 
 [3dSen.x86_64]
 BOX64_DYNAREC_BLEEDING_EDGE=0   # avoid the use of STRONGMEM for much better performances
-BOX64_DYNAREC_HOTPAGE=0 # disabling hotpage seems to give better performances here
 
 [7z]
 # Those are safe to use on 7z and give a bit of a boost
@@ -25,12 +24,6 @@ BOX64_DYNAREC_CALLRET=1
 
 [chrome]
 BOX64_MALLOC_HACK=2
-
-[dav1d]
-# Speed hacks (those 3 gives ~10% speedup)
-BOX64_DYNAREC_SAFEFLAGS=0
-BOX64_DYNAREC_BIGBLOCK=2
-BOX64_DYNAREC_CALLRET=1
 
 [deadcells]
 BOX64_PREFER_EMULATED=1
@@ -96,9 +89,6 @@ BOX64_MALLOC_HACK=2
 BOX64_DYNAREC_BIGBLOCK=0
 # if steamwebhelper takes too much memory, enable next line to disable it
 #BOX64_EXIT=1
-
-[Stardew Valley]
-BOX64_DYNAREC_HOTPAGE=0
 
 [steam-runtime-check-requirements]
 BOX64_EXIT=1


### PR DESCRIPTION
Cached by cosim when running dav1d 1.2.0. I believe that dav1d did not work yesterday because of this reason, because I also ran cosim yesterday, and it also reported inconsistent results for this opcode. But I can't reproduce the problem that dav1d prints a bunch of error logs and then exits abnormally.