### PR TITLE
Try to fix mmap64 already defined error in custommem.c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,7 @@ set(ELFLOADER_SRC
     "${BOX64_ROOT}/src/box64context.c"
     "${BOX64_ROOT}/src/build_info.c"
     "${BOX64_ROOT}/src/custommem.c"
+    "${BOX64_ROOT}/src/custommmap.c"
     "${BOX64_ROOT}/src/dynarec/dynarec.c"
     "${BOX64_ROOT}/src/elfs/elfloader.c"
     "${BOX64_ROOT}/src/elfs/elfparser.c"

--- a/src/custommem.c
+++ b/src/custommem.c
@@ -66,7 +66,7 @@ rbtree* memprot = NULL;
 int have48bits = 0;
 static int inited = 0;
 
-static rbtree*  mapallmem = NULL;
+rbtree*  mapallmem = NULL;
 static rbtree*  mmapmem = NULL;
 
 typedef struct blocklist_s {
@@ -1711,30 +1711,5 @@ int internal_munmap(void* addr, unsigned long length)
     }
     int ret = libc_munmap(addr, length);
     #endif
-    return ret;
-}
-
-void* my_mmap64(x64emu_t* emu, void *addr, unsigned long length, int prot, int flags, int fd, ssize_t offset);
-
-extern int running32bits;
-EXPORT void* mmap64(void *addr, unsigned long length, int prot, int flags, int fd, ssize_t offset)
-{
-    void* ret;
-    if(!addr && ((running32bits && box64_mmap32) || (flags&0x40)))
-        ret = my_mmap64(NULL, addr, length, prot, flags | 0x40, fd, offset);
-    else
-        ret = internal_mmap(addr, length, prot, flags, fd, offset);
-    if(ret!=MAP_FAILED && mapallmem)
-        setProtection((uintptr_t)ret, length, prot);
-    return ret;
-}
-EXPORT void* mmap(void *addr, unsigned long length, int prot, int flags, int fd, ssize_t offset) __attribute__((alias("mmap64")));
-
-EXPORT int munmap(void* addr, unsigned long length)
-{
-    int ret = internal_munmap(addr, length);
-    if(!ret && mapallmem) {
-        freeProtection((uintptr_t)addr, length);
-    }
     return ret;
 }

--- a/src/custommmap.c
+++ b/src/custommmap.c
@@ -1,0 +1,48 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
+#include <unistd.h>
+#include <stdint.h>
+
+#ifndef MAP_FAILED
+#define MAP_FAILED ((void *) -1)
+#endif
+
+#define EXPORT __attribute__((visibility("default")))
+#ifdef BUILD_DYNAMIC
+#define EXPORTDYN __attribute__((visibility("default")))
+#else
+#define EXPORTDYN
+#endif
+
+typedef void x64emu_t;
+extern void* mapallmem;
+void setProtection(uintptr_t addr, size_t size, uint32_t prot);
+void freeProtection(uintptr_t addr, size_t size);
+void* internal_mmap(void *addr, unsigned long length, int prot, int flags, int fd, ssize_t offset);
+int internal_munmap(void* addr, unsigned long length);
+
+void* my_mmap64(x64emu_t* emu, void *addr, unsigned long length, int prot, int flags, int fd, ssize_t offset);
+
+extern int running32bits;
+extern int box64_mmap32;
+
+EXPORT void* mmap64(void *addr, unsigned long length, int prot, int flags, int fd, ssize_t offset)
+{
+    void* ret;
+    if(!addr && ((running32bits && box64_mmap32) || (flags&0x40)))
+        ret = my_mmap64(NULL, addr, length, prot, flags | 0x40, fd, offset);
+    else
+        ret = internal_mmap(addr, length, prot, flags, fd, offset);
+    if(ret!=MAP_FAILED && mapallmem)
+        setProtection((uintptr_t)ret, length, prot);
+    return ret;
+}
+EXPORT void* mmap(void *addr, unsigned long length, int prot, int flags, int fd, ssize_t offset) __attribute__((alias("mmap64")));
+
+EXPORT int munmap(void* addr, unsigned long length)
+{
+    int ret = internal_munmap(addr, length);
+    if(!ret && mapallmem) {
+        freeProtection((uintptr_t)addr, length);
+    }
+    return ret;
+}


### PR DESCRIPTION
As you suggested, I added a barebones custommap.c file and it passes compilation and linking in my buildroot GCC 13.3 cross-compilation toolchain to arm64 / rv64.

It can probably be tidied up.