### PR TITLE
Wrapped libtiff5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -659,6 +659,7 @@ set(WRAPPEDS
     "${BOX64_ROOT}/src/wrapped/wrappedlibunistring2.c"
     "${BOX64_ROOT}/src/wrapped/wrappedlibhogweed6.c"
     "${BOX64_ROOT}/src/wrapped/wrappedlibsqlite3.c"
+    "${BOX64_ROOT}/src/wrapped/wrappedlibtiff5.c"
 )
 endif()
 if(ANDROID)

--- a/src/library_list.h
+++ b/src/library_list.h
@@ -262,6 +262,7 @@ GO("libnettle.so.8", libnettle8)
 GO("libunistring.so.2", libunistring2)
 GO("libhogweed.so.6", libhogweed6)
 GO("libsqlite3.so.0", libsqlite3)
+GO("libtiff.so.5", libtiff5)
 
 #ifdef ANDROID
 GO("libc.so", libc)

--- a/src/wrapped/wrappedlibtiff5.c
+++ b/src/wrapped/wrappedlibtiff5.c
@@ -1,0 +1,21 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+
+#include "wrappedlibs.h"
+
+#include "wrapper.h"
+#include "bridge.h"
+#include "librarian/library_private.h"
+#include "x64emu.h"
+
+const char* libtiff5Name = "libtiff.so.5";
+#define LIBNAME libtiff5
+
+#include "generated/wrappedlibtiff5types.h"
+
+// Insert code here
+
+#include "wrappedlib_init.h"

--- a/src/wrapped/wrappedlibtiff5_private.h
+++ b/src/wrapped/wrappedlibtiff5_private.h
@@ -1,0 +1,3 @@
+#if !(defined(GO) && defined(GOM) && defined(GO2) && defined(DATA))
+#error Meh....
+#endif


### PR DESCRIPTION
wrapped libtiff5 for wpspdf (WPS PDF). 
no “symbol not found” errors during runtime. interesting.