### PR TITLE
[RV64_DYNAREC] Fixed GETGXSS_empty on upper bits handling

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_helper.c
+++ b/src/dynarec/rv64/dynarec_rv64_helper.c
@@ -1614,8 +1614,7 @@ int sse_get_reg_empty(dynarec_rv64_t* dyn, int ninst, int s1, int a, int single)
             if (single) {
                 // writing back the float
                 FSW(dyn->e.ssecache[a].reg, xEmu, offsetof(x64emu_t, xmm[a]));
-                // clear upper 32 bit
-                SW(xZR, xEmu, offsetof(x64emu_t, xmm[a]) + 4);
+                // there is no need to clear upper bits, it's cleared manually when needed.
             }
             dyn->e.olds[a].changed = 1;
             dyn->e.olds[a].purged = 0;


### PR DESCRIPTION
This may be a bit confusing, but we don't really need to clear the upper bits here, it's already cleared for opcodes like movss, and for others, the upper bits should be retained.