### PR TITLE
[WRAPPER] Fixed a typo in the signature of my___libc_start_main

### DIFF
--- a/src/emu/x64run_private.c
+++ b/src/emu/x64run_private.c
@@ -48,7 +48,7 @@ void EXPORT my___libc_init(x64emu_t* emu, void* raw_args , void (*onexit)(void) 
     emu->quit = 1; // finished!
 }
 #else
-int32_t EXPORT my___libc_start_main(x64emu_t* emu, int *(main) (int, char * *, char * *), int argc, char * * ubp_av, void (*init) (void), void (*fini) (void), void (*rtld_fini) (void), void (* stack_end))
+int32_t EXPORT my___libc_start_main(x64emu_t* emu, int (*main) (int, char * *, char * *), int argc, char * * ubp_av, void (*init) (void), void (*fini) (void), void (*rtld_fini) (void), void (* stack_end))
 {
     (void)argc; (void)ubp_av; (void)fini; (void)rtld_fini; (void)stack_end;
 

--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -454,7 +454,7 @@ static void* findprintf_typeFct(void* fct)
 #undef SUPER
 
 // some my_XXX declare and defines
-int32_t my___libc_start_main(x64emu_t* emu, int *(main) (int, char * *, char * *),
+int32_t my___libc_start_main(x64emu_t* emu, int (*main) (int, char * *, char * *),
     int argc, char * * ubp_av, void (*init) (void), void (*fini) (void),
     void (*rtld_fini) (void), void (* stack_end)); // implemented in x64run_private.c
 EXPORT void my___libc_init_first(x64emu_t* emu, int argc, char* arg0, char** b)


### PR DESCRIPTION
The asterisk is placed outside the neighbor parentheses.

References:
1. https://elixir.bootlin.com/glibc/glibc-2.39/source/csu/libc-start.c#L209
2. https://cdecl.org/?q=int+*%28main%29+%28int%2C+char+**%2C+char+**%29
3. https://cdecl.org/?q=int+%28*main%29+%28int%2C+char+**%2C+char+**%29