### PR TITLE
[RV64_DYNAREC] Cleanup for removed rv64_lock_cas_dq

### DIFF
--- a/src/dynarec/rv64/rv64_lock.S
+++ b/src/dynarec/rv64/rv64_lock.S
@@ -20,7 +20,6 @@
 .global rv64_lock_store_dd
 .global rv64_lock_cas_d
 .global rv64_lock_cas_dd
-.global rv64_lock_cas_dq
 .global rv64_lock_get_b
 .global rv64_lock_get_d
 .global rv64_lock_get_dd

--- a/src/dynarec/rv64/rv64_lock.h
+++ b/src/dynarec/rv64/rv64_lock.h
@@ -47,9 +47,6 @@ extern void rv64_lock_store(void*p, uint32_t v);
 // atomic store (with memory barrier)
 extern void rv64_lock_store_dd(void*p, uint64_t v);
 
-// (mostly) Atomically store val1 and val2 at [p] if old [p] is ref. Return 0 if OK, 1 is not. p needs to be aligned
-extern int rv64_lock_cas_dq(void* p, uint64_t ref, uint64_t val1, uint64_t val2);
-
 // atomic get (with memory barrier)
 extern uint32_t rv64_lock_get_b(void* p);
 


### PR DESCRIPTION
Since rv64_lock_cas_dq is removed, we should also remove its global symbol declaration and its prototype. Otherwise, we get and undefined symbol reference, which breaks ELF checks that some distros employ.

Fixes: 9dbd7fc7e0615f48c9287305610bf9aed1cc24f3