### PR TITLE
[RV64_DYNAREC] Detect vector extension

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -108,6 +108,7 @@ int rv64_zba = 0;
 int rv64_zbb = 0;
 int rv64_zbc = 0;
 int rv64_zbs = 0;
+int rv64_vector = 0;
 int rv64_xtheadba = 0;
 int rv64_xtheadbb = 0;
 int rv64_xtheadbs = 0;
@@ -501,6 +502,7 @@ HWCAP2_AFP
     if(rv64_zbb) printf_log(LOG_INFO, " Zbb");
     if(rv64_zbc) printf_log(LOG_INFO, " Zbc");
     if(rv64_zbs) printf_log(LOG_INFO, " Zbs");
+    if(rv64_vector) printf_log(LOG_INFO, " Vector");
     if(rv64_xtheadba) printf_log(LOG_INFO, " XTheadBa");
     if(rv64_xtheadbb) printf_log(LOG_INFO, " XTheadBb");
     if(rv64_xtheadbs) printf_log(LOG_INFO, " XTheadBs");

--- a/src/include/debug.h
+++ b/src/include/debug.h
@@ -54,6 +54,7 @@ extern int rv64_zba;
 extern int rv64_zbb;
 extern int rv64_zbc;
 extern int rv64_zbs;
+extern int rv64_vector;
 extern int rv64_xtheadba;
 extern int rv64_xtheadbb;
 extern int rv64_xtheadbs;

--- a/src/rv64detect.c
+++ b/src/rv64detect.c
@@ -68,6 +68,11 @@ void RV64_Detect_Function()
     BR(xRA);
     rv64_zbs = Check(my_block);
 
+    // Test Vector v1.0 with CSRR zero, vcsr
+    CSRRS(xZR, xZR, 0x00f);
+    BR(xRA);
+    rv64_vector = Check(my_block);
+
     // THead vendor extensions
     if (!rv64_zba) {
         // Test XTheadBa with TH_ADDSL


### PR DESCRIPTION
Dynarec for RISC-V With extension: I M A F D C Zba Zbb Zbc Zbs Vector PageSize:4096 Running on Spacemit(R) X60 with 8 Cores