### PR TITLE
Fix X64 FS_BASE

### DIFF
--- a/src/emu/x64tls.c
+++ b/src/emu/x64tls.c
@@ -197,7 +197,7 @@ int my_arch_prctl(x64emu_t *emu, int code, void* addr)
             my_context->segtls[idx].base = (uintptr_t)addr;
             my_context->segtls[idx].limit = 0;
             my_context->segtls[idx].present = 1;
-            if(idx>8 && !my_context->segtls[idx].key_init) {
+            if(idx>=8 && !my_context->segtls[idx].key_init) {
                 pthread_key_create(&my_context->segtls[idx].key, NULL);
                 my_context->segtls[idx].key_init = 1;
             }


### PR DESCRIPTION
I found that `mov %fs:0x0, %rax` in my application got wrong FS BASE. After investigation, I found that `my_context->segtls[idx].key` (where `idx = 8` in my case corresponding to FS BASE) is not correctly initialized. I modified the if-statement condition and my app is working well now.

I am not very sure if my patch is correct. If I am wrong, please correct me.