### PR TITLE
add /usr/x86_64-linux-gnu/lib to the shared library search path

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1027,6 +1027,8 @@ void LoadEnvVars(box64context_t *context)
         AddPath("/lib/x86_64-linux-gnu", &context->box64_ld_lib, 1);
     if(FileExist("/usr/lib/x86_64-linux-gnu", 0))
         AddPath("/usr/lib/x86_64-linux-gnu", &context->box64_ld_lib, 1);
+    if(FileExist("/usr/x86_64-linux-gnu/lib", 0))
+        AddPath("/usr/x86_64-linux-gnu/lib", &context->box64_ld_lib, 1);
     if(getenv("LD_LIBRARY_PATH"))
         PrependList(&context->box64_ld_lib, getenv("LD_LIBRARY_PATH"), 1);   // in case some of the path are for x86 world
     if(getenv("BOX64_EMULATED_LIBS")) {


### PR DESCRIPTION
On Debian there are the packages libstdc++6-amd64-cross and libgcc-s1-amd64-cross which provide amd64 shared libraries which are usually used for cross compiling without multiarch but using a sysroot prefix instead. Since libgcc_s.so.1 and libstdc++.so.6 shipped by these packages are fully functional, let box64 use them as a fallback if it cannot find them in the other paths that it searched before.