### PR TITLE
[DYNAREC] Fixed `ymm0_purge` for some instructions

### DIFF
--- a/src/dynarec/dynarec_native.c
+++ b/src/dynarec/dynarec_native.c
@@ -413,9 +413,11 @@ static void updateYmm0s(dynarec_native_t* dyn, int ninst, int max_ninst_reached)
         uint16_t new_purge_ymm, new_ymm0_in, new_ymm0_out;
 
         if (dyn->insts[ninst].pred_sz && dyn->insts[ninst].x64.alive) {
-            // The union of the empty set is empty, the intersection is the universe
+            // The union of the empty set is empty (0), the intersection is the universe (-1)
             // The first instruction is the entry point, which has a virtual pred with ymm0_out = 0
-            uint16_t ymm0_union = 0, ymm0_inter = ninst ? ((uint16_t)-1) : (uint16_t)0;
+            // Similarly, float barriers reset ymm0s
+            uint16_t ymm0_union = 0;
+            uint16_t ymm0_inter = (ninst && !(dyn->insts[ninst].x64.barrier & BARRIER_FLOAT)) ? ((uint16_t)-1) : (uint16_t)0;
             for (int i = 0; i < dyn->insts[ninst].pred_sz; ++i) {
                 int pred = dyn->insts[ninst].pred[i];
                 //if(box64_dynarec_dump) dynarec_log(LOG_NONE, "\twith pred[%d] = %d", i, pred);

--- a/src/dynarec/dynarec_native.c
+++ b/src/dynarec/dynarec_native.c
@@ -412,8 +412,10 @@ static void updateYmm0s(dynarec_native_t* dyn, int ninst, int max_ninst_reached)
         //if(box64_dynarec_dump) dynarec_log(LOG_NONE, "update ninst=%d (%d): can_incr=%d\n", ninst, max_ninst_reached, can_incr);
         uint16_t new_purge_ymm, new_ymm0_in, new_ymm0_out;
 
-        if (ninst && dyn->insts[ninst].pred_sz && dyn->insts[ninst].x64.alive) {
-            uint16_t ymm0_union = 0, ymm0_inter = (uint16_t)-1; // The union of the empty set is empty, the intersection is the universe
+        if (dyn->insts[ninst].pred_sz && dyn->insts[ninst].x64.alive) {
+            // The union of the empty set is empty, the intersection is the universe
+            // The first instruction is the entry point, which has a virtual pred with ymm0_out = 0
+            uint16_t ymm0_union = 0, ymm0_inter = ninst ? ((uint16_t)-1) : (uint16_t)0;
             for (int i = 0; i < dyn->insts[ninst].pred_sz; ++i) {
                 int pred = dyn->insts[ninst].pred[i];
                 //if(box64_dynarec_dump) dynarec_log(LOG_NONE, "\twith pred[%d] = %d", i, pred);


### PR DESCRIPTION
This PR fixes an issue which may appear if an instruction with non-zero `ymm0_out` jumps to the first instruction of a block.