### PR TITLE
[RV64_DYNAREC] Fixed 66 C7 MOV opcode

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_66.c
+++ b/src/dynarec/rv64/dynarec_rv64_66.c
@@ -1029,9 +1029,8 @@ uintptr_t dynarec64_66(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
             INST_NAME("MOV Ew, Iw");
             nextop = F8;
             if(MODREG) {
-                ed = xRAX+(nextop&7)+(rex.b<<3);
-                ADDI(x1, xZR, -1);
-                SRLI(x1, x1, 48);
+                ed = xRAX + (nextop & 7) + (rex.b << 3);
+                LUI(x1, 0xffff0);
                 AND(ed, ed, x1);
                 u16 = F16;
                 MOV32w(x1, u16);


### PR DESCRIPTION
Copy-paste is the new way of code review. This issue can be traced back to the very beginning, but we discovered it only now, and not through debugging.