### PR TITLE
[CI] Test RISCV with bit-manipulation extensions on

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,7 @@ jobs:
           if [[ ${{ matrix.platform }} != 'ANDROID' ]]; then
             if [[ ${{ matrix.platform }} == 'RISCV' ]]; then
               QEMU_LD_PREFIX=/usr/riscv64-linux-gnu/ ctest -j$(nproc) --rerun-failed --output-on-failure
+              QEMU_LD_PREFIX=/usr/riscv64-linux-gnu/ QEMU_CPU=rv64,x-zba=true,x-zbb=true,x-zbc=true,x-zbs=true ctest -j$(nproc) --rerun-failed --output-on-failure
             elif [[ ${{ matrix.platform }} != 'X64' ]]; then
               QEMU_LD_PREFIX=/usr/aarch64-linux-gnu/ ctest -j$(nproc) --rerun-failed --output-on-failure
             else

--- a/src/dynarec/rv64/rv64_emitter.h
+++ b/src/dynarec/rv64/rv64_emitter.h
@@ -311,7 +311,7 @@ f28–31  ft8–11  FP temporaries                  Caller
 #define ADDIz(rd, rs1, imm12)       EMIT(I_type((imm12)&0b111111111111, rs1, 0b000, rd, rex.is32bits?0b0011011:0b0010011))
 
 // rd = rs1 + (rs2 << imm2)
-#define ADDSL(rd, rs1, rs2, imm2, scratch) if (!imm2) { \
+#define ADDSL(rd, rs1, rs2, imm2, scratch) if (!(imm2)) { \
         ADD(rd, rs1, rs2);              \
     } else if (rv64_zba) {              \
         SHxADD(rd, rs2, imm2, rs1);     \


### PR DESCRIPTION
xthead extensions require qemu 8.1.0, therefore not available in CI