### PR TITLE
[RV64_DYNAREC] Refactored vector SEW tracking

### DIFF
--- a/src/dynarec/arm64/dynarec_arm64_private.h
+++ b/src/dynarec/arm64/dynarec_arm64_private.h
@@ -89,7 +89,7 @@ typedef struct instruction_arm64_s {
     uint16_t            ymm0_in;    // bitmap of ymm to zero at purge
     uint16_t            ymm0_add;   // the ymm0 added by the opcode
     uint16_t            ymm0_sub;   // the ymm0 removed by the opcode
-    uint16_t            ymm0_out;   // the ymmm0 at th end of the opcode
+    uint16_t            ymm0_out;   // the ymm0 at th end of the opcode
     uint16_t            ymm0_pass2, ymm0_pass3;
     uint8_t             barrier_maybe;
     uint8_t             will_write;

--- a/src/dynarec/la64/dynarec_la64_private.h
+++ b/src/dynarec/la64/dynarec_la64_private.h
@@ -85,7 +85,7 @@ typedef struct instruction_la64_s {
     uint16_t            ymm0_in;    // bitmap of ymm to zero at purge
     uint16_t            ymm0_add;   // the ymm0 added by the opcode
     uint16_t            ymm0_sub;   // the ymm0 removed by the opcode
-    uint16_t            ymm0_out;   // the ymmm0 at th end of the opcode
+    uint16_t            ymm0_out;   // the ymm0 at th end of the opcode
     uint16_t            ymm0_pass2, ymm0_pass3;
     uint8_t             barrier_maybe;
     uint8_t             will_write;

--- a/src/dynarec/rv64/dynarec_rv64_helper.c
+++ b/src/dynarec/rv64/dynarec_rv64_helper.c
@@ -2432,9 +2432,9 @@ static void sewTransform(dynarec_rv64_t* dyn, int ninst, int s1)
     int j64;
     int jmp = dyn->insts[ninst].x64.jmp_insts;
     if (jmp < 0) return;
-    if (dyn->insts[jmp].vector_sew == VECTOR_SEWNA) return;
-    MESSAGE(LOG_DUMP, "\tSEW changed to %d ---- ninst=%d -> %d\n", dyn->insts[jmp].vector_sew, ninst, jmp);
-    vector_vsetvl_emul1(dyn, ninst, s1, dyn->insts[jmp].vector_sew, 1);
+    if (dyn->insts[jmp].vector_sew_entry == VECTOR_SEWNA) return;
+    MESSAGE(LOG_DUMP, "\tSEW changed to %d ---- ninst=%d -> %d\n", dyn->insts[jmp].vector_sew_entry, ninst, jmp);
+    vector_vsetvl_emul1(dyn, ninst, s1, dyn->insts[jmp].vector_sew_entry, 1);
 }
 
 void CacheTransform(dynarec_rv64_t* dyn, int ninst, int cacheupd, int s1, int s2, int s3)
@@ -2528,10 +2528,10 @@ void fpu_reset_cache(dynarec_rv64_t* dyn, int ninst, int reset_n)
     #if STEP > 1
     // for STEP 2 & 3, just need to refresh with current, and undo the changes (push & swap)
     dyn->e = dyn->insts[ninst].e;
-    dyn->vector_sew = dyn->insts[ninst].vector_sew;
+    dyn->vector_sew = dyn->insts[ninst].vector_sew_exit;
     #else
     dyn->e = dyn->insts[reset_n].e;
-    dyn->vector_sew = dyn->insts[reset_n].vector_sew;
+    dyn->vector_sew = dyn->insts[reset_n].vector_sew_exit;
     #endif
     extcacheUnwind(&dyn->e);
     #if STEP == 0

--- a/src/dynarec/rv64/dynarec_rv64_pass0.h
+++ b/src/dynarec/rv64/dynarec_rv64_pass0.h
@@ -19,25 +19,24 @@
 #define JUMP(A, C)         add_jump(dyn, ninst); add_next(dyn, (uintptr_t)A); SMEND(); dyn->insts[ninst].x64.jmp = A; dyn->insts[ninst].x64.jmp_cond = C; dyn->insts[ninst].x64.jmp_insts = 0
 #define BARRIER(A)      if(A!=BARRIER_MAYBE) {fpu_purgecache(dyn, ninst, 0, x1, x2, x3); dyn->insts[ninst].x64.barrier = A;} else dyn->insts[ninst].barrier_maybe = 1
 #define SET_HASCALLRET()    dyn->insts[ninst].x64.has_callret = 1
-#define NEW_INST                                                                   \
-    ++dyn->size;                                                                   \
-    memset(&dyn->insts[ninst], 0, sizeof(instruction_native_t));                   \
-    dyn->insts[ninst].x64.addr = ip;                                               \
-    dyn->e.combined1 = dyn->e.combined2 = 0;                                       \
-    dyn->e.swapped = 0;                                                            \
-    dyn->e.barrier = 0;                                                            \
-    for (int i = 0; i < 16; ++i)                                                   \
-        dyn->e.olds[i].v = 0;                                                      \
-    dyn->insts[ninst].f_entry = dyn->f;                                            \
-    if (reset_n == -1)                                                             \
-        dyn->vector_sew = ninst ? dyn->insts[ninst - 1].vector_sew : VECTOR_SEWNA; \
-    if (ninst)                                                                     \
+#define NEW_INST                                                 \
+    ++dyn->size;                                                 \
+    memset(&dyn->insts[ninst], 0, sizeof(instruction_native_t)); \
+    dyn->insts[ninst].x64.addr = ip;                             \
+    dyn->e.combined1 = dyn->e.combined2 = 0;                     \
+    dyn->e.swapped = 0;                                          \
+    dyn->e.barrier = 0;                                          \
+    for (int i = 0; i < 16; ++i)                                 \
+        dyn->e.olds[i].v = 0;                                    \
+    dyn->insts[ninst].f_entry = dyn->f;                          \
+    dyn->insts[ninst].vector_sew_entry = dyn->vector_sew;        \
+    if (ninst)                                                   \
         dyn->insts[ninst - 1].x64.size = dyn->insts[ninst].x64.addr - dyn->insts[ninst - 1].x64.addr;
 
-#define INST_EPILOG                                 \
-    dyn->insts[ninst].f_exit = dyn->f;              \
-    dyn->insts[ninst].e = dyn->e;                   \
-    dyn->insts[ninst].vector_sew = dyn->vector_sew; \
+#define INST_EPILOG                                      \
+    dyn->insts[ninst].f_exit = dyn->f;                   \
+    dyn->insts[ninst].e = dyn->e;                        \
+    dyn->insts[ninst].vector_sew_exit = dyn->vector_sew; \
     dyn->insts[ninst].x64.has_next = (ok > 0) ? 1 : 0;
 #define INST_NAME(name)
 #define DEFAULT                         \

--- a/src/dynarec/rv64/dynarec_rv64_pass1.h
+++ b/src/dynarec/rv64/dynarec_rv64_pass1.h
@@ -2,18 +2,18 @@
 #define FINI
 #define MESSAGE(A, ...) do {} while (0)
 #define EMIT(A) do {} while (0)
-#define NEW_INST                                                                   \
-    dyn->insts[ninst].f_entry = dyn->f;                                            \
-    dyn->e.combined1 = dyn->e.combined2 = 0;                                       \
-    for (int i = 0; i < 16; ++i)                                                   \
-        dyn->e.olds[i].v = 0;                                                      \
-    if (reset_n != -1)                                                             \
-        dyn->vector_sew = ninst ? dyn->insts[ninst - 1].vector_sew : VECTOR_SEWNA; \
-    dyn->e.swapped = 0;                                                            \
+#define NEW_INST                                          \
+    dyn->insts[ninst].f_entry = dyn->f;                   \
+    dyn->e.combined1 = dyn->e.combined2 = 0;              \
+    for (int i = 0; i < 16; ++i)                          \
+        dyn->e.olds[i].v = 0;                             \
+    dyn->insts[ninst].vector_sew_entry = dyn->vector_sew; \
+    dyn->e.swapped = 0;                                   \
     dyn->e.barrier = 0
 
-#define INST_EPILOG                             \
-        dyn->insts[ninst].e = dyn->e;           \
-        dyn->insts[ninst].f_exit = dyn->f
+#define INST_EPILOG                    \
+    dyn->insts[ninst].e = dyn->e;      \
+    dyn->insts[ninst].f_exit = dyn->f; \
+    dyn->insts[ninst].vector_sew_exit = dyn->vector_sew;
 
 #define INST_NAME(name)

--- a/src/dynarec/rv64/dynarec_rv64_pass2.h
+++ b/src/dynarec/rv64/dynarec_rv64_pass2.h
@@ -8,8 +8,6 @@
 #define MESSAGE(A, ...) do {} while (0)
 #define EMIT(A)     do {dyn->insts[ninst].size+=4; dyn->native_size+=4;}while(0)
 #define NEW_INST                                                                                                                                                               \
-    if (reset_n != -1)                                                                                                                                                         \
-        dyn->vector_sew = ninst ? dyn->insts[ninst - 1].vector_sew : VECTOR_SEWNA;                                                                                             \
     if (ninst) {                                                                                                                                                               \
         dyn->insts[ninst].address = (dyn->insts[ninst - 1].address + dyn->insts[ninst - 1].size);                                                                              \
         dyn->insts_size += 1 + ((dyn->insts[ninst - 1].x64.size > (dyn->insts[ninst - 1].size / 4)) ? dyn->insts[ninst - 1].x64.size : (dyn->insts[ninst - 1].size / 4)) / 15; \

--- a/src/dynarec/rv64/dynarec_rv64_pass3.h
+++ b/src/dynarec/rv64/dynarec_rv64_pass3.h
@@ -13,8 +13,6 @@
 
 #define MESSAGE(A, ...)  if(box64_dynarec_dump) dynarec_log(LOG_NONE, __VA_ARGS__)
 #define NEW_INST                                                                                                  \
-    if (reset_n != -1)                                                                                            \
-        dyn->vector_sew = ninst ? dyn->insts[ninst - 1].vector_sew : VECTOR_SEWNA;                                \
     if (box64_dynarec_dump) print_newinst(dyn, ninst);                                                            \
     if (ninst) {                                                                                                  \
         addInst(dyn->instsize, &dyn->insts_size, dyn->insts[ninst - 1].x64.size, dyn->insts[ninst - 1].size / 4); \

--- a/src/dynarec/rv64/dynarec_rv64_private.h
+++ b/src/dynarec/rv64/dynarec_rv64_private.h
@@ -108,13 +108,14 @@ typedef struct instruction_rv64_s {
     uint16_t            ymm0_in;    // bitmap of ymm to zero at purge
     uint16_t            ymm0_add;   // the ymm0 added by the opcode
     uint16_t            ymm0_sub;   // the ymm0 removed by the opcode
-    uint16_t            ymm0_out;   // the ymmm0 at th end of the opcode
+    uint16_t            ymm0_out;   // the ymm0 at th end of the opcode
     uint16_t            ymm0_pass2, ymm0_pass3;
     int                 barrier_maybe;
     flagcache_t         f_exit;     // flags status at end of instruction
     extcache_t          e;          // extcache at end of instruction (but before poping)
     flagcache_t         f_entry;    // flags status before the instruction begin
-    uint8_t             vector_sew;
+    uint8_t             vector_sew_entry; // sew status before the instruction begin
+    uint8_t             vector_sew_exit;  // sew status at the end of instruction
 } instruction_rv64_t;
 
 typedef struct dynarec_rv64_s {
@@ -153,8 +154,8 @@ typedef struct dynarec_rv64_s {
     uint16_t            ymm_zero;   // bitmap of ymm to zero at purge
     uint8_t             always_test;
     uint8_t             abort;
-    uint8_t             vector_sew;
-    uint8_t             vector_eew; // effective element width
+    uint8_t             vector_sew; // current sew status
+    uint8_t             vector_eew; // current effective sew status, should only be used after SET_ELEMENT_WIDTH
 } dynarec_rv64_t;
 
 // v0 is hardware wired to vector mask register, which should be always reserved


### PR DESCRIPTION
Separated `dyn->insts[ninst].vector_sew` to `_entry` and `_exit` to simplify the initialization process, also it's better for the dump log.

Related PR: #1819 
Related Issue: #1818 