### PR TITLE
Fixed barrier_next setting

### DIFF
--- a/src/dynarec/dynarec_native_pass.c
+++ b/src/dynarec/dynarec_native_pass.c
@@ -169,6 +169,7 @@ uintptr_t native_pass(dynarec_native_t* dyn, uintptr_t addr, int alternate, int 
         if(ninst && dyn->insts[ninst-1].x64.barrier_next) {
             BARRIER(dyn->insts[ninst-1].x64.barrier_next);
         }
+        #endif
         int next = ninst+1;
         #if STEP > 0
         if(dyn->insts[ninst].x64.has_next && dyn->insts[next].x64.barrier) {

--- a/src/dynarec/dynarec_native_pass.c
+++ b/src/dynarec/dynarec_native_pass.c
@@ -112,11 +112,6 @@ uintptr_t native_pass(dynarec_native_t* dyn, uintptr_t addr, int alternate, int 
         dyn->f.dfnone_here = 0;
         NEW_INST;
         MESSAGE(LOG_DUMP, "New Instruction x64:%p, native:%p\n", (void*)addr, (void*)dyn->block);
-        #if STEP == 0
-        if(ninst && dyn->insts[ninst-1].x64.barrier_next) {
-            BARRIER(dyn->insts[ninst-1].x64.barrier_next);
-        }
-        #endif
         if(!ninst) {
             GOTEST(x1, x2);
         }
@@ -170,6 +165,10 @@ uintptr_t native_pass(dynarec_native_t* dyn, uintptr_t addr, int alternate, int 
             return ip;
         INST_EPILOG;
         fpu_reset_scratch(dyn);
+        #if STEP == 0
+        if(ninst && dyn->insts[ninst-1].x64.barrier_next) {
+            BARRIER(dyn->insts[ninst-1].x64.barrier_next);
+        }
         int next = ninst+1;
         #if STEP > 0
         if(dyn->insts[ninst].x64.has_next && dyn->insts[next].x64.barrier) {

--- a/src/dynarec/rv64/dynarec_rv64_d9.c
+++ b/src/dynarec/rv64/dynarec_rv64_d9.c
@@ -210,6 +210,7 @@ uintptr_t dynarec64_D9(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
 
         case 0xE8:
             INST_NAME("FLD1");
+            LAST_BARRIER_NEXT(BARRIER_FLOAT);
             X87_PUSH_OR_FAIL(v1, dyn, ninst, x1, EXT_CACHE_ST_F);
             if(ST_IS_F(0)) {
                 MOV32w(x1, 0x3f800000);
@@ -246,6 +247,7 @@ uintptr_t dynarec64_D9(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
             break;
         case 0xEE:
             INST_NAME("FLDZ");
+            LAST_BARRIER_NEXT(BARRIER_FLOAT);
             X87_PUSH_OR_FAIL(v1, dyn, ninst, x1, EXT_CACHE_ST_F);
             if(ST_IS_F(0)) {
                 FMVWX(v1, xZR);

--- a/src/dynarec/rv64/dynarec_rv64_de.c
+++ b/src/dynarec/rv64/dynarec_rv64_de.c
@@ -45,6 +45,7 @@ uintptr_t dynarec64_DE(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
         case 0xC6:
         case 0xC7:
             INST_NAME("FADDP STx, ST0");
+            LAST_BARRIER_NEXT(BARRIER_FLOAT);
             v2 = x87_get_st(dyn, ninst, x1, x2, 0, X87_COMBINE(0, nextop&7));
             v1 = x87_get_st(dyn, ninst, x1, x2, nextop&7, X87_COMBINE(0, nextop&7));
             if(ST_IS_F(0)) {

--- a/src/dynarec/rv64/dynarec_rv64_df.c
+++ b/src/dynarec/rv64/dynarec_rv64_df.c
@@ -47,6 +47,7 @@ uintptr_t dynarec64_DF(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
 
         case 0xE0:
             INST_NAME("FNSTSW AX");
+            LAST_BARRIER_NEXT(BARRIER_FULL);
             LWU(x2, xEmu, offsetof(x64emu_t, top));
             LHU(x1, xEmu, offsetof(x64emu_t, sw));
             MOV32w(x3, 0b1100011111111111); // mask

--- a/src/dynarec/rv64/dynarec_rv64_pass0.h
+++ b/src/dynarec/rv64/dynarec_rv64_pass0.h
@@ -19,6 +19,7 @@
 #define JUMP(A, C)         add_jump(dyn, ninst); add_next(dyn, (uintptr_t)A); SMEND(); dyn->insts[ninst].x64.jmp = A; dyn->insts[ninst].x64.jmp_cond = C; dyn->insts[ninst].x64.jmp_insts = 0
 #define BARRIER(A)      if(A!=BARRIER_MAYBE) {fpu_purgecache(dyn, ninst, 0, x1, x2, x3); dyn->insts[ninst].x64.barrier = A;} else dyn->insts[ninst].barrier_maybe = 1
 #define BARRIER_NEXT(A) dyn->insts[ninst].x64.barrier_next = A
+#define LAST_BARRIER_NEXT(A) dyn->insts[ninst-1].x64.barrier_next = A
 #define SET_HASCALLRET()    dyn->insts[ninst].x64.has_callret = 1
 #define NEW_INST                                                                   \
     ++dyn->size;                                                                   \

--- a/src/dynarec/rv64/dynarec_rv64_pass1.h
+++ b/src/dynarec/rv64/dynarec_rv64_pass1.h
@@ -17,3 +17,4 @@
         dyn->insts[ninst].f_exit = dyn->f
 
 #define INST_NAME(name)
+#define LAST_BARRIER_NEXT(A)

--- a/src/dynarec/rv64/dynarec_rv64_pass2.h
+++ b/src/dynarec/rv64/dynarec_rv64_pass2.h
@@ -19,3 +19,4 @@
 #define INST_NAME(name)
 #define TABLE64(A, V)   {Table64(dyn, (V), 2); EMIT(0); EMIT(0);}
 #define FTABLE64(A, V)  {mmx87_regs_t v = {.d = V}; Table64(dyn, v.q, 2); EMIT(0); EMIT(0);}
+#define LAST_BARRIER_NEXT(A)

--- a/src/dynarec/rv64/dynarec_rv64_pass3.h
+++ b/src/dynarec/rv64/dynarec_rv64_pass3.h
@@ -25,3 +25,4 @@
 
 #define TABLE64(A, V)   {int val64offset = Table64(dyn, (V), 3); MESSAGE(LOG_DUMP, "  Table64: 0x%lx\n", (V)); AUIPC(A, SPLIT20(val64offset)); LD(A, A, SPLIT12(val64offset));}
 #define FTABLE64(A, V)  {mmx87_regs_t v = {.d = V}; int val64offset = Table64(dyn, v.q, 3); MESSAGE(LOG_DUMP, "  FTable64: %g\n", v.d); AUIPC(x1, SPLIT20(val64offset)); FLD(A, x1, SPLIT12(val64offset));}
+#define LAST_BARRIER_NEXT(A)


### PR DESCRIPTION
When testing the “FNSTSW AX” instruction, I found that the results were inconsistent with the x86 instruction. The reason for this is that barrier_next and barrier are not set in native_pass0, while in native_pass “ #if STEP == 0
        if(ninst && dyn->insts[ninst-1].x64.barrier_next) {
            BARRIER(dyn->insts[ninst-1].x64.barrier_next);
        }
        #endif “ The if judgment of this code never passes, I think this is problematic, every floating point and FPU status word operation instruction's barrier should be set with its previous instruction's barrier_next, so I made some modifications, but only for the instructions I use for testing, if the modification is reasonable, I will continue to improve it, if the modification is not reasonable, I will continue to improve it, if the modification is not reasonable, I will continue to improve it. , I will continue to improve it, if the modification is not reasonable, you can reject this pull request, but please be aware of this issue, the current “FNSTSW AX” instruction will cause an error.