### PR TITLE
Add missing func declaration: `get_first_jump_addr`

### DIFF
--- a/src/dynarec/la64/dynarec_la64_private.h
+++ b/src/dynarec/la64/dynarec_la64_private.h
@@ -137,6 +137,7 @@ void add_next(dynarec_la64_t *dyn, uintptr_t addr);
 uintptr_t get_closest_next(dynarec_la64_t *dyn, uintptr_t addr);
 void add_jump(dynarec_la64_t *dyn, int ninst);
 int get_first_jump(dynarec_la64_t *dyn, int next);
+int get_first_jump_addr(dynarec_la64_t *dyn, uintptr_t next);
 int is_nops(dynarec_la64_t *dyn, uintptr_t addr, int n);
 int is_instructions(dynarec_la64_t *dyn, uintptr_t addr, int n);
 

--- a/src/dynarec/rv64/dynarec_rv64_private.h
+++ b/src/dynarec/rv64/dynarec_rv64_private.h
@@ -150,6 +150,7 @@ void add_next(dynarec_rv64_t *dyn, uintptr_t addr);
 uintptr_t get_closest_next(dynarec_rv64_t *dyn, uintptr_t addr);
 void add_jump(dynarec_rv64_t *dyn, int ninst);
 int get_first_jump(dynarec_rv64_t *dyn, int next);
+int get_first_jump_addr(dynarec_rv64_t *dyn, uintptr_t next);
 int is_nops(dynarec_rv64_t *dyn, uintptr_t addr, int n);
 int is_instructions(dynarec_rv64_t *dyn, uintptr_t addr, int n);
 


### PR DESCRIPTION
4b0b3fc98ae4a1e848765e0cd48f958a13fc683d introduced a new function called `get_first_jump_addr`. And I found my machine (cross-compile for riscv64) failed to compile it, because the function declaration was missing for rv64 and la64.

I have no ideas why the CI passed at that time, but I believe we had better add these function declaration.