### PR TITLE
[LA64_DYNAREC] Removed F_OF2 trick as it's unnecessary

### DIFF
--- a/src/dynarec/la64/dynarec_la64_emit_math.c
+++ b/src/dynarec/la64/dynarec_la64_emit_math.c
@@ -97,7 +97,7 @@ void emit_add32(dynarec_la64_t* dyn, int ninst, rex_t rex, int s1, int s2, int s
             XOR(s3, s3, s4);
             ANDI(s3, s3, 1); // OF: xor of two MSB's of cc
             BEQZ(s3, 8);
-            ORI(xFlags, xFlags, 1 << F_OF2);
+            ORI(xFlags, xFlags, 1 << F_OF);
         }
     }
     IFX(X_SF)
@@ -207,7 +207,7 @@ void emit_add32c(dynarec_la64_t* dyn, int ninst, rex_t rex, int s1, int64_t c, i
             XOR(s3, s3, s4);
             ANDI(s3, s3, 1); // OF: xor of two MSB's of cc
             BEQZ(s3, 8);
-            ORI(xFlags, xFlags, 1 << F_OF2);
+            ORI(xFlags, xFlags, 1 << F_OF);
         }
     }
     IFX(X_SF)
@@ -267,7 +267,7 @@ void emit_add8(dynarec_la64_t* dyn, int ninst, int s1, int s2, int s3, int s4)
             XOR(s3, s3, s4);
             ANDI(s3, s3, 1); // OF: xor of two MSB's of cc
             BEQZ(s3, 8);
-            ORI(xFlags, xFlags, 1 << F_OF2);
+            ORI(xFlags, xFlags, 1 << F_OF);
         }
     }
     IFX(X_CF)
@@ -342,7 +342,7 @@ void emit_add8c(dynarec_la64_t* dyn, int ninst, int s1, int c, int s2, int s3, i
             XOR(s3, s3, s4);
             ANDI(s3, s3, 1); // OF: xor of two MSB's of cc
             BEQZ(s3, 8);
-            ORI(xFlags, xFlags, 1 << F_OF2);
+            ORI(xFlags, xFlags, 1 << F_OF);
         }
     }
     IFX(X_CF)

--- a/src/dynarec/la64/dynarec_la64_helper.c
+++ b/src/dynarec/la64/dynarec_la64_helper.c
@@ -405,7 +405,6 @@ void call_c(dynarec_la64_t* dyn, int ninst, void* fnc, int reg, int ret, int sav
     if (savereg == 0)
         savereg = x6;
     if (saveflags) {
-        FLAGS_ADJUST_TO11(xFlags, xFlags, reg);
         ST_D(xFlags, xEmu, offsetof(x64emu_t, eflags));
     }
     fpu_pushcache(dyn, ninst, reg, 0);
@@ -449,7 +448,6 @@ void call_c(dynarec_la64_t* dyn, int ninst, void* fnc, int reg, int ret, int sav
     fpu_popcache(dyn, ninst, reg, 0);
     if (saveflags) {
         LD_D(xFlags, xEmu, offsetof(x64emu_t, eflags));
-        FLAGS_ADJUST_FROM11(xFlags, xFlags, reg);
     }
     SET_NODF();
     dyn->last_ip = 0;

--- a/src/dynarec/la64/dynarec_la64_helper.h
+++ b/src/dynarec/la64/dynarec_la64_helper.h
@@ -235,7 +235,7 @@
 #define SET_DFOK() dyn->f.dfnone = 1
 
 #define CLEAR_FLAGS() \
-    IFX(X_ALL) { ANDI(xFlags, xFlags, ~((1UL << F_AF) | (1UL << F_CF) | (1UL << F_OF2) | (1UL << F_ZF) | (1UL << F_SF) | (1UL << F_PF))); }
+    IFX(X_ALL) { ANDI(xFlags, xFlags, ~((1UL << F_AF) | (1UL << F_CF) | (1UL << F_OF) | (1UL << F_ZF) | (1UL << F_SF) | (1UL << F_PF))); }
 
 #define CALC_SUB_FLAGS(op1_, op2, res, scratch1, scratch2, width)     \
     IFX(X_AF | X_CF | X_OF)                                           \
@@ -273,25 +273,9 @@
             XOR(scratch1, scratch1, scratch2);                        \
             ANDI(scratch1, scratch1, 1);                              \
             BEQZ(scratch1, 8);                                        \
-            ORI(xFlags, xFlags, 1 << F_OF2);                          \
+            ORI(xFlags, xFlags, 1 << F_OF);                          \
         }                                                             \
     }
-
-// Adjust the flags bit 11 -> bit 5, result in reg (can be same as flags, but not s1)
-#define FLAGS_ADJUST_FROM11(reg, flags, s1) \
-    ANDI(reg, flags, ~(1 << 5));            \
-    SRLI_D(s1, reg, 11 - 5);                \
-    ANDI(s1, s1, 1 << 5);                   \
-    OR(reg, reg, s1)
-
-// Adjust the xFlags bit 5 -> bit 11, src and dst can be the same (and can be xFlags, but not s1)
-#define FLAGS_ADJUST_TO11(dst, src, s1) \
-    LU12I_W(s1, 0xFFFFF);               \
-    ADDI_W(s1, s1, 0x7DF);              \
-    AND(s1, src, s1);                   \
-    ANDI(dst, src, 1 << 5);             \
-    SLLI_D(dst, dst, 11 - 5);           \
-    OR(dst, dst, s1)
 
 #ifndef READFLAGS
 #define READFLAGS(A)                                \
@@ -303,7 +287,6 @@
             BEQ(x3, xZR, j64);                      \
         }                                           \
         CALL_(UpdateFlags, -1, 0);                  \
-        FLAGS_ADJUST_FROM11(xFlags, xFlags, x3);    \
         MARKF;                                      \
         dyn->f.pending = SF_SET;                    \
         SET_DFOK();                                 \

--- a/src/dynarec/la64/la64_emitter.h
+++ b/src/dynarec/la64/la64_emitter.h
@@ -99,9 +99,6 @@ f24-f31  fs0-fs7   Static registers                Callee
 #define wZR     xZR
 #define r0      xZR
 
-// replacement for F_OF internaly, using a reserved bit. Need to use F_OF2 internaly, never F_OF directly!
-#define F_OF2 F_res3
-
 // split a 32bits value in 20bits + 12bits, adjust the upper part is 12bits is negative
 #define SPLIT20(A) (((A) + 0x800) >> 12)
 #define SPLIT12(A) ((A) & 0xfff)


### PR DESCRIPTION
Unlike RISC-V, the imm part in `ANDI`/`ORI`/`XORI` on LoongArch is zero-extended instead of sign-extended, thus the F_OF2 trick is unnecessary.

cc @factfinding 