### PR TITLE
Add missing wrappings for winewayland.so

### DIFF
--- a/src/wrapped/wrappedwaylandclient.c
+++ b/src/wrapped/wrappedwaylandclient.c
@@ -475,6 +475,57 @@ static void* find_zwp_relative_pointer_v1_listener_Fct(void* fct)
     printf_log(LOG_NONE, "Warning, no more slot for wayland-client zwp_relative_pointer_v1_listener callback\n");
     return NULL;
 }
+// zxdg_output_v1_listener ...
+typedef struct my_zxdg_output_v1_listener_s {
+    uintptr_t   logical_position; //vFppii
+    uintptr_t   logical_size; //vFppii
+    uintptr_t   done; //vFpp
+    uintptr_t   name; //vFppp
+    uintptr_t   description; //vFppp
+} my_zxdg_output_v1_listener_t;
+#define GO(A)   \
+static my_zxdg_output_v1_listener_t* ref_zxdg_output_v1_listener_##A = NULL;                                              \
+static void* my_zxdg_output_v1_listener_logical_position_##A(void* a, void* b, int32_t c, int32_t d)  \
+{                                                                                                                                           \
+    RunFunctionFmt(ref_zxdg_output_v1_listener_##A->logical_position, "ppii", a, b, c, d);                          \
+}                                                                                                                                           \
+static void* my_zxdg_output_v1_listener_logical_size_##A(void* a, void* b, int32_t c, int32_t d)  \
+{                                                                                                                                           \
+    RunFunctionFmt(ref_zxdg_output_v1_listener_##A->logical_size, "ppii", a, b, c, d);                          \
+}                                                                                                                                           \
+static void* my_zxdg_output_v1_listener_done_##A(void* a, void* b)  \
+{                                                                                                                                           \
+    RunFunctionFmt(ref_zxdg_output_v1_listener_##A->done, "pp", a, b);                          \
+}                                                                                                                                           \
+static void* my_zxdg_output_v1_listener_name_##A(void* a, void* b, void* c)  \
+{                                                                                                                                           \
+    RunFunctionFmt(ref_zxdg_output_v1_listener_##A->name, "ppp", a, b, c);                          \
+}                                                                                                                                           \
+static void* my_zxdg_output_v1_listener_description_##A(void* a, void* b, void* c)  \
+{                                                                                                                                           \
+    RunFunctionFmt(ref_zxdg_output_v1_listener_##A->description, "ppp", a, b, c);                          \
+}                                                                                                                                           \
+static my_zxdg_output_v1_listener_t my_zxdg_output_v1_listener_fct_##A = {                                                \
+    (uintptr_t)my_zxdg_output_v1_listener_logical_position_##A,                                                                     \
+    (uintptr_t)my_zxdg_output_v1_listener_logical_size_##A,                                                                     \
+    (uintptr_t)my_zxdg_output_v1_listener_done_##A,                                                                     \
+    (uintptr_t)my_zxdg_output_v1_listener_name_##A,                                                                     \
+    (uintptr_t)my_zxdg_output_v1_listener_description_##A,                                                                     \
+};
+SUPER()
+#undef GO
+static void* find_zxdg_output_v1_listener_Fct(void* fct)
+{
+    if(!fct) return fct;
+    #define GO(A) if(ref_zxdg_output_v1_listener_##A == fct) return &my_zxdg_output_v1_listener_fct_##A;
+    SUPER()
+    #undef GO
+    #define GO(A) if(ref_zxdg_output_v1_listener_##A == 0) {ref_zxdg_output_v1_listener_##A = fct; return &my_zxdg_output_v1_listener_fct_##A; }
+    SUPER()
+    #undef GO
+    printf_log(LOG_NONE, "Warning, no more slot for wayland-client zxdg_output_v1_listener callback\n");
+    return NULL;
+}
 
 #undef SUPER
 
@@ -503,6 +554,8 @@ EXPORT int my_wl_proxy_add_listener(x64emu_t* emu, void* proxy, void** l, void* 
         l = find_wl_buffer_listener_Fct(l);
     } else if(!strcmp(proxy_name, "zwp_relative_pointer_v1")) {
         l = find_zwp_relative_pointer_v1_listener_Fct(l);
+    } else if(!strcmp(proxy_name, "zxdg_output_v1")) {
+        l = find_zxdg_output_v1_listener_Fct(l);
     } else
         printf_log(LOG_INFO, "BOX64: Error, Wayland-client, add_listener to %s unknown, will crash soon!\n", proxy_name);
     return my->wl_proxy_add_listener(proxy, l, data);

--- a/src/wrapped/wrappedwaylandclient_private.h
+++ b/src/wrapped/wrappedwaylandclient_private.h
@@ -2,10 +2,10 @@
 #error meh!
 #endif
 
-//GO(wl_array_add, 
+GO(wl_array_add, pFpL)
 //GO(wl_array_copy, 
-//GO(wl_array_init, 
-//GO(wl_array_release, 
+GO(wl_array_init, vFp)
+GO(wl_array_release, vFp)
 DATA(wl_buffer_interface, 40)
 //DATA(wl_callback_interface, 
 DATA(wl_compositor_interface, 40)
@@ -35,11 +35,11 @@ GO(wl_display_roundtrip_queue, iFpp)
 GO(wl_event_queue_destroy, vFp)
 DATA(wl_keyboard_interface, 40)
 //GO(wl_list_empty, 
-//GO(wl_list_init, 
-//GO(wl_list_insert, 
+GO(wl_list_init, vFp)
+GO(wl_list_insert, vFpp)
 //GO(wl_list_insert_list, 
 //GO(wl_list_length, 
-//GO(wl_list_remove, 
+GO(wl_list_remove, vFp)
 //GO(wl_log_set_handler_client, 
 DATA(wl_output_interface, 40)
 DATA(wl_pointer_interface, 40)

--- a/src/wrapped/wrappedxkbregistry_private.h
+++ b/src/wrapped/wrappedxkbregistry_private.h
@@ -9,7 +9,7 @@
 //GO(rxkb_context_include_path_append_default, 
 GO(rxkb_context_new, pFu)
 //GO(rxkb_context_parse, 
-//GO(rxkb_context_parse_default_ruleset, 
+GO(rxkb_context_parse_default_ruleset, uFp)
 //GO(rxkb_context_ref, 
 //GO(rxkb_context_set_log_fn, 
 //GO(rxkb_context_set_log_level, 
@@ -31,7 +31,7 @@ GO(rxkb_layout_get_description, pFp)
 GO(rxkb_layout_get_name, pFp)
 //GO(rxkb_layout_get_popularity, 
 GO(rxkb_layout_get_variant, pFp)
-//GO(rxkb_layout_next, 
+GO(rxkb_layout_next, pFp)
 //GO(rxkb_layout_ref, 
 //GO(rxkb_layout_unref, 
 //GO(rxkb_model_first, 


### PR DESCRIPTION
This was a late-night attempt to fix issue #1581.

I still don't really know how the wrappings work (I should take time and learn) so I just did what seemed right. For `size_t` and `bool` I guessed how they are specified ('L' and 'c'??).

Unsuprisingly, it does not work at this point! Now there is a SIGILL during/after mapping winewayland.so.