### PR TITLE
When BOX64_VERSION is set, just print the version and exit

### DIFF
--- a/docs/box64.pod
+++ b/docs/box64.pod
@@ -467,4 +467,17 @@ script. yyyy needs to be a full path to a valid x86_64 version of bash
     * 1 : Launch `gdb` when a segfault, bus error or illegal instruction signal is trapped, attached to the offending process and go in an endless loop, waiting. When in gdb, you need to find the correct thread yourself (the one with `my_box64signalhandler` in is stack) then probably need to `finish` 1 or 2 functions (inside `usleep(..)`) and then you'll be in `my_box64signalhandler`, just before the printf of the Segfault message. Then simply  `set waiting=0` to exit the infinite loop.
     * 2 : Launch `gdbserver` when a segfault, bus error or illegal instruction signal is trapped, attached to the offending process, and go in an endless loop, waiting. Use `gdb /PATH/TO/box64` and then `target remote 127.0.0.1:1234` to connect to the gdbserver (or use actual IP if not on the machine). After that, the procedure is the same as with ` BOX64_JITGDB=1`. This mode can be usefullwhen programs redirect all console output to a file (like Unity3D Games)
 
+=head1 VARIABLES FOR ENVIRONMENT ONLY
+
+=over 8
+
+=item B<BOX64_VERSION>
+
+When set, B<box64> will only print its version and then exit. This option is
+analogous to B<QEMU_VERSION> used by C<binfmt_misc> emulation of qemu-user. Its
+purpose is the same: provide a way to soft-disable C<binfmt_misc> emulation as
+well as for identifying B<box64> as the registered C<binfmt_misc> emulator.
+
+=back
+
 =cut

--- a/src/main.c
+++ b/src/main.c
@@ -1468,6 +1468,11 @@ extern char** environ;
 int main(int argc, const char **argv, char **env) {
     init_malloc_hook();
     init_auxval(argc, argv, environ?environ:env);
+    // analogue to QEMU_VERSION in qemu-user-mode emulation
+    if(getenv("BOX64_VERSION")) {
+        PrintBox64Version();
+        exit(0);
+    }
     // trying to open and load 1st arg
     if(argc==1) {
         /*PrintBox64Version();


### PR DESCRIPTION
When set, box64 will only print its version and then exit. This option is analogous to QEMU_VERSION used by binfmt_misc emulation of qemu-user. Its purpose is the same: provide a way to soft-disable binfmt_misc emulation as well as for identifying box64 as the registered binfmt_misc emulator.

This commit enables adding support for box64 to the arch-test utility. With this change, arch-test is able to soft-disable box64 as the x86_64 emulator in the same way as it does this for qemu and wine already. Without this change, arch-test will report an architecture as natively executable by the processor, disregarding that it actually gets emulated by box64.

Furthermore, this commit enables identifying box64 as the currently registered emulator for x86_64. This way, applications that know that their emulation requirements cannot work with box64 can add a check to find out that it is box64 doing the emulation and are able to print a helpful error message.

Closes: #1237