### PR TITLE
[RV64_DYNAREC] Fixed 6B IMUL opcode

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_00_1.c
+++ b/src/dynarec/rv64/dynarec_rv64_00_1.c
@@ -181,12 +181,12 @@ uintptr_t dynarec64_00_1(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                 // 64bits imul
                 UFLAG_IF {
                     MULH(x3, ed, x4);
-                    MULW(gd, ed, x4);
+                    MUL(gd, ed, x4);
                     UFLAG_OP1(x3);
                     UFLAG_RES(gd);
                     UFLAG_DF(x3, d_imul64);
                 } else {
-                    MULxw(gd, ed, x4);
+                    MUL(gd, ed, x4);
                 }
             } else {
                 // 32bits imul
@@ -197,7 +197,7 @@ uintptr_t dynarec64_00_1(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                     UFLAG_OP1(x3);
                     UFLAG_DF(x3, d_imul32);
                 } else {
-                    MULxw(gd, ed, x4);
+                    MULW(gd, ed, x4);
                 }
                 ZEROUP(gd);
             }


### PR DESCRIPTION
Caught by cosim when trying to run Overcooked! 2 (Unity). But the game still not working. Unity games seem generally not working.

```
Found path: /home/ksco/Documents/Overcooked! 2/Overcooked2.x86_64
Using emulated /home/ksco/Documents/Overcooked! 2/Overcooked2_Data/Mono/x86_64/libmono.so
Mono path[0] = '/home/ksco/Documents/Overcooked! 2/Overcooked2_Data/Managed'
Mono config path = '/home/ksco/Documents/Overcooked! 2/Overcooked2_Data/Mono/etc'
25295|SIGBUS @0x378f068c (???(0x378f068c)) (x64pc=0x102b25c25//home/ksco/Documents/Overcooked! 2/Overcooked2_Data/Mono/x86_64/libmono.so:"/home/ksco/Documents/Overcooked! 2/Overcooked2_Data/Mono/x86_64/libmono.so + 0xd5bf4", rsp=0x101ffdf20, stack=0x101800000:0x102000000 own=(nil) fp=0x2c0160), for accessing 0x2c0052 (code=1/prot=7), db=0x4002d189b0(0x378f0550:0x378f0818/0x102b25bf4:0x102b25c44//home/ksco/Documents/Overcooked! 2/Overcooked2_Data/Mono/x86_64/libmono.so + 0xd5bf4:clean, hash:e5f5523f/e5f5523f) handler=0x102a87068
RAX:0x00000000002c006e RCX:0x0000000000000200 RDX:0x0000000000000000 RBX:0x00000000002c005d 
RSP:0x0000000101ffdf20 RBP:0x00000000002c0160 RSI:0x00000000002c005f RDI:0x0000000102f07a30 
 R8:0x0000000000000010  R9:0x0000000101ffdf38 R10:0x00000000002c005f R11:0x00000000002c0040 
R12:0x0000000000000001 R13:0x00000000002c0160 R14:0x00000000002c0160 R15:0x0000000101ffe1d8 
RSP-0x20:0x0000000000000000 RSP-0x18:0x00000000002c005d RSP-0x10:0x00000000002c0160 RSP-0x08:0x0000000102b25bf4
RSP+0x00:0x00000000002c005d RSP+0x08:0x0000000037337900 RSP+0x10:0x0000000000000002 RSP+0x18:0x00002c006ebb4908 x86opcode=F0 48 0F B1 6B F5 75 F8
Stacktrace:

  at System.OutOfMemoryException..ctor (string) <0xffffffff>
  at System.OutOfMemoryException..ctor (string) <0x0001d>
  at (wrapper runtime-invoke) object.runtime_invoke_void__this___object (object,intptr,intptr,intptr) <0x00069>

Native stacktrace:

	/home/ksco/Documents/Overcooked! 2/Overcooked2_Data/Mono/x86_64/libmono.so+9843b [0x102ae843b]
	/home/ksco/Documents/Overcooked! 2/Overcooked2_Data/Mono/x86_64/libmono.so+37150 [0x102a87150]
	??? [0x3732f350]

Debug info from gdb:
```

`F0 48 0F B1 6B F5` is `lock cmpxchg QWORD PTR [rbx-0xb],rbp`, maybe it's an unaligned atomic? Not sure.