### PR TITLE
[RV64_DYNAREC] Added vlen detection

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -109,6 +109,7 @@ int rv64_zbb = 0;
 int rv64_zbc = 0;
 int rv64_zbs = 0;
 int rv64_vector = 0;
+int rv64_vlen = 0;
 int rv64_xtheadba = 0;
 int rv64_xtheadbb = 0;
 int rv64_xtheadbs = 0;
@@ -509,7 +510,7 @@ HWCAP2_AFP
     if(rv64_zbb) printf_log(LOG_INFO, " Zbb");
     if(rv64_zbc) printf_log(LOG_INFO, " Zbc");
     if(rv64_zbs) printf_log(LOG_INFO, " Zbs");
-    if(rv64_vector) printf_log(LOG_INFO, " Vector");
+    if(rv64_vector) printf_log(LOG_INFO, " Vector (vlen: %d)", rv64_vlen);
     if(rv64_xtheadba) printf_log(LOG_INFO, " XTheadBa");
     if(rv64_xtheadbb) printf_log(LOG_INFO, " XTheadBb");
     if(rv64_xtheadbs) printf_log(LOG_INFO, " XTheadBs");

--- a/src/include/debug.h
+++ b/src/include/debug.h
@@ -55,6 +55,7 @@ extern int rv64_zbb;
 extern int rv64_zbc;
 extern int rv64_zbs;
 extern int rv64_vector;
+extern int rv64_vlen;
 extern int rv64_xtheadba;
 extern int rv64_xtheadbb;
 extern int rv64_xtheadbs;

--- a/src/rv64detect.c
+++ b/src/rv64detect.c
@@ -72,7 +72,17 @@ void RV64_Detect_Function()
     block = (uint32_t*)my_block;
     CSRRS(xZR, xZR, 0x00f);
     BR(xRA);
-    rv64_vector = Check(my_block); // TODO: also check vlen >= 128
+    rv64_vector = Check(my_block);
+
+    if (rv64_vector) {
+        int vlenb = 0;
+        asm volatile("csrr %0, 0xc22" : "=r"(vlenb));
+        rv64_vlen = vlenb * 8;
+        if (vlenb < 16) {
+            // we need vlen >= 128
+            rv64_vector = 0;
+        }
+    }
 
     // THead vendor extensions
     if (!rv64_zba) {


### PR DESCRIPTION
We require VLEN >= 128 for the convenience of implementing SSE 2/3/4 opcodes, this PR checks it.