### PR TITLE
[RV64_DYNAREC] Fixed 66 0F B6 MOVZX opcode

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_660f.c
+++ b/src/dynarec/rv64/dynarec_rv64_660f.c
@@ -2094,6 +2094,7 @@ uintptr_t dynarec64_660F(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
         case 0xB6:
             INST_NAME("MOVZX Gw, Eb");
             nextop = F8;
+            gd = xRAX+((nextop&0x38)>>3)+(rex.r<<3);
             if (MODREG) {
                 if (rex.rex) {
                     eb1 = xRAX + (nextop & 7) + (rex.b << 3);


### PR DESCRIPTION
After tedious bisecting with BOX64_NODYNAREC, I found that this opcode was not correctly implemented. However, a strange SIGBUS error pops up when I'm trying to run YuanShen.exe (Genshin Impact) with this patch. If the fix is only applied to VMP areas (by checking `addr` in dynarec), the program can produce a meaningful "A debugger has been found running in your system.\nPlease, unload it from memory and restart your program." message instead of garbage as before.