### PR TITLE
switch to maintained Pi-Apps-Coders apt repo

### DIFF
--- a/docs/COMPILE.md
+++ b/docs/COMPILE.md
@@ -2,12 +2,34 @@ Compiling/Installing
 ----
 
 ### Debian-based Linux 
-You can use [@ryanfortner](https://github.com/ryanfortner)'s apt repository to install precompiled box64 debs, updated every 24 hours. 
+You can use the [Pi-Apps-Coders apt repository](https://github.com/Pi-Apps-Coders/box64-debs) to install precompiled box64 debs, updated every 24 hours. 
 
 ```
-sudo wget https://ryanfortner.github.io/box64-debs/box64.list -O /etc/apt/sources.list.d/box64.list
-wget -qO- https://ryanfortner.github.io/box64-debs/KEY.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/box64-debs-archive-keyring.gpg
-sudo apt update && sudo apt install box64-arm64 -y
+# check if .list file already exists
+if [ -f /etc/apt/sources.list.d/box64.list ]; then
+  sudo rm -f /etc/apt/sources.list.d/box64.list || exit 1
+fi
+
+# check if .sources file already exists
+if [ -f /etc/apt/sources.list.d/box64.sources ]; then
+  sudo rm -f /etc/apt/sources.list.d/box64.sources || exit 1
+fi
+
+# download gpg key from specified url
+if [ -f /usr/share/keyrings/box64-archive-keyring.gpg ]; then
+  sudo rm -f /usr/share/keyrings/box64-archive-keyring.gpg
+fi
+sudo mkdir -p /usr/share/keyrings
+wget -qO- "https://pi-apps-coders.github.io/box64-debs/KEY.gpg" | sudo gpg --dearmor -o /usr/share/keyrings/box64-archive-keyring.gpg
+
+# create .sources file
+echo "Types: deb
+URIs: https://Pi-Apps-Coders.github.io/box64-debs/debian
+Suites: ./
+Signed-By: /usr/share/keyrings/box64-archive-keyring.gpg" | sudo tee /etc/apt/sources.list.d/box64.sources >/dev/null
+
+sudo apt update
+sudo apt install box64-generic-arm -y
 ```
 
 Alternatively, you can generate your own package using the [instructions below](https://github.com/ptitSeb/box64/blob/main/docs/COMPILE.md#debian-packaging). 


### PR DESCRIPTION
closes https://github.com/ptitSeb/box64/issues/1576

at pi-apps we have been using our own apt repo which is better maintained and we keep strict rules of not breaking old installs (eg: through package renaming or otherwise). this has been the case for a year now. Our efforts (including both Ryan and Itai) are consolidated in these repos that we all have access to.