### PR TITLE
Update GH-Actions workflows to remove Node.js deprecation warning.

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Box64 Repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: "Environment preparation"
         run: |
@@ -90,7 +90,7 @@ jobs:
           make -j$(nproc) VERBOSE=1
 
       - name: "Upload Artifact"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: box64-${{ github.event.inputs.platform }}-${{ github.event.inputs.build_type }}
           path: build/box64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout Box64 Repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Environment preparation"
         run: |
@@ -166,7 +166,7 @@ jobs:
           fi
 
       - name: "Upload Artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: box64-${{ matrix.platform }}-${{ matrix.type }}
           path: build/box64


### PR DESCRIPTION
The older version of these workflows use an old version of Node.js, this brings in the current versions.