### PR TITLE
[RBTREE] Reverted memory tracking to 32 bits

### DIFF
--- a/src/custommem.c
+++ b/src/custommem.c
@@ -1003,13 +1003,13 @@ void protectDB(uintptr_t addr, uintptr_t size)
 
     mutex_lock(&mutex_prot);
     while(cur!=end) {
-        uint8_t prot = 0, oprot;
+        uint32_t prot = 0, oprot;
         uintptr_t bend = 0;
         rb_get_end(memprot, cur, &prot, &bend);
         if(bend>end)
             bend = end;
         oprot = prot;
-        uint8_t dyn = prot&PROT_DYN;
+        uint32_t dyn = prot&PROT_DYN;
         if(!prot)
             prot = PROT_READ | PROT_WRITE | PROT_EXEC;
         if(!(dyn&PROT_NOPROT)) {
@@ -1038,7 +1038,7 @@ void unprotectDB(uintptr_t addr, size_t size, int mark)
 
     mutex_lock(&mutex_prot);
     while(cur!=end) {
-        uint8_t prot = 0, oprot;
+        uint32_t prot = 0, oprot;
         uintptr_t bend = 0;
         if (!rb_get_end(memprot, cur, &prot, &bend)) {
             if(bend>=end) break;
@@ -1073,7 +1073,7 @@ int isprotectedDB(uintptr_t addr, size_t size)
     addr &=~(box64_pagesize-1);
     mutex_lock(&mutex_prot);
     while (addr < end) {
-        uint8_t prot;
+        uint32_t prot;
         uintptr_t bend;
         if (!rb_get_end(memprot, addr, &prot, &bend) || !(prot&PROT_DYN)) {
             dynarec_log(LOG_DEBUG, "0\n");
@@ -1188,7 +1188,7 @@ void removeMapMem(mapmem_t* mapmem, uintptr_t begin, uintptr_t end)
     }
 }
 
-void updateProtection(uintptr_t addr, size_t size, uint8_t prot)
+void updateProtection(uintptr_t addr, size_t size, uint32_t prot)
 {
     dynarec_log(LOG_DEBUG, "updateProtection %p:%p 0x%hhx\n", (void*)addr, (void*)(addr+size-1), prot);
     mutex_lock(&mutex_prot);
@@ -1197,9 +1197,9 @@ void updateProtection(uintptr_t addr, size_t size, uint8_t prot)
     uintptr_t end = (cur+size+(box64_pagesize-1))&~(box64_pagesize-1);
     while (cur < end) {
         uintptr_t bend;
-        uint8_t prot;
+        uint32_t prot;
         rb_get_end(memprot, cur, &prot, &bend);
-        uint8_t dyn=(prot&PROT_DYN);
+        uint32_t dyn=(prot&PROT_DYN);
         if(!(dyn&PROT_NOPROT)) {
             if(dyn && (prot&PROT_WRITE)) {   // need to remove the write protection from this block
                 dyn = PROT_DYNAREC;
@@ -1215,7 +1215,7 @@ void updateProtection(uintptr_t addr, size_t size, uint8_t prot)
     mutex_unlock(&mutex_prot);
 }
 
-void setProtection(uintptr_t addr, size_t size, uint8_t prot)
+void setProtection(uintptr_t addr, size_t size, uint32_t prot)
 {
     mutex_lock(&mutex_prot);
     addMapMem(mapallmem, addr, addr+size-1);
@@ -1225,7 +1225,7 @@ void setProtection(uintptr_t addr, size_t size, uint8_t prot)
     mutex_unlock(&mutex_prot);
 }
 
-void setProtection_mmap(uintptr_t addr, size_t size, uint8_t prot)
+void setProtection_mmap(uintptr_t addr, size_t size, uint32_t prot)
 {
     if(!size)
         return;
@@ -1242,7 +1242,7 @@ void setProtection_mmap(uintptr_t addr, size_t size, uint8_t prot)
     }
 }
 
-void setProtection_elf(uintptr_t addr, size_t size, uint8_t prot)
+void setProtection_elf(uintptr_t addr, size_t size, uint32_t prot)
 {
     if(prot)
         setProtection(addr, size, prot);
@@ -1256,7 +1256,7 @@ void setProtection_elf(uintptr_t addr, size_t size, uint8_t prot)
 void refreshProtection(uintptr_t addr)
 {
     mutex_lock(&mutex_prot);
-    uint8_t prot;
+    uint32_t prot;
     uintptr_t bend;
     if (rb_get_end(memprot, addr, &prot, &bend)) {
         int ret = mprotect((void*)(addr&~(box64_pagesize-1)), box64_pagesize, prot&~PROT_CUSTOM);
@@ -1316,12 +1316,12 @@ void freeProtection(uintptr_t addr, size_t size)
     mutex_unlock(&mutex_prot);
 }
 
-uint8_t getProtection(uintptr_t addr)
+uint32_t getProtection(uintptr_t addr)
 {
     if(addr>=(1LL<<48))
         return 0;
     mutex_lock(&mutex_prot);
-    uint8_t ret = rb_get(memprot, addr);
+    uint32_t ret = rb_get(memprot, addr);
     mutex_unlock(&mutex_prot);
     return ret;
 }

--- a/src/include/custommem.h
+++ b/src/include/custommem.h
@@ -75,13 +75,13 @@ uintptr_t getJumpAddress64(uintptr_t addr);
 #define PROT_CUSTOM     (PROT_DYNAREC | PROT_DYNAREC_R | PROT_NOPROT)
 #define PROT_WAIT       0xFF
 
-void updateProtection(uintptr_t addr, size_t size, uint8_t prot);
-void setProtection(uintptr_t addr, size_t size, uint8_t prot);
-void setProtection_mmap(uintptr_t addr, size_t size, uint8_t prot);
-void setProtection_elf(uintptr_t addr, size_t size, uint8_t prot);
+void updateProtection(uintptr_t addr, size_t size, uint32_t prot);
+void setProtection(uintptr_t addr, size_t size, uint32_t prot);
+void setProtection_mmap(uintptr_t addr, size_t size, uint32_t prot);
+void setProtection_elf(uintptr_t addr, size_t size, uint32_t prot);
 void freeProtection(uintptr_t addr, size_t size);
 void refreshProtection(uintptr_t addr);
-uint8_t getProtection(uintptr_t addr);
+uint32_t getProtection(uintptr_t addr);
 int getMmapped(uintptr_t addr);
 void loadProtectionFromMap(void);
 #ifdef DYNAREC

--- a/src/include/rbtree.h
+++ b/src/include/rbtree.h
@@ -1,13 +1,18 @@
 #include <stdint.h>
 
+#ifndef RBTREE_H
+#define RBTREE_H
+
 typedef struct rbtree rbtree;
 
 rbtree* init_rbtree();
 void delete_rbtree(rbtree *tree);
 
-uint8_t rb_get(rbtree *tree, uintptr_t addr);
-int rb_get_end(rbtree* tree, uintptr_t addr, uint8_t* val, uintptr_t* end);
-int rb_set(rbtree *tree, uintptr_t start, uintptr_t end, uint8_t data);
+uint32_t rb_get(rbtree *tree, uintptr_t addr);
+int rb_get_end(rbtree* tree, uintptr_t addr, uint32_t* val, uintptr_t* end);
+int rb_set(rbtree *tree, uintptr_t start, uintptr_t end, uint32_t data);
 int rb_unset(rbtree *tree, uintptr_t start, uintptr_t end);
 
 void print_rbtree(const rbtree *tree);
+
+#endif // RBTREE_H

--- a/src/libtools/signals.c
+++ b/src/libtools/signals.c
@@ -1003,7 +1003,7 @@ void my_sigactionhandler_oldcode(int32_t sig, int simple, siginfo_t* info, void 
     TRAP_x86_MCHK       = 18,  // Machine check exception
     TRAP_x86_CACHEFLT   = 19   // SIMD exception (via SIGFPE) if CPU is SSE capable otherwise Cache flush exception (via SIGSEV)
     */
-    uint8_t prot = getProtection((uintptr_t)info->si_addr);
+    uint32_t prot = getProtection((uintptr_t)info->si_addr);
     if(sig==SIGBUS)
         sigcontext->uc_mcontext.gregs[X64_TRAPNO] = 17;
     else if(sig==SIGSEGV) {
@@ -1282,7 +1282,7 @@ void my_box64signalhandler(int32_t sig, siginfo_t* info, void * ucntx)
         return;
     }
     int Locks = unlockMutex();
-    uint8_t prot = getProtection((uintptr_t)addr);
+    uint32_t prot = getProtection((uintptr_t)addr);
     #ifdef BAD_SIGNAL
     // try to see if the si_code makes sense
     // the RK3588 tend to need a special Kernel that seems to have a weird behaviour sometimes
@@ -1386,7 +1386,7 @@ void my_box64signalhandler(int32_t sig, siginfo_t* info, void * ucntx)
         cleanDBFromAddressRange(((uintptr_t)addr)&~(box64_pagesize-1), box64_pagesize, 0);
         static void* glitch_pc = NULL;
         static void* glitch_addr = NULL;
-        static uint8_t glitch_prot = 0;
+        static uint32_t glitch_prot = 0;
         if(addr && pc /*&& db*/) {
             if((glitch_pc!=pc || glitch_addr!=addr || glitch_prot!=prot)) {
                 // probably a glitch due to intensive multitask...

--- a/src/mallochook.c
+++ b/src/mallochook.c
@@ -134,7 +134,7 @@ typedef void* (*pFpLLp_t)(void*, size_t, size_t, void*);
 size_t(*box_malloc_usable_size)(void*) = NULL;
 
 int GetTID();
-uint8_t getProtection(uintptr_t addr);
+uint32_t getProtection(uintptr_t addr);
 // malloc_hack "2" handling
 // mmap history
 static int malloc_hack_2 = 0;

--- a/src/tools/rbtree.c
+++ b/src/tools/rbtree.c
@@ -21,8 +21,8 @@
 typedef struct rbnode {
     struct rbnode *left, *right, *parent;
     uintptr_t start, end;
+    uint32_t data;
     uint8_t meta;
-    uint8_t data;
 } rbnode;
 
 typedef struct rbtree {
@@ -52,7 +52,7 @@ void delete_rbtree(rbtree *tree) {
 #define IS_BLACK 0x2
 
 // Make sure prev is either the rightmost node before start or the leftmost range after start
-int add_range_next_to(rbtree *tree, rbnode *prev, uintptr_t start, uintptr_t end, uint8_t data) {
+int add_range_next_to(rbtree *tree, rbnode *prev, uintptr_t start, uintptr_t end, uint32_t data) {
 // printf("Adding %lX-%lX:%hhX next to %p\n", start, end, data, prev);
     rbnode *node = rbtreeMalloc(sizeof(*node));
     if (!node) return -1;
@@ -226,7 +226,7 @@ int add_range_next_to(rbtree *tree, rbnode *prev, uintptr_t start, uintptr_t end
     tree->is_unstable = 0;
     return -1; // unreachable
 }
-int add_range(rbtree *tree, uintptr_t start, uintptr_t end, uint8_t data) {
+int add_range(rbtree *tree, uintptr_t start, uintptr_t end, uint32_t data) {
 // printf("add_range\n");
     rbnode *cur = tree->root, *prev = NULL;
     while (cur) {
@@ -559,13 +559,13 @@ rbnode *succ_node(rbnode *node) {
     }
 }
 
-uint8_t rb_get(rbtree *tree, uintptr_t addr) {
+uint32_t rb_get(rbtree *tree, uintptr_t addr) {
     rbnode *node = find_addr(tree, addr);
     if (node) return node->data;
     else return 0;
 }
 
-int rb_get_end(rbtree* tree, uintptr_t addr, uint8_t* val, uintptr_t* end) {
+int rb_get_end(rbtree* tree, uintptr_t addr, uint32_t* val, uintptr_t* end) {
     rbnode *node = tree->root, *next = NULL;
     while (node) {
         if (node->end <= addr) {
@@ -588,7 +588,7 @@ int rb_get_end(rbtree* tree, uintptr_t addr, uint8_t* val, uintptr_t* end) {
     return 0;
 }
 
-int rb_set(rbtree *tree, uintptr_t start, uintptr_t end, uint8_t data) {
+int rb_set(rbtree *tree, uintptr_t start, uintptr_t end, uint32_t data) {
 // printf("rb_set( "); print_rbtree(tree); printf(" , 0x%lX, 0x%lX, %hhu);\n", start, end, data); fflush(stdout);
 dynarec_log(LOG_DEBUG, "set 0x%lX, 0x%lX, %hhu\n", start, end, data);
     if (!tree->root) {
@@ -859,7 +859,7 @@ int main() {
     ret = rb_set(tree, 0x10, 0x20, 0x01);
     printf("%d; ", ret); print_rbtree(tree); fflush(stdout);
 
-    uint8_t val = rb_get(tree, 0x33);
+    uint32_t val = rb_get(tree, 0x33);
     printf("0x33 has attribute %hhu\n", val); fflush(stdout);*/
     /* rbnode *node = find_addr(tree, 0x33);
     printf("0x33 is at %p: ", node); print_rbnode(node, 0); printf("\n"); fflush(stdout);
@@ -880,7 +880,7 @@ int main() {
     // rb_set(tree, 2, 3, 1); print_rbtree(tree); fflush(stdout);
     // add_range_next_to(tree, node24, 0x0E7000, 0x0E8000, 69); print_rbtree(tree); fflush(stdout);
     // print_rbtree(tree); fflush(stdout);
-    // uint8_t val = rb_get(tree, 0x11003000);
+    // uint32_t val = rb_get(tree, 0x11003000);
     // printf("0x11003000 has attribute %hhu\n", val); fflush(stdout);
     // remove_node(tree, node0); print_rbtree(tree); fflush(stdout);
     // add_range_next_to(tree, node1, 0x0E7000, 0x0E8000, 69); print_rbtree(tree); fflush(stdout);
@@ -894,7 +894,7 @@ rb_set(tree, 0x140000, 0x141000, 7);
     print_rbtree(tree); fflush(stdout);
 rb_set(tree, 0x140000, 0x141000, 135);
     print_rbtree(tree); fflush(stdout);
-    uint8_t val = rb_get(tree, 0x141994); printf("0x141994 has attribute %hhu\n", val); fflush(stdout);
+    uint32_t val = rb_get(tree, 0x141994); printf("0x141994 has attribute %hhu\n", val); fflush(stdout);
     delete_rbtree(tree);
 }
 #endif

--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -2648,9 +2648,9 @@ EXPORT void* my_mmap64(x64emu_t* emu, void *addr, unsigned long length, int prot
     #endif
     if(ret!=MAP_FAILED) {
         if(emu)
-            setProtection_mmap((uintptr_t)ret, length, (uint8_t)prot);
+            setProtection_mmap((uintptr_t)ret, length, prot);
         else
-            setProtection((uintptr_t)ret, length, (uint8_t)prot);
+            setProtection((uintptr_t)ret, length, prot);
     }
     return ret;
 }
@@ -2663,7 +2663,7 @@ EXPORT void* my_mremap(x64emu_t* emu, void* old_addr, size_t old_size, size_t ne
     void* ret = mremap(old_addr, old_size, new_size, flags, new_addr);
     if(emu && (box64_log>=LOG_DEBUG || box64_dynarec_log>=LOG_DEBUG)) {printf_log(LOG_NONE, "%p\n", ret);}
     if(ret!=(void*)-1) {
-        uint8_t prot = getProtection((uintptr_t)old_addr)&~PROT_CUSTOM;
+        uint32_t prot = getProtection((uintptr_t)old_addr)&~PROT_CUSTOM;
         if(ret==old_addr) {
             if(old_size && old_size<new_size) {
                 setProtection_mmap((uintptr_t)ret+old_size, new_size-old_size, prot);
@@ -2739,11 +2739,11 @@ EXPORT int my_mprotect(x64emu_t* emu, void *addr, unsigned long len, int prot)
     #endif
     if(!ret && len) {
         if(prot)
-            updateProtection((uintptr_t)addr, len, (uint8_t)prot);
+            updateProtection((uintptr_t)addr, len, prot);
         else {
             // avoid allocating detailled protection for a no prot 0
             freeProtection((uintptr_t)addr, len);
-            setProtection_mmap((uintptr_t)addr, len, (uint8_t)prot);
+            setProtection_mmap((uintptr_t)addr, len, prot);
         }
     }
     return ret;


### PR DESCRIPTION
Some protections are in fact 32 bits wide (`PROT_GROWSDOWN`, `PROT_GROWSUP`). This PR reverts the narrowing to an 8-bit integer for the memory tracking (fixes *maybe* #1200 and similar issues).