### PR TITLE
Should not follow symlinks on `argv[0]` path resolution

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1930,7 +1930,7 @@ int initialize(int argc, const char **argv, char** env, x64emu_t** emulator, elf
     PrintCollection(&my_context->box64_path, "BOX64 BIN PATH");
     // lets build argc/argv stuff
     printf_log(LOG_INFO, "Looking for %s\n", prog);
-    my_context->argv[0] = ResolveFile(prog, &my_context->box64_path);
+    my_context->argv[0] = ResolveFileSoft(prog, &my_context->box64_path);
     // check if box86 is present
     {
         my_context->box86path = box_strdup(my_context->box64path);

--- a/src/include/fileutils.h
+++ b/src/include/fileutils.h
@@ -10,8 +10,10 @@
 // 0 : doesn't exist, 1: Does exist
 int FileExist(const char* filename, int flags);
 
-// find a file, using Path if needed
+// find a file, using Path if needed, resolving symlinks
 char* ResolveFile(const char* filename, path_collection_t* paths);
+// find a file, using Path if needed, NOT resolving symlinks
+char* ResolveFileSoft(const char* filename, path_collection_t* paths);
 
 // 1: if file is an x86 elf, 0: if not (or not found)
 int FileIsX86ELF(const char* filename);

--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -2270,7 +2270,7 @@ EXPORT int32_t my_execve(x64emu_t* emu, const char* path, char* const argv[], ch
 EXPORT int32_t my_execvp(x64emu_t* emu, const char* path, char* const argv[])
 {
     // need to use BOX64_PATH / PATH here...
-    char* fullpath = ResolveFile(path, &my_context->box64_path);
+    char* fullpath = ResolveFileSoft(path, &my_context->box64_path);
     // use fullpath...
     int self = isProcSelf(fullpath, "exe");
     int x64 = FileIsX64ELF(fullpath);
@@ -2387,7 +2387,7 @@ EXPORT int32_t my_execle(x64emu_t* emu, const char* path)
 EXPORT int32_t my_execlp(x64emu_t* emu, const char* path)
 {
     // need to use BOX64_PATH / PATH here...
-    char* fullpath = ResolveFile(path, &my_context->box64_path);
+    char* fullpath = ResolveFileSoft(path, &my_context->box64_path);
     // use fullpath...
     int self = isProcSelf(fullpath, "exe");
     int x64 = FileIsX64ELF(fullpath);
@@ -2465,7 +2465,7 @@ EXPORT int32_t my_posix_spawnp(x64emu_t* emu, pid_t* pid, const char* path,
     const posix_spawn_file_actions_t *actions, const posix_spawnattr_t* attrp,  char* const argv[], char* const envp[])
 {
     // need to use BOX64_PATH / PATH here...
-    char* fullpath = ResolveFile(path, &my_context->box64_path);
+    char* fullpath = ResolveFileSoft(path, &my_context->box64_path);
     // use fullpath...
     int self = isProcSelf(fullpath, "exe");
     int x64 = FileIsX64ELF(fullpath);


### PR DESCRIPTION
Many programs (e.g. busybox, ex, bash) can have different behaviors on different `argv[0]`. We should only resolve the `argv[0]` (program name)  to its absolute path but not realpath, i.e. don't resolve the symlinks.