### PR TITLE
Set last_ip to an unclean state at the end of CALL 

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_helper.c
+++ b/src/dynarec/rv64/dynarec_rv64_helper.c
@@ -737,6 +737,7 @@ void call_c(dynarec_rv64_t* dyn, int ninst, void* fnc, int reg, int ret, int sav
         FLAGS_ADJUST_FROM11(xFlags, xFlags, reg);
     }
     //SET_NODF();
+    CLEARIP();
 }
 
 void call_n(dynarec_rv64_t* dyn, int ninst, void* fnc, int w)


### PR DESCRIPTION
Should fix #1649. This was removed in 4f229629c007d65b505a72dbac66eb0e686ee312 (by mistake I believe), this PR adds it back.