### PR TITLE
[ARM64_DYNAREC] Fixed a falsy optimization on PSHUFHW

### DIFF
--- a/src/dynarec/arm64/dynarec_arm64_f30f.c
+++ b/src/dynarec/arm64/dynarec_arm64_f30f.c
@@ -334,19 +334,15 @@ uintptr_t dynarec64_F30F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
             GETGX(v0, 1);
             u8 = F8;
             d0 = fpu_get_scratch(dyn);
-            if(u8==0b00000000 || u8==0b01010101 || u8==0b10101010 || u8==0b11111111) {
-                VDUP_16(d0, v1, u8&3);
-            } else {
-                // only high part need to be suffled. VTBL only handle 8bits value, so the 16bits suffles need to be changed in 8bits
-                u64 = 0;
-                for (int i=0; i<4; ++i) {
-                    u64 |= ((uint64_t)((u8>>(i*2))&3)*2+8)<<(i*16+0);
-                    u64 |= ((uint64_t)((u8>>(i*2))&3)*2+9)<<(i*16+8);
-                }
-                MOV64x(x2, u64);
-                VMOVQDfrom(d0, 0, x2);
-                VTBL1_8(d0, v1, d0);
+            // only high part need to be suffled. VTBL only handle 8bits value, so the 16bits suffles need to be changed in 8bits
+            u64 = 0;
+            for (int i=0; i<4; ++i) {
+                u64 |= ((uint64_t)((u8>>(i*2))&3)*2+8)<<(i*16+0);
+                u64 |= ((uint64_t)((u8>>(i*2))&3)*2+9)<<(i*16+8);
             }
+            MOV64x(x2, u64);
+            VMOVQDfrom(d0, 0, x2);
+            VTBL1_8(d0, v1, d0);
             VMOVeD(v0, 1, d0, 0);
             if(v0!=v1) {
                 VMOVeD(v0, 0, v1, 0);

--- a/src/dynarec/arm64/dynarec_arm64_f30f.c
+++ b/src/dynarec/arm64/dynarec_arm64_f30f.c
@@ -312,7 +312,7 @@ uintptr_t dynarec64_F30F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
             VMOVeS(v0, 0, v1, 0);   // to not erase uper part
             #endif
             break;
-            
+
         case 0x6F:
             INST_NAME("MOVDQU Gx,Ex");// no alignment constraint on NEON here, so same as MOVDQA
             nextop = F8;
@@ -334,15 +334,19 @@ uintptr_t dynarec64_F30F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
             GETGX(v0, 1);
             u8 = F8;
             d0 = fpu_get_scratch(dyn);
-            // only high part need to be suffled. VTBL only handle 8bits value, so the 16bits suffles need to be changed in 8bits
-            u64 = 0;
-            for (int i=0; i<4; ++i) {
-                u64 |= ((uint64_t)((u8>>(i*2))&3)*2+8)<<(i*16+0);
-                u64 |= ((uint64_t)((u8>>(i*2))&3)*2+9)<<(i*16+8);
+            if (u8 == 0b00000000 || u8 == 0b01010101 || u8 == 0b10101010 || u8 == 0b11111111) {
+                VDUPQ_16(d0, v1, (u8 & 3) + 4);
+            } else {
+                // only high part need to be suffled. VTBL only handle 8bits value, so the 16bits suffles need to be changed in 8bits
+                u64 = 0;
+                for (int i = 0; i < 4; ++i) {
+                    u64 |= ((uint64_t)((u8 >> (i * 2)) & 3) * 2 + 8) << (i * 16 + 0);
+                    u64 |= ((uint64_t)((u8 >> (i * 2)) & 3) * 2 + 9) << (i * 16 + 8);
+                }
+                MOV64x(x2, u64);
+                VMOVQDfrom(d0, 0, x2);
+                VTBL1_8(d0, v1, d0);
             }
-            MOV64x(x2, u64);
-            VMOVQDfrom(d0, 0, x2);
-            VTBL1_8(d0, v1, d0);
             VMOVeD(v0, 1, d0, 0);
             if(v0!=v1) {
                 VMOVeD(v0, 0, v1, 0);


### PR DESCRIPTION
`VDUP_16` duplicates 16-bit element from the low qword of v1, which is not what we want.

Fixes #1342