### PR TITLE
[DYNAREC] Fixed call_c issues

### DIFF
--- a/src/dynarec/arm64/dynarec_arm64_0f.c
+++ b/src/dynarec/arm64/dynarec_arm64_0f.c
@@ -332,9 +332,9 @@ uintptr_t dynarec64_0F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int nin
             INST_NAME("RDTSC");
             NOTEST(x1);
             MESSAGE(LOG_DUMP, "Need Optimization\n");
-            CALL(ReadTSC, xRAX);   // will return the u64 in xEAX
-            LSRx(xRDX, xRAX, 32);
-            MOVw_REG(xRAX, xRAX);   // wipe upper part
+            CALL(ReadTSC, x3);    // will return the u64 in x3
+            LSRx(xRDX, x3, 32);
+            MOVw_REG(xRAX, x3);   // wipe upper part
             break;
 
         case 0x38:
@@ -416,7 +416,7 @@ uintptr_t dynarec64_0F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int nin
                     GETEM(q1, 1);
                     u8 = F8;
                     if(u8>15) {
-                        VEOR(q0, q0, q0);    
+                        VEOR(q0, q0, q0);
                     } else if(u8>7) {
                         d0 = fpu_get_scratch(dyn);
                         VEOR(d0, d0, d0);
@@ -498,7 +498,7 @@ uintptr_t dynarec64_0F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int nin
             // more precise
             if(q1==q0)
                 v1 = fpu_get_scratch(dyn);
-            else 
+            else
                 v1 = q1;
             VFRSQRTEQS(v0, q0);
             VFMULQS(v1, v0, q0);
@@ -1087,7 +1087,7 @@ uintptr_t dynarec64_0F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int nin
 
         GOCOND(0x90, "SET", "Eb");
         #undef GO
-            
+
         case 0xA2:
             INST_NAME("CPUID");
             NOTEST(x1);
@@ -1242,7 +1242,7 @@ uintptr_t dynarec64_0F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int nin
                             CALL(rex.w?((void*)fpu_fxrstor64):((void*)fpu_fxrstor32), -1);
                         }
                         break;
-                    case 2:                 
+                    case 2:
                         INST_NAME("LDMXCSR Md");
                         GETED(0);
                         STRw_U12(ed, xEmu, offsetof(x64emu_t, mxcsr));
@@ -1593,21 +1593,21 @@ uintptr_t dynarec64_0F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int nin
                 case 0: VFCMEQQS(v0, v0, v1); break;   // Equal
                 case 1: VFCMGTQS(v0, v1, v0); break;   // Less than
                 case 2: VFCMGEQS(v0, v1, v0); break;   // Less or equal
-                case 3: VFCMEQQS(v0, v0, v0); 
+                case 3: VFCMEQQS(v0, v0, v0);
                         if(v0!=v1) {
-                            q0 = fpu_get_scratch(dyn); 
-                            VFCMEQQS(q0, v1, v1); 
+                            q0 = fpu_get_scratch(dyn);
+                            VFCMEQQS(q0, v1, v1);
                             VANDQ(v0, v0, q0);
                         }
-                        VMVNQ(v0, v0); 
+                        VMVNQ(v0, v0);
                         break;   // NaN (NaN is not equal to himself)
                 case 4: VFCMEQQS(v0, v0, v1); VMVNQ(v0, v0); break;   // Not Equal (or unordered on ARM, not on X86...)
                 case 5: VFCMGTQS(v0, v1, v0); VMVNQ(v0, v0); break;   // Greater or equal or unordered
                 case 6: VFCMGEQS(v0, v1, v0); VMVNQ(v0, v0); break;   // Greater or unordered
-                case 7: VFCMEQQS(v0, v0, v0); 
+                case 7: VFCMEQQS(v0, v0, v0);
                         if(v0!=v1) {
-                            q0 = fpu_get_scratch(dyn); 
-                            VFCMEQQS(q0, v1, v1); 
+                            q0 = fpu_get_scratch(dyn);
+                            VFCMEQQS(q0, v1, v1);
                             VANDQ(v0, v0, q0);
                         }
                         break;   // not NaN
@@ -1739,7 +1739,7 @@ uintptr_t dynarec64_0F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int nin
             USHL_8(q1, q1, v0); // shift
             UADDLV_8(q1, q1);   // accumalte
             VMOVBto(gd, q1, 0);
-            break;        
+            break;
         case 0xD8:
             INST_NAME("PSUBUSB Gm, Em");
             nextop = F8;
@@ -1870,7 +1870,7 @@ uintptr_t dynarec64_0F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int nin
             GETEM(d1, 0);
             SQADD_16(d0, d0, d1);
             break;
-        
+
         case 0xEF:
             INST_NAME("PXOR Gm,Em");
             nextop = F8;

--- a/src/dynarec/rv64/dynarec_rv64_00_3.c
+++ b/src/dynarec/rv64/dynarec_rv64_00_3.c
@@ -899,15 +899,14 @@ uintptr_t dynarec64_00_3(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                         AND(xRAX, x2, xMASK);
                         ZEROUP(xRDX);
                     } else {
-                        if(ninst 
-                           && dyn->insts[ninst-1].x64.addr 
-                           && *(uint8_t*)(dyn->insts[ninst-1].x64.addr)==0x31 
+                        if(ninst
+                           && dyn->insts[ninst-1].x64.addr
+                           && *(uint8_t*)(dyn->insts[ninst-1].x64.addr)==0x31
                            && *(uint8_t*)(dyn->insts[ninst-1].x64.addr+1)==0xD2) {
                             SET_DFNONE();
                             GETED(0);
-                            DIVU(x2, xRAX, ed);
                             REMU(xRDX, xRAX, ed);
-                            MV(xRAX, x2);
+                            DIVU(xRAX, xRAX, ed);
                         } else {
                             GETEDH(x1, 0);  // get edd changed addr, so cannot be called 2 times for same op...
                             BEQ_MARK(xRDX, xZR);
@@ -915,9 +914,8 @@ uintptr_t dynarec64_00_3(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                             CALL(div64, -1);
                             B_NEXT_nocond;
                             MARK;
-                            DIVU(x2, xRAX, ed);
                             REMU(xRDX, xRAX, ed);
-                            MV(xRAX, x2);
+                            DIVU(xRAX, xRAX, ed);
                             SET_DFNONE();
                         }
                     }
@@ -938,14 +936,13 @@ uintptr_t dynarec64_00_3(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                         ZEROUP(xRDX);
                     } else {
                         if(ninst && dyn->insts
-                           &&  dyn->insts[ninst-1].x64.addr 
+                           &&  dyn->insts[ninst-1].x64.addr
                            && *(uint8_t*)(dyn->insts[ninst-1].x64.addr)==0x48
                            && *(uint8_t*)(dyn->insts[ninst-1].x64.addr+1)==0x99) {
                             SET_DFNONE()
                             GETED(0);
-                            DIV(x2, xRAX, ed);
                             REM(xRDX, xRAX, ed);
-                            MV(xRAX, x2);
+                            DIV(xRAX, xRAX, ed);
                         } else {
                             GETEDH(x1, 0);  // get edd changed addr, so cannot be called 2 times for same op...
                             //Need to see if RDX==0 and RAX not signed
@@ -961,9 +958,8 @@ uintptr_t dynarec64_00_3(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                             CALL((void*)idiv64, -1);
                             B_NEXT_nocond;
                             MARK;
-                            DIV(x2, xRAX, ed);
                             REM(xRDX, xRAX, ed);
-                            MV(xRAX, x2);
+                            DIV(xRAX, xRAX, ed);
                             SET_DFNONE()
                         }
                     }
@@ -1029,7 +1025,7 @@ uintptr_t dynarec64_00_3(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                     break;
                 case 2: // CALL Ed
                     INST_NAME("CALL Ed");
-                    PASS2IF((box64_dynarec_safeflags>1) || 
+                    PASS2IF((box64_dynarec_safeflags>1) ||
                         ((ninst && dyn->insts[ninst-1].x64.set_flags)
                         || ((ninst>1) && dyn->insts[ninst-2].x64.set_flags)), 1)
                     {

--- a/src/dynarec/rv64/dynarec_rv64_00_3.c
+++ b/src/dynarec/rv64/dynarec_rv64_00_3.c
@@ -899,14 +899,15 @@ uintptr_t dynarec64_00_3(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                         AND(xRAX, x2, xMASK);
                         ZEROUP(xRDX);
                     } else {
-                        if(ninst
-                           && dyn->insts[ninst-1].x64.addr
-                           && *(uint8_t*)(dyn->insts[ninst-1].x64.addr)==0x31
+                        if(ninst 
+                           && dyn->insts[ninst-1].x64.addr 
+                           && *(uint8_t*)(dyn->insts[ninst-1].x64.addr)==0x31 
                            && *(uint8_t*)(dyn->insts[ninst-1].x64.addr+1)==0xD2) {
                             SET_DFNONE();
                             GETED(0);
+                            DIVU(x2, xRAX, ed);
                             REMU(xRDX, xRAX, ed);
-                            DIVU(xRAX, xRAX, ed);
+                            MV(xRAX, x2);
                         } else {
                             GETEDH(x1, 0);  // get edd changed addr, so cannot be called 2 times for same op...
                             BEQ_MARK(xRDX, xZR);
@@ -914,8 +915,9 @@ uintptr_t dynarec64_00_3(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                             CALL(div64, -1);
                             B_NEXT_nocond;
                             MARK;
+                            DIVU(x2, xRAX, ed);
                             REMU(xRDX, xRAX, ed);
-                            DIVU(xRAX, xRAX, ed);
+                            MV(xRAX, x2);
                             SET_DFNONE();
                         }
                     }
@@ -936,13 +938,14 @@ uintptr_t dynarec64_00_3(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                         ZEROUP(xRDX);
                     } else {
                         if(ninst && dyn->insts
-                           &&  dyn->insts[ninst-1].x64.addr
+                           &&  dyn->insts[ninst-1].x64.addr 
                            && *(uint8_t*)(dyn->insts[ninst-1].x64.addr)==0x48
                            && *(uint8_t*)(dyn->insts[ninst-1].x64.addr+1)==0x99) {
                             SET_DFNONE()
                             GETED(0);
+                            DIV(x2, xRAX, ed);
                             REM(xRDX, xRAX, ed);
-                            DIV(xRAX, xRAX, ed);
+                            MV(xRAX, x2);
                         } else {
                             GETEDH(x1, 0);  // get edd changed addr, so cannot be called 2 times for same op...
                             //Need to see if RDX==0 and RAX not signed
@@ -958,8 +961,9 @@ uintptr_t dynarec64_00_3(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                             CALL((void*)idiv64, -1);
                             B_NEXT_nocond;
                             MARK;
+                            DIV(x2, xRAX, ed);
                             REM(xRDX, xRAX, ed);
-                            DIV(xRAX, xRAX, ed);
+                            MV(xRAX, x2);
                             SET_DFNONE()
                         }
                     }
@@ -1025,7 +1029,7 @@ uintptr_t dynarec64_00_3(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                     break;
                 case 2: // CALL Ed
                     INST_NAME("CALL Ed");
-                    PASS2IF((box64_dynarec_safeflags>1) ||
+                    PASS2IF((box64_dynarec_safeflags>1) || 
                         ((ninst && dyn->insts[ninst-1].x64.set_flags)
                         || ((ninst>1) && dyn->insts[ninst-2].x64.set_flags)), 1)
                     {

--- a/src/dynarec/rv64/dynarec_rv64_0f.c
+++ b/src/dynarec/rv64/dynarec_rv64_0f.c
@@ -311,6 +311,7 @@ uintptr_t dynarec64_0F(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
             break;
         case 0x31:
             INST_NAME("RDTSC");
+            NOTEST(x1);
             MESSAGE(LOG_DUMP, "Need Optimization\n");
             CALL(ReadTSC, x3);   // will return the u64 in x3
             SRLI(xRDX, x3, 32);

--- a/src/dynarec/rv64/dynarec_rv64_0f.c
+++ b/src/dynarec/rv64/dynarec_rv64_0f.c
@@ -312,9 +312,9 @@ uintptr_t dynarec64_0F(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
         case 0x31:
             INST_NAME("RDTSC");
             MESSAGE(LOG_DUMP, "Need Optimization\n");
-            CALL(ReadTSC, xRAX);   // will return the u64 in xEAX
-            SRLI(xRDX, xRAX, 32);
-            ZEROUP(xRAX);   // wipe upper part
+            CALL(ReadTSC, x3);   // will return the u64 in x3
+            SRLI(xRDX, x3, 32);
+            AND(xRAX, x3, 32);   // wipe upper part
             break;
 
 

--- a/src/dynarec/rv64/dynarec_rv64_helper.c
+++ b/src/dynarec/rv64/dynarec_rv64_helper.c
@@ -583,6 +583,7 @@ void call_c(dynarec_rv64_t* dyn, int ninst, void* fnc, int reg, int ret, int sav
         // x5..x8, x10..x17, x28..x31 those needs to be saved by caller
         STORE_REG(RAX);
         STORE_REG(RCX);
+        STORE_REG(RDX);
         STORE_REG(R12);
         STORE_REG(R13);
         STORE_REG(R14);
@@ -601,6 +602,7 @@ void call_c(dynarec_rv64_t* dyn, int ninst, void* fnc, int reg, int ret, int sav
         #define GO(A)   if(ret!=x##A) {LOAD_REG(A);}
         GO(RAX);
         GO(RCX);
+        GO(RDX);
         GO(R12);
         GO(R13);
         GO(R14);


### PR DESCRIPTION
1. We cannot use xRAX as a return value register when using `call_c`, it will be "restored" after the c function returns.
2. `div64` and `div32` sets `xRDX`, so even if `xRDX` is a callee-saved register, we still need to save & restore it.