### PR TITLE
Revert "[ANDROID] Not use 'libbsd.so' as needed lib and don't define NEEDED_LIBS_234 for Android Too, Use BOX64_LD_LIBRARY_PATH instead of LD_LIBRARY_PATH on CTEST"

### DIFF
--- a/runTest.cmake
+++ b/runTest.cmake
@@ -19,10 +19,10 @@ set(ENV{BOX64_LOG} 0)
 set(ENV{BOX64_NOBANNER} 1)
 if( EXISTS ${CMAKE_SOURCE_DIR}/x64lib )
   # we are inside box64 folder
-  set(ENV{BOX64_LD_LIBRARY_PATH} ${CMAKE_SOURCE_DIR}/x64lib)
+  set(ENV{LD_LIBRARY_PATH} ${CMAKE_SOURCE_DIR}/x64lib)
 else()
   # we are inside build folder
-  set(ENV{BOX64_LD_LIBRARY_PATH} ${CMAKE_SOURCE_DIR}/../x64lib)
+  set(ENV{LD_LIBRARY_PATH} ${CMAKE_SOURCE_DIR}/../x64lib)
 endif( EXISTS ${CMAKE_SOURCE_DIR}/x64lib )
 
 # run the test program, capture the stdout/stderr and the result var

--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -3698,11 +3698,27 @@ __attribute__((weak)) uint32_t arc4random()
 #endif
 
 #if defined(ANDROID)
-#define NEEDED_LIBS_DEF   2,\
-    "libdl.so" ,            \
+#ifdef STATICBUILD
+#define NEEDED_LIBS_DEF   3,\
     "libpthread.so",        \
+    "libdl.so" ,            \
     "libm.so"
-#define NEEDED_LIBS_234 0
+#define NEEDED_LIBS_234 3,  \
+    "libpthread.so",        \
+    "libdl.so" ,            \
+    "libm.so"
+#else
+#define NEEDED_LIBS_DEF   4,\
+    "libpthread.so",        \
+    "libdl.so" ,            \
+    "libm.so",              \
+    "libbsd.so"
+#define NEEDED_LIBS_234 4,  \
+    "libpthread.so",        \
+    "libdl.so" ,            \
+    "libm.so",              \
+    "libbsd.so"
+#endif
 #else
 #ifdef STATICBUILD
 #define NEEDED_LIBS_DEF   5,\


### PR DESCRIPTION
Reverts ptitSeb/box64#1754