### PR TITLE
Better wrapper helper

### DIFF
--- a/wrapperhelper/Makefile
+++ b/wrapperhelper/Makefile
@@ -238,7 +238,7 @@ $(call wrapperhelper_o,,parse,parse): CFLAGS+= -fno-analyzer
 
 src/machine.gen:
 	$(call colorize,96,GEN,33,Generating $@)
-	$(SILENCER)echo | LC_ALL=C LANG=C $(CC) $(CPPFLAGS) -E -v - |& sed ':l; $$ ! { N; b l }; s/.*#include <...> search starts here:\n//; s/End of search list.*//; s/^ /DO_PATH("/; s/\n /")\nDO_PATH("/g; s/\n$$/")/' >src/machine.gen
+	$(SILENCER)echo | LC_ALL=C LANG=C $(CC) $(CPPFLAGS) -E -v - 2>&1 | sed ':l; $$ ! { N; b l }; s/.*#include <...> search starts here:\n//; s/End of search list.*//; s/^ /DO_PATH("/; s/\n /")\nDO_PATH("/g; s/\n$$/")/' >src/machine.gen
 
 #$(eval $(call compile_test_cxx,core/number))
 

--- a/wrapperhelper/README.md
+++ b/wrapperhelper/README.md
@@ -31,9 +31,11 @@ The first file is a `C` file containing every declaration required. The second f
 
 The support file may contain pragma declarations of the form
 ```c
-#pragma wrappers explicit_simple TYPE
+#pragma wrappers type-letters c TYPE
 ```
-where `TYPE` is a `typedef` to a structure. This marks the structure pointed to by `TYPE` as "simple", which means that functions taking such structures are not required to be `GOM`-like.
+where `TYPE` is a `type-name`. This marks the *exact* type `TYPE` as being a complex type though with a conversion as `c` (which may be multiple characters). Meaning:
+- if a parameter has type `TYPE`, the character output will be `c`;
+- if a parameter has a pointer to `TYPE`, or a structure containing `TYPE`, the output will be a `GOM` function.
 
 System headers included (directly or indirectly) by the support file are overriden by the files in `include-fixed`.
 
@@ -94,9 +96,7 @@ This project only works for `box64`; more work is required for this to be compat
 
 Only native structures are read. This means that the current version of `wrapperhelper` does not detect an issue when a structure has different members or alignments in two different architectures.
 
-Structure letters (i.e. `S` for `struct _IO_FILE*`) are hard-coded. A pragma should be used instead (`#pragma wrappers type_letter IDENT type-name`, parsed as `PTOK_PRAGMA: Type is letter: <char>`, followed by `type-name`, followed by `PTOK_NEWLINE`).
-
-Conditionals in the `_private.h` files are ignored, except for taking only the negative branch. Manual cleanup of the output is required.
+No checking of signatures under `#ifdef`s is made.
 
 Line numbers are missing entirely. For most errors, the corresponding file is not written with the error message.
 
@@ -114,8 +114,8 @@ The following features are missing from the preprocessor:
 - Proper out-of-memory error handling
 
 The following features are missing from the parser:
-- `inline` and `_Noreturn`
 - `_Atomic(type-name)`
 - `_Alignas(type-name)` and `_Alignas(constant-expression)`
 - `(type-name){initializer-list}`
+- Old style function declarations
 - Function definitions are ignored, not parsed

--- a/wrapperhelper/example-libc.h
+++ b/wrapperhelper/example-libc.h
@@ -2,9 +2,6 @@
 #define __USE_MISC 1
 #define PORTMAP
 
-// TODO
-#define inline
-
 #include <stdint.h>
 
 #include <aliases.h>
@@ -132,7 +129,13 @@
 #include <wctype.h>
 #include <wordexp.h>
 
-#pragma wrappers explicit_simple FTS
-#pragma wrappers explicit_simple FTS64
-#pragma wrappers explicit_simple glob_t
-#pragma wrappers explicit_simple glob64_t
+#pragma wrappers type_letters S FILE*
+#pragma wrappers type_letters S const FILE*
+#pragma wrappers type_letters p FTS*
+#pragma wrappers type_letters p const FTS*
+#pragma wrappers type_letters p FTS64*
+#pragma wrappers type_letters p const FTS64*
+#pragma wrappers type_letters p glob_t*
+#pragma wrappers type_letters p const glob_t*
+#pragma wrappers type_letters p glob64_t*
+#pragma wrappers type_letters p const glob64_t*

--- a/wrapperhelper/src/generator.h
+++ b/wrapperhelper/src/generator.h
@@ -10,8 +10,8 @@
 
 typedef struct request_s {
 	string_t *obj_name;
-	_Bool has_default, default_comment;
-	_Bool has_val;
+	_Bool default_comment;
+	_Bool has_val, ignored;
 	_Bool weak;
 	struct {
 		enum request_type_e {
@@ -41,6 +41,10 @@ typedef struct reference_s {
 	enum {
 		REF_REQ,
 		REF_LINE,
+		REF_IFDEF,
+		REF_IFNDEF,
+		REF_ELSE,
+		REF_ENDIF,
 	} typ;
 	union {
 		request_t req;
@@ -48,9 +52,10 @@ typedef struct reference_s {
 	};
 } reference_t;
 VECTOR_DECLARE(references, reference_t)
-void request_print(request_t *req);
-void request_print_check(request_t *req);
-void output_from_references(FILE *f, VECTOR(references) *reqs);
+void request_print(const request_t *req);
+void request_print_check(const request_t *req);
+void references_print_check(const VECTOR(references) *refs);
+void output_from_references(FILE *f, const VECTOR(references) *reqs);
 
 VECTOR(references) *references_from_file(const char *filename, FILE *f); // Takes ownership of f
 int solve_request(request_t *req, type_t *typ);

--- a/wrapperhelper/src/lang.h
+++ b/wrapperhelper/src/lang.h
@@ -162,7 +162,7 @@ typedef struct proc_token_s {
 		struct {
 			enum proc_pragma_e {
 				PRAGMA_ALLOW_INTS,
-				PRAGMA_MARK_SIMPLE,
+				PRAGMA_EXPLICIT_CONV,
 			} typ;
 			string_t *val;
 		} pragma;
@@ -368,6 +368,7 @@ typedef struct type_s {
 		} fun;
 	} val;
 	size_info_t szinfo;
+	string_t *converted; // NULL for default behavior
 } type_t;
 void type_del(type_t *typ);
 KHASH_MAP_DECLARE_STR(type_map, type_t*)
@@ -387,7 +388,6 @@ typedef struct struct_s {
 	size_t nrefs;
 	int is_struct; // 0 = union, 1 = struct
 	int has_incomplete; // 1 if the last element of the structure is a VLA or if an element of the union recursively contains a VLA
-	int explicit_simple;
 	size_t nmembers;
 	st_member_t *members;
 } struct_t;

--- a/wrapperhelper/src/main.c
+++ b/wrapperhelper/src/main.c
@@ -131,31 +131,31 @@ int main(int argc, char **argv) {
 			del_str2kw();
 			return 2;
 		}
-		VECTOR(references) *reqs = references_from_file(ref_file, ref);
-		if (!reqs) {
+		VECTOR(references) *refs = references_from_file(ref_file, ref);
+		if (!refs) {
 			file_del(content);
 			del_machines();
 			del_str2kw();
 			return 2;
 		}
-		// vector_for(references, req, reqs) request_print(req);
-		if (!solve_references(reqs, content->decl_map)) {
+		// vector_for(references, req, refs) request_print(req);
+		if (!solve_references(refs, content->decl_map)) {
 			printf("Warning: failed to solve all default requests\n");
 		}
-		// vector_for(references, req, reqs) request_print(req);
-		//vector_for(references, req, reqs) request_print_check(req);
+		// vector_for(references, req, refs) request_print(req);
+		references_print_check(refs);
 		FILE *out = fopen(out_file, "w");
 		if (!out) {
 			err(2, "Error: failed to open %s", ref_file);
 			file_del(content);
-			vector_del(references, reqs);
+			vector_del(references, refs);
 			del_machines();
 			del_str2kw();
 			return 2;
 		}
-		output_from_references(out, reqs);
+		output_from_references(out, refs);
 		fclose(out);
-		vector_del(references, reqs);
+		vector_del(references, refs);
 		file_del(content);
 		del_machines();
 		del_str2kw();
@@ -181,6 +181,11 @@ int main(int argc, char **argv) {
 		kh_foreach(content->struct_map, name, st,
 			printf("Struct: %s -> %p = ", name, st);
 			struct_print(st);
+			printf("\n")
+		)
+		kh_foreach_key(content->type_set, typ,
+			printf("Type: %p = ", typ);
+			type_print(typ);
 			printf("\n")
 		)
 		kh_foreach(content->type_map, name, typ,


### PR DESCRIPTION
This PR:
- greatly improves the output of the wrapper helper, by not changing ignored lines;
- should make the Makefile compatible on more platforms (using fd redirection instead of `|&`);
- implements some more features in the parser (`inline` and `_Noreturn`);
- allows for explicit type mapping (using the `#pragma wrappers type-letters` pragma), for example mapping `FILE*` to type letter `S`