### PR TITLE
more wrapped functions in libxcb-randr and libcap

### DIFF
--- a/src/wrapped/wrappedcap_private.h
+++ b/src/wrapped/wrappedcap_private.h
@@ -9,7 +9,7 @@
 //GO(cap_copy_int, 
 //GO(cap_drop_bound, 
 //GO(cap_dup, 
-//GO(cap_free, 
+GO(cap_free, iFp)
 //GO(cap_from_name, 
 //GO(cap_from_text, 
 //GO(cap_get_ambient, 
@@ -21,7 +21,7 @@
 //GO(cap_get_nsowner, 
 //GO(capgetp, 
 //GO(cap_get_pid, 
-//GO(cap_get_proc, 
+GO(cap_get_proc, pFi)
 //GO(cap_get_secbits, 
 //GO(cap_iab_fill, 
 //GO(cap_iab_from_text, 
@@ -46,12 +46,12 @@
 //GO(cap_set_ambient, 
 //GO(cap_set_fd, 
 //GO(cap_set_file, 
-//GO(cap_set_flag, 
+GO(cap_set_flag, iFpiipi)
 //GO(cap_setgroups, 
 //GO(cap_set_mode, 
 //GO(cap_set_nsowner, 
 //GO(capsetp, 
-//GO(cap_set_proc, 
+GO(cap_set_proc, iFp)
 //GO(cap_set_secbits, 
 //GO(cap_set_syscall, 
 //GO(cap_setuid, 

--- a/src/wrapped/wrappedlibxcbrandr_private.h
+++ b/src/wrapped/wrappedlibxcbrandr_private.h
@@ -101,9 +101,9 @@ GO(xcb_randr_get_output_info, pFbppu)
 //GO(xcb_randr_get_output_info_crtcs, 
 //GO(xcb_randr_get_output_info_crtcs_end, 
 //GO(xcb_randr_get_output_info_crtcs_length, 
-//GO(xcb_randr_get_output_info_modes, 
+GO(xcb_randr_get_output_info_modes, pFp)
 //GO(xcb_randr_get_output_info_modes_end, 
-//GO(xcb_randr_get_output_info_modes_length, 
+GO(xcb_randr_get_output_info_modes_length, iFp)
 GO(xcb_randr_get_output_info_name, pFp)
 GO(xcb_randr_get_output_info_name_end, pFp)
 GO(xcb_randr_get_output_info_name_length, iFp)
@@ -185,9 +185,9 @@ GO(xcb_randr_get_screen_resources_current_outputs_length, iFp)
 GO(xcb_randr_get_screen_resources_current_reply, pFbup)
 //GO(xcb_randr_get_screen_resources_current_sizeof, 
 GO(xcb_randr_get_screen_resources_current_unchecked, pFbpu)
-//GO(xcb_randr_get_screen_resources_modes, 
+GO(xcb_randr_get_screen_resources_modes, pFp)
 //GO(xcb_randr_get_screen_resources_modes_iterator, 
-//GO(xcb_randr_get_screen_resources_modes_length, 
+GO(xcb_randr_get_screen_resources_modes_length, iFp)
 //GO(xcb_randr_get_screen_resources_names, 
 //GO(xcb_randr_get_screen_resources_names_end, 
 //GO(xcb_randr_get_screen_resources_names_length, 


### PR DESCRIPTION
These functions are needed for SteamVR's vrcompositor and vrcompositor-launcher to run.