### PR TITLE
Improve the wrapper helper

### DIFF
--- a/wrapperhelper/README.md
+++ b/wrapperhelper/README.md
@@ -31,11 +31,19 @@ The first file is a `C` file containing every declaration required. The second f
 
 The support file may contain pragma declarations of the form
 ```c
-#pragma wrappers type-letters c TYPE
+#pragma wrappers type_letters c TYPE
+#pragma wrappers type_letters_strict c TYPE
 ```
-where `TYPE` is a `type-name`. This marks the *exact* type `TYPE` as being a complex type though with a conversion as `c` (which may be multiple characters). Meaning:
+where `TYPE` is a `type-name`. The second form marks the *exact* type `TYPE` as being a complex type though with a conversion as `c` (which may be multiple characters), while the first marks the type `TYPE`, regardless of type qualifers (`_Atomic`, `const`, `restrict`, `volatile`). Meaning:
 - if a parameter has type `TYPE`, the character output will be `c`;
 - if a parameter has a pointer to `TYPE`, or a structure containing `TYPE`, the output will be a `GOM` function.
+
+Declarations of the form
+```c
+#pragma wrappers mark_simple TAG
+```
+will mark the structure or union with tag `TAG`, or the structure or union aliased to `TAG` by a `typedef` if no such structure exist, as simple. This means that a pointer to such a structure will have a character output of `p`.
+This is not the same as making the pointer to the structure a complex type with conversion as `p` as e.g. pointers to pointers will behave differently.
 
 System headers included (directly or indirectly) by the support file are overriden by the files in `include-fixed`.
 

--- a/wrapperhelper/example-libc.h
+++ b/wrapperhelper/example-libc.h
@@ -130,14 +130,7 @@
 #include <wordexp.h>
 
 #pragma wrappers type_letters S FILE*
-#pragma wrappers type_letters S const FILE*
-#pragma wrappers type_letters S FILE* restrict
-#pragma wrappers type_letters S const FILE* restrict
-#pragma wrappers type_letters p FTS*
-#pragma wrappers type_letters p const FTS*
-#pragma wrappers type_letters p FTS64*
-#pragma wrappers type_letters p const FTS64*
-#pragma wrappers type_letters p glob_t*
-#pragma wrappers type_letters p const glob_t*
-#pragma wrappers type_letters p glob64_t*
-#pragma wrappers type_letters p const glob64_t*
+#pragma wrappers mark_simple FTS
+#pragma wrappers mark_simple FTS64
+#pragma wrappers mark_simple glob_t
+#pragma wrappers mark_simple glob64_t

--- a/wrapperhelper/include-override/aarch64/stdc-predef.h
+++ b/wrapperhelper/include-override/aarch64/stdc-predef.h
@@ -1,0 +1,421 @@
+#define __aarch64__ 1
+#define __AARCH64_CMODEL_SMALL__ 1
+#define __AARCH64EL__ 1
+#define __ARM_64BIT_STATE 1
+#define __ARM_ALIGN_MAX_PWR 28
+#define __ARM_ALIGN_MAX_STACK_PWR 16
+#define __ARM_ARCH 8
+#define __ARM_ARCH_8A 1
+#define __ARM_ARCH_ISA_A64 1
+#define __ARM_ARCH_PROFILE 65
+#define __ARM_FEATURE_CLZ 1
+#define __ARM_FEATURE_FMA 1
+#define __ARM_FEATURE_IDIV 1
+#define __ARM_FEATURE_NUMERIC_MAXMIN 1
+#define __ARM_FEATURE_UNALIGNED 1
+#define __ARM_FP 14
+#define __ARM_FP16_ARGS 1
+#define __ARM_FP16_FORMAT_IEEE 1
+#define __arm_in(...) [[__extension__ arm::in(__VA_ARGS__)]]
+#define __arm_inout(...) [[__extension__ arm::inout(__VA_ARGS__)]]
+#define __arm_locally_streaming [[__extension__ arm::locally_streaming]]
+#define __ARM_NEON 1
+#define __ARM_NEON_SVE_BRIDGE 1
+#define __arm_new(...) [[__extension__ arm::new(__VA_ARGS__)]]
+#define __arm_out(...) [[__extension__ arm::out(__VA_ARGS__)]]
+#define __ARM_PCS_AAPCS64 1
+#define __arm_preserves(...) [[__extension__ arm::preserves(__VA_ARGS__)]]
+#define __ARM_SIZEOF_MINIMAL_ENUM 4
+#define __ARM_SIZEOF_WCHAR_T 4
+#define __ARM_STATE_ZA 1
+#define __ARM_STATE_ZT0 1
+#define __arm_streaming_compatible [[__extension__ arm::streaming_compatible]]
+#define __arm_streaming [[__extension__ arm::streaming]]
+#define __ATOMIC_ACQ_REL 4
+#define __ATOMIC_ACQUIRE 2
+#define __ATOMIC_CONSUME 1
+#define __ATOMIC_RELAXED 0
+#define __ATOMIC_RELEASE 3
+#define __ATOMIC_SEQ_CST 5
+#define __BFLT16_DECIMAL_DIG__ 4
+#define __BFLT16_DENORM_MIN__ 9.18354961579912115600575419704879436e-41BF16
+#define __BFLT16_DIG__ 2
+#define __BFLT16_EPSILON__ 7.81250000000000000000000000000000000e-3BF16
+#define __BFLT16_HAS_DENORM__ 1
+#define __BFLT16_HAS_INFINITY__ 1
+#define __BFLT16_HAS_QUIET_NAN__ 1
+#define __BFLT16_IS_IEC_60559__ 0
+#define __BFLT16_MANT_DIG__ 8
+#define __BFLT16_MAX_10_EXP__ 38
+#define __BFLT16_MAX__ 3.38953138925153547590470800371487867e+38BF16
+#define __BFLT16_MAX_EXP__ 128
+#define __BFLT16_MIN_10_EXP__ (-37)
+#define __BFLT16_MIN__ 1.17549435082228750796873653722224568e-38BF16
+#define __BFLT16_MIN_EXP__ (-125)
+#define __BFLT16_NORM_MAX__ 3.38953138925153547590470800371487867e+38BF16
+#define __BIGGEST_ALIGNMENT__ 16
+#define __BITINT_MAXWIDTH__ 65535
+#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __CHAR16_TYPE__ short unsigned int
+#define __CHAR32_TYPE__ unsigned int
+#define __CHAR_BIT__ 8
+#define __CHAR_UNSIGNED__ 1
+#define __DBL_DECIMAL_DIG__ 17
+#define __DBL_DENORM_MIN__ ((double)4.94065645841246544176568792868221372e-324L)
+#define __DBL_DIG__ 15
+#define __DBL_EPSILON__ ((double)2.22044604925031308084726333618164062e-16L)
+#define __DBL_HAS_DENORM__ 1
+#define __DBL_HAS_INFINITY__ 1
+#define __DBL_HAS_QUIET_NAN__ 1
+#define __DBL_IS_IEC_60559__ 1
+#define __DBL_MANT_DIG__ 53
+#define __DBL_MAX_10_EXP__ 308
+#define __DBL_MAX__ ((double)1.79769313486231570814527423731704357e+308L)
+#define __DBL_MAX_EXP__ 1024
+#define __DBL_MIN_10_EXP__ (-307)
+#define __DBL_MIN__ ((double)2.22507385850720138309023271733240406e-308L)
+#define __DBL_MIN_EXP__ (-1021)
+#define __DBL_NORM_MAX__ ((double)1.79769313486231570814527423731704357e+308L)
+#define __DEC128_EPSILON__ 1E-33DL
+#define __DEC128_MANT_DIG__ 34
+#define __DEC128_MAX__ 9.999999999999999999999999999999999E6144DL
+#define __DEC128_MAX_EXP__ 6145
+#define __DEC128_MIN__ 1E-6143DL
+#define __DEC128_MIN_EXP__ (-6142)
+#define __DEC128_SUBNORMAL_MIN__ 0.000000000000000000000000000000001E-6143DL
+#define __DEC32_EPSILON__ 1E-6DF
+#define __DEC32_MANT_DIG__ 7
+#define __DEC32_MAX__ 9.999999E96DF
+#define __DEC32_MAX_EXP__ 97
+#define __DEC32_MIN__ 1E-95DF
+#define __DEC32_MIN_EXP__ (-94)
+#define __DEC32_SUBNORMAL_MIN__ 0.000001E-95DF
+#define __DEC64_EPSILON__ 1E-15DD
+#define __DEC64_MANT_DIG__ 16
+#define __DEC64_MAX__ 9.999999999999999E384DD
+#define __DEC64_MAX_EXP__ 385
+#define __DEC64_MIN__ 1E-383DD
+#define __DEC64_MIN_EXP__ (-382)
+#define __DEC64_SUBNORMAL_MIN__ 0.000000000000001E-383DD
+#define __DEC_EVAL_METHOD__ 2
+#define __DECIMAL_BID_FORMAT__ 1
+#define __DECIMAL_DIG__ 36
+#define __ELF__ 1
+#define __FINITE_MATH_ONLY__ 0
+#define __FLOAT_WORD_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __FLT128_DECIMAL_DIG__ 36
+#define __FLT128_DENORM_MIN__ 6.47517511943802511092443895822764655e-4966F128
+#define __FLT128_DIG__ 33
+#define __FLT128_EPSILON__ 1.92592994438723585305597794258492732e-34F128
+#define __FLT128_HAS_DENORM__ 1
+#define __FLT128_HAS_INFINITY__ 1
+#define __FLT128_HAS_QUIET_NAN__ 1
+#define __FLT128_IS_IEC_60559__ 1
+#define __FLT128_MANT_DIG__ 113
+#define __FLT128_MAX_10_EXP__ 4932
+#define __FLT128_MAX__ 1.18973149535723176508575932662800702e+4932F128
+#define __FLT128_MAX_EXP__ 16384
+#define __FLT128_MIN_10_EXP__ (-4931)
+#define __FLT128_MIN__ 3.36210314311209350626267781732175260e-4932F128
+#define __FLT128_MIN_EXP__ (-16381)
+#define __FLT128_NORM_MAX__ 1.18973149535723176508575932662800702e+4932F128
+#define __FLT16_DECIMAL_DIG__ 5
+#define __FLT16_DENORM_MIN__ 5.96046447753906250000000000000000000e-8F16
+#define __FLT16_DIG__ 3
+#define __FLT16_EPSILON__ 9.76562500000000000000000000000000000e-4F16
+#define __FLT16_HAS_DENORM__ 1
+#define __FLT16_HAS_INFINITY__ 1
+#define __FLT16_HAS_QUIET_NAN__ 1
+#define __FLT16_IS_IEC_60559__ 1
+#define __FLT16_MANT_DIG__ 11
+#define __FLT16_MAX_10_EXP__ 4
+#define __FLT16_MAX__ 6.55040000000000000000000000000000000e+4F16
+#define __FLT16_MAX_EXP__ 16
+#define __FLT16_MIN_10_EXP__ (-4)
+#define __FLT16_MIN__ 6.10351562500000000000000000000000000e-5F16
+#define __FLT16_MIN_EXP__ (-13)
+#define __FLT16_NORM_MAX__ 6.55040000000000000000000000000000000e+4F16
+#define __FLT32_DECIMAL_DIG__ 9
+#define __FLT32_DENORM_MIN__ 1.40129846432481707092372958328991613e-45F32
+#define __FLT32_DIG__ 6
+#define __FLT32_EPSILON__ 1.19209289550781250000000000000000000e-7F32
+#define __FLT32_HAS_DENORM__ 1
+#define __FLT32_HAS_INFINITY__ 1
+#define __FLT32_HAS_QUIET_NAN__ 1
+#define __FLT32_IS_IEC_60559__ 1
+#define __FLT32_MANT_DIG__ 24
+#define __FLT32_MAX_10_EXP__ 38
+#define __FLT32_MAX__ 3.40282346638528859811704183484516925e+38F32
+#define __FLT32_MAX_EXP__ 128
+#define __FLT32_MIN_10_EXP__ (-37)
+#define __FLT32_MIN__ 1.17549435082228750796873653722224568e-38F32
+#define __FLT32_MIN_EXP__ (-125)
+#define __FLT32_NORM_MAX__ 3.40282346638528859811704183484516925e+38F32
+#define __FLT32X_DECIMAL_DIG__ 17
+#define __FLT32X_DENORM_MIN__ 4.94065645841246544176568792868221372e-324F32x
+#define __FLT32X_DIG__ 15
+#define __FLT32X_EPSILON__ 2.22044604925031308084726333618164062e-16F32x
+#define __FLT32X_HAS_DENORM__ 1
+#define __FLT32X_HAS_INFINITY__ 1
+#define __FLT32X_HAS_QUIET_NAN__ 1
+#define __FLT32X_IS_IEC_60559__ 1
+#define __FLT32X_MANT_DIG__ 53
+#define __FLT32X_MAX_10_EXP__ 308
+#define __FLT32X_MAX__ 1.79769313486231570814527423731704357e+308F32x
+#define __FLT32X_MAX_EXP__ 1024
+#define __FLT32X_MIN_10_EXP__ (-307)
+#define __FLT32X_MIN__ 2.22507385850720138309023271733240406e-308F32x
+#define __FLT32X_MIN_EXP__ (-1021)
+#define __FLT32X_NORM_MAX__ 1.79769313486231570814527423731704357e+308F32x
+#define __FLT64_DECIMAL_DIG__ 17
+#define __FLT64_DENORM_MIN__ 4.94065645841246544176568792868221372e-324F64
+#define __FLT64_DIG__ 15
+#define __FLT64_EPSILON__ 2.22044604925031308084726333618164062e-16F64
+#define __FLT64_HAS_DENORM__ 1
+#define __FLT64_HAS_INFINITY__ 1
+#define __FLT64_HAS_QUIET_NAN__ 1
+#define __FLT64_IS_IEC_60559__ 1
+#define __FLT64_MANT_DIG__ 53
+#define __FLT64_MAX_10_EXP__ 308
+#define __FLT64_MAX__ 1.79769313486231570814527423731704357e+308F64
+#define __FLT64_MAX_EXP__ 1024
+#define __FLT64_MIN_10_EXP__ (-307)
+#define __FLT64_MIN__ 2.22507385850720138309023271733240406e-308F64
+#define __FLT64_MIN_EXP__ (-1021)
+#define __FLT64_NORM_MAX__ 1.79769313486231570814527423731704357e+308F64
+#define __FLT64X_DECIMAL_DIG__ 36
+#define __FLT64X_DENORM_MIN__ 6.47517511943802511092443895822764655e-4966F64x
+#define __FLT64X_DIG__ 33
+#define __FLT64X_EPSILON__ 1.92592994438723585305597794258492732e-34F64x
+#define __FLT64X_HAS_DENORM__ 1
+#define __FLT64X_HAS_INFINITY__ 1
+#define __FLT64X_HAS_QUIET_NAN__ 1
+#define __FLT64X_IS_IEC_60559__ 1
+#define __FLT64X_MANT_DIG__ 113
+#define __FLT64X_MAX_10_EXP__ 4932
+#define __FLT64X_MAX__ 1.18973149535723176508575932662800702e+4932F64x
+#define __FLT64X_MAX_EXP__ 16384
+#define __FLT64X_MIN_10_EXP__ (-4931)
+#define __FLT64X_MIN__ 3.36210314311209350626267781732175260e-4932F64x
+#define __FLT64X_MIN_EXP__ (-16381)
+#define __FLT64X_NORM_MAX__ 1.18973149535723176508575932662800702e+4932F64x
+#define __FLT_DECIMAL_DIG__ 9
+#define __FLT_DENORM_MIN__ 1.40129846432481707092372958328991613e-45F
+#define __FLT_DIG__ 6
+#define __FLT_EPSILON__ 1.19209289550781250000000000000000000e-7F
+#define __FLT_EVAL_METHOD__ 0
+#define __FLT_EVAL_METHOD_C99__ 0
+#define __FLT_EVAL_METHOD_TS_18661_3__ 0
+#define __FLT_HAS_DENORM__ 1
+#define __FLT_HAS_INFINITY__ 1
+#define __FLT_HAS_QUIET_NAN__ 1
+#define __FLT_IS_IEC_60559__ 1
+#define __FLT_MANT_DIG__ 24
+#define __FLT_MAX_10_EXP__ 38
+#define __FLT_MAX__ 3.40282346638528859811704183484516925e+38F
+#define __FLT_MAX_EXP__ 128
+#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT_MIN__ 1.17549435082228750796873653722224568e-38F
+#define __FLT_MIN_EXP__ (-125)
+#define __FLT_NORM_MAX__ 3.40282346638528859811704183484516925e+38F
+#define __FLT_RADIX__ 2
+#define __FP_FAST_FMA 1
+#define __FP_FAST_FMAF 1
+#define __FP_FAST_FMAF32 1
+#define __FP_FAST_FMAF32x 1
+#define __FP_FAST_FMAF64 1
+#define __GCC_ASM_FLAG_OUTPUTS__ 1
+#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+#define __GCC_ATOMIC_INT_LOCK_FREE 2
+#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+#define __GCC_CONSTRUCTIVE_SIZE 64
+#define __GCC_DESTRUCTIVE_SIZE 256
+#define __GCC_HAVE_DWARF2_CFI_ASM 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
+#define __GCC_IEC_559 2
+#define __GCC_IEC_559_COMPLEX 2
+#define __GNUC__ 14
+#define __GNUC_EXECUTION_CHARSET_NAME "UTF-8"
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 0
+#define __GNUC_STDC_INLINE__ 1
+#define __GNUC_WIDE_EXECUTION_CHARSET_NAME "UTF-32LE"
+#define __gnu_linux__ 1
+#define __GXX_ABI_VERSION 1019
+#define __HAVE_SPECULATION_SAFE_VALUE 1
+#define __INT16_C(c) c
+#define __INT16_MAX__ 0x7fff
+#define __INT16_TYPE__ short int
+#define __INT32_C(c) c
+#define __INT32_MAX__ 0x7fffffff
+#define __INT32_TYPE__ int
+#define __INT64_C(c) c ## L
+#define __INT64_MAX__ 0x7fffffffffffffffL
+#define __INT64_TYPE__ long int
+#define __INT8_C(c) c
+#define __INT8_MAX__ 0x7f
+#define __INT8_TYPE__ signed char
+#define __INT_FAST16_MAX__ 0x7fffffffffffffffL
+#define __INT_FAST16_TYPE__ long int
+#define __INT_FAST16_WIDTH__ 64
+#define __INT_FAST32_MAX__ 0x7fffffffffffffffL
+#define __INT_FAST32_TYPE__ long int
+#define __INT_FAST32_WIDTH__ 64
+#define __INT_FAST64_MAX__ 0x7fffffffffffffffL
+#define __INT_FAST64_TYPE__ long int
+#define __INT_FAST64_WIDTH__ 64
+#define __INT_FAST8_MAX__ 0x7f
+#define __INT_FAST8_TYPE__ signed char
+#define __INT_FAST8_WIDTH__ 8
+#define __INT_LEAST16_MAX__ 0x7fff
+#define __INT_LEAST16_TYPE__ short int
+#define __INT_LEAST16_WIDTH__ 16
+#define __INT_LEAST32_MAX__ 0x7fffffff
+#define __INT_LEAST32_TYPE__ int
+#define __INT_LEAST32_WIDTH__ 32
+#define __INT_LEAST64_MAX__ 0x7fffffffffffffffL
+#define __INT_LEAST64_TYPE__ long int
+#define __INT_LEAST64_WIDTH__ 64
+#define __INT_LEAST8_MAX__ 0x7f
+#define __INT_LEAST8_TYPE__ signed char
+#define __INT_LEAST8_WIDTH__ 8
+#define __INT_MAX__ 0x7fffffff
+#define __INTMAX_C(c) c ## L
+#define __INTMAX_MAX__ 0x7fffffffffffffffL
+#define __INTMAX_TYPE__ long int
+#define __INTMAX_WIDTH__ 64
+#define __INTPTR_MAX__ 0x7fffffffffffffffL
+#define __INTPTR_TYPE__ long int
+#define __INTPTR_WIDTH__ 64
+#define __INT_WIDTH__ 32
+#define __LDBL_DECIMAL_DIG__ 36
+#define __LDBL_DENORM_MIN__ 6.47517511943802511092443895822764655e-4966L
+#define __LDBL_DIG__ 33
+#define __LDBL_EPSILON__ 1.92592994438723585305597794258492732e-34L
+#define __LDBL_HAS_DENORM__ 1
+#define __LDBL_HAS_INFINITY__ 1
+#define __LDBL_HAS_QUIET_NAN__ 1
+#define __LDBL_IS_IEC_60559__ 1
+#define __LDBL_MANT_DIG__ 113
+#define __LDBL_MAX_10_EXP__ 4932
+#define __LDBL_MAX__ 1.18973149535723176508575932662800702e+4932L
+#define __LDBL_MAX_EXP__ 16384
+#define __LDBL_MIN_10_EXP__ (-4931)
+#define __LDBL_MIN__ 3.36210314311209350626267781732175260e-4932L
+#define __LDBL_MIN_EXP__ (-16381)
+#define __LDBL_NORM_MAX__ 1.18973149535723176508575932662800702e+4932L
+#define __linux 1
+#define __linux__ 1
+#define linux 1
+#define __LONG_LONG_MAX__ 0x7fffffffffffffffLL
+#define __LONG_LONG_WIDTH__ 64
+#define __LONG_MAX__ 0x7fffffffffffffffL
+#define __LONG_WIDTH__ 64
+#define __LP64__ 1
+#define _LP64 1
+#define __NO_INLINE__ 1
+#define __ORDER_BIG_ENDIAN__ 4321
+#define __ORDER_LITTLE_ENDIAN__ 1234
+#define __ORDER_PDP_ENDIAN__ 3412
+#define __pic__ 2
+#define __PIC__ 2
+#define __pie__ 2
+#define __PIE__ 2
+#define __PRAGMA_REDEFINE_EXTNAME 1
+#define __PTRDIFF_MAX__ 0x7fffffffffffffffL
+#define __PTRDIFF_TYPE__ long int
+#define __PTRDIFF_WIDTH__ 64
+#define __REGISTER_PREFIX__ 
+#define __SCHAR_MAX__ 0x7f
+#define __SCHAR_WIDTH__ 8
+#define __SHRT_MAX__ 0x7fff
+#define __SHRT_WIDTH__ 16
+#define __SIG_ATOMIC_MAX__ 0x7fffffff
+#define __SIG_ATOMIC_MIN__ (-__SIG_ATOMIC_MAX__ - 1)
+#define __SIG_ATOMIC_TYPE__ int
+#define __SIG_ATOMIC_WIDTH__ 32
+#define __SIZE_MAX__ 0xffffffffffffffffUL
+#define __SIZEOF_DOUBLE__ 8
+#define __SIZEOF_FLOAT__ 4
+#define __SIZEOF_INT128__ 16
+#define __SIZEOF_INT__ 4
+#define __SIZEOF_LONG__ 8
+#define __SIZEOF_LONG_DOUBLE__ 16
+#define __SIZEOF_LONG_LONG__ 8
+#define __SIZEOF_POINTER__ 8
+#define __SIZEOF_PTRDIFF_T__ 8
+#define __SIZEOF_SHORT__ 2
+#define __SIZEOF_SIZE_T__ 8
+#define __SIZEOF_WCHAR_T__ 4
+#define __SIZEOF_WINT_T__ 4
+#define __SIZE_TYPE__ long unsigned int
+#define __SIZE_WIDTH__ 64
+#define __STDC__ 1
+#define __STDC_HOSTED__ 1
+#define __STDC_IEC_559__ 1
+#define __STDC_IEC_559_COMPLEX__ 1
+#define __STDC_IEC_60559_BFP__ 201404L
+#define __STDC_IEC_60559_COMPLEX__ 201404L
+#define __STDC_ISO_10646__ 201706L
+#define _STDC_PREDEF_H 1
+#define __STDC_UTF_16__ 1
+#define __STDC_UTF_32__ 1
+#define __STDC_VERSION__ 201710L
+#define __UINT16_C(c) c
+#define __UINT16_MAX__ 0xffff
+#define __UINT16_TYPE__ short unsigned int
+#define __UINT32_C(c) c ## U
+#define __UINT32_MAX__ 0xffffffffU
+#define __UINT32_TYPE__ unsigned int
+#define __UINT64_C(c) c ## UL
+#define __UINT64_MAX__ 0xffffffffffffffffUL
+#define __UINT64_TYPE__ long unsigned int
+#define __UINT8_C(c) c
+#define __UINT8_MAX__ 0xff
+#define __UINT8_TYPE__ unsigned char
+#define __UINT_FAST16_MAX__ 0xffffffffffffffffUL
+#define __UINT_FAST16_TYPE__ long unsigned int
+#define __UINT_FAST32_MAX__ 0xffffffffffffffffUL
+#define __UINT_FAST32_TYPE__ long unsigned int
+#define __UINT_FAST64_MAX__ 0xffffffffffffffffUL
+#define __UINT_FAST64_TYPE__ long unsigned int
+#define __UINT_FAST8_MAX__ 0xff
+#define __UINT_FAST8_TYPE__ unsigned char
+#define __UINT_LEAST16_MAX__ 0xffff
+#define __UINT_LEAST16_TYPE__ short unsigned int
+#define __UINT_LEAST32_MAX__ 0xffffffffU
+#define __UINT_LEAST32_TYPE__ unsigned int
+#define __UINT_LEAST64_MAX__ 0xffffffffffffffffUL
+#define __UINT_LEAST64_TYPE__ long unsigned int
+#define __UINT_LEAST8_MAX__ 0xff
+#define __UINT_LEAST8_TYPE__ unsigned char
+#define __UINTMAX_C(c) c ## UL
+#define __UINTMAX_MAX__ 0xffffffffffffffffUL
+#define __UINTMAX_TYPE__ long unsigned int
+#define __UINTPTR_MAX__ 0xffffffffffffffffUL
+#define __UINTPTR_TYPE__ long unsigned int
+#define __unix 1
+#define __unix__ 1
+#define unix 1
+#define __USER_LABEL_PREFIX__ 
+#define __VERSION__ "14.2.0"
+#define __WCHAR_MAX__ 0xffffffffU
+#define __WCHAR_MIN__ 0U
+#define __WCHAR_TYPE__ unsigned int
+#define __WCHAR_WIDTH__ 32
+#define __WINT_MAX__ 0xffffffffU
+#define __WINT_MIN__ 0U
+#define __WINT_TYPE__ unsigned int
+#define __WINT_WIDTH__ 32

--- a/wrapperhelper/src/cstring.c
+++ b/wrapperhelper/src/cstring.c
@@ -98,6 +98,16 @@ int string_add_char(string_t *s, char elem) {
 	return 1;
 }
 
+int string_add_char_at(string_t *s, char elem, size_t idx) {
+	if (idx == s->ssize) return string_add_char(s, elem);
+	if (idx > s->ssize) return 0;
+	if (!string_reserve_grow(s, s->ssize + 1)) return 0;
+	memmove(s->buf + idx + 1, s->buf + idx, s->ssize + 1 - idx);
+	++s->ssize;
+	s->buf[idx] = elem;
+	return 1;
+}
+
 int string_add_string(string_t *s1, string_t *s2) {
 	if (!string_reserve_grow(s1, s1->ssize + s2->ssize)) return 0;
 	memcpy(s1->buf + s1->ssize, s2->buf, s2->ssize);

--- a/wrapperhelper/src/cstring.h
+++ b/wrapperhelper/src/cstring.h
@@ -19,6 +19,7 @@
  * string_del ---------- Frees a string. Takes the string.
  * string_steal -------- Frees a string, keeping the content alive. Takes the string. The content (also returned) needs to be freed separately.
  * string_add_char ----- Add a character at the end. Takes the string and the new character. May increase the string capacity.
+ * string_add_char_at -- Add a character at a given index. Takes the string, the new character and the index. May increase the string capacity.
  * string_add_string --- Add a string at the end in-place. Takes both strings. May increase the string capacity.
  * string_add_cstr ----- Add a C string at the end in-place. Takes both strings. May increase the string capacity.
  * string_pop ---------- Pops the last character. Takes the string. May reduce the string capacity.
@@ -68,6 +69,7 @@ int       string_trim(string_t *s);
 void      string_del(string_t *s);
 char     *string_steal(string_t *s);
 int       string_add_char(string_t *s, char elem);
+int       string_add_char_at(string_t *s, char elem, size_t idx);
 int       string_add_string(string_t *s1, string_t *s2);
 int       string_add_cstr(string_t *s1, const char *s2);
 void      string_pop(string_t *s);

--- a/wrapperhelper/src/generator.h
+++ b/wrapperhelper/src/generator.h
@@ -57,8 +57,8 @@ void references_print_check(const VECTOR(references) *refs);
 void output_from_references(FILE *f, const VECTOR(references) *reqs);
 
 VECTOR(references) *references_from_file(const char *filename, FILE *f); // Takes ownership of f
-int solve_request(request_t *req, type_t *typ);
-int solve_request_map(request_t *req, khash_t(type_map) *decl_map);
-int solve_references(VECTOR(references) *reqs, khash_t(type_map) *decl_map);
+int solve_request(request_t *req, type_t *typ, khash_t(conv_map) *conv_map);
+int solve_request_map(request_t *req, khash_t(decl_map) *decl_map, khash_t(conv_map) *conv_map);
+int solve_references(VECTOR(references) *reqs, khash_t(decl_map) *decl_map, khash_t(conv_map) *conv_map);
 
 #endif // GENERATOR_H

--- a/wrapperhelper/src/lang.c
+++ b/wrapperhelper/src/lang.c
@@ -84,7 +84,9 @@ void proc_token_del(proc_token_t *tok) {
 		break;
 	case PTOK_PRAGMA:
 		switch (tok->tokv.pragma.typ) {
+		case PRAGMA_SIMPLE_SU:
 		case PRAGMA_EXPLICIT_CONV:
+		case PRAGMA_EXPLICIT_CONV_STRICT:
 			string_del(tok->tokv.pragma.val);
 			break;
 		case PRAGMA_ALLOW_INTS:
@@ -289,8 +291,14 @@ void proc_token_print(const proc_token_t *tok) {
 		case PRAGMA_ALLOW_INTS:
 			printf("Token: %7s Allow ints\n", "PRAGMA");
 			break;
+		case PRAGMA_SIMPLE_SU:
+			printf("Token: %7s Mark simple: struct or union %s is simple\n", "PRAGMA", string_content(tok->tokv.pragma.val));
+			break;
 		case PRAGMA_EXPLICIT_CONV:
-			printf("Token: %7s Explicit conversion: destination is %s\n", "PRAGMA", string_content(tok->tokv.pragma.val));
+			printf("Token: %7s Relaxed explicit conversion: destination is %s\n", "PRAGMA", string_content(tok->tokv.pragma.val));
+			break;
+		case PRAGMA_EXPLICIT_CONV_STRICT:
+			printf("Token: %7s Strict explicit conversion: destination is %s\n", "PRAGMA", string_content(tok->tokv.pragma.val));
 			break;
 		default:
 			printf("Token: %7s ???\n", "PRAGMA");
@@ -340,6 +348,7 @@ int proc_token_isend(const proc_token_t *tok) {
 #pragma GCC diagnostic ignored "-Wanalyzer-null-dereference"
 KHASH_MAP_IMPL_STR(str2kw, enum token_keyword_type_e)
 KHASH_MAP_IMPL_STR(type_map, type_t*)
+KHASH_MAP_IMPL_STR(decl_map, declaration_t*)
 KHASH_MAP_IMPL_STR(struct_map, struct_t*)
 KHASH_MAP_IMPL_STR(const_map, num_constant_t)
 #pragma GCC diagnostic pop
@@ -622,11 +631,21 @@ void type_map_del(khash_t(type_map) *map) {
 #pragma GCC diagnostic pop
 	kh_destroy(type_map, map);
 }
+void conv_map_del(khash_t(conv_map) *map) {
+	type_t *typ;
+	string_t **conv;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+	kh_foreach_key_value_ref(map, typ, conv, type_del(typ); string_del(*conv))
+#pragma GCC diagnostic pop
+	kh_destroy(conv_map, map);
+}
 void type_set_del(khash_t(type_set) *set) {
 	type_t *it;
 	kh_foreach_key(set, it, type_del(it))
 	kh_destroy(type_set, set);
 }
+
 void const_map_del(khash_t(const_map) *map) {
 	kh_cstr_t str;
 #pragma GCC diagnostic push
@@ -634,6 +653,20 @@ void const_map_del(khash_t(const_map) *map) {
 	kh_foreach_key(map, str, free((void*)str))
 #pragma GCC diagnostic pop
 	kh_destroy(const_map, map);
+}
+
+void decl_del(declaration_t *decl) {
+	type_del(decl->typ);
+	free(decl);
+}
+void decl_map_del(khash_t(decl_map) *map) {
+	kh_cstr_t str;
+	declaration_t **it;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+	kh_foreach_key_value_ref(map, str, it, free((void*)str); decl_del(*it))
+#pragma GCC diagnostic pop
+	kh_destroy(decl_map, map);
 }
 
 void st_member_del(st_member_t *member) {
@@ -693,49 +726,6 @@ type_t *type_new_ptr(type_t *target) {
 	ret->val.typ = target;
 	return ret;
 }
-// The following functions do not work for functions (val.args needs to be duplicated)
-/* type_t *type_do_copy(type_t *ref) {
-	type_t *ret = type_do_copy_nodec(ref);
-	if (!ret) return NULL;
-	type_del(ref);
-	return ret;
-}
-type_t *type_do_copy_nodec(const type_t *ref) {
-	type_t *ret = malloc(sizeof *ret);
-	if (!ret) {
-		printf("Failed to duplicate type\n");
-		return NULL;
-	}
-	memcpy(ret, ref, sizeof *ret);
-	switch (ref->typ) {
-	case TYPE_BUILTIN:
-		break;
-	case TYPE_ARRAY:
-		++ref->val.array.typ->nrefs;
-		break;
-	case TYPE_STRUCT_UNION:
-		++ret->val.st->nrefs;
-		break;
-	case TYPE_ENUM:
-	case TYPE_PTR:
-		++ref->val.typ->nrefs;
-		break;
-	case TYPE_FUNCTION:
-		++ref->val.fun.ret->nrefs;
-		if (ref->val.fun.nargs != (size_t)-1) {
-			for (size_t i = 0; i < ref->val.fun.nargs; ++i) {
-				++ref->val.fun.args[i]->nrefs;
-			}
-		}
-		break;
-	}
-	ret->nrefs = 1;
-	return ret;
-}
-type_t *type_maybe_copy(type_t *ref) {
-	if (ref->nrefs == 1) return ref;
-	else return type_do_copy(ref);
-} */
 int type_copy_into(type_t *dest, const type_t *ref) {
 	size_t nrefs = dest->nrefs;
 	_Bool is_atomic = dest->is_atomic;
@@ -825,12 +815,8 @@ khint_t type_t_hash(type_t *typ) {
 	default: return 0;
 	}
 }
-int type_t_equal(type_t *typ1, type_t *typ2) {
+int type_t_equal_lax(type_t *typ1, type_t *typ2) {
 	if (typ1->typ != typ2->typ) return 0;
-	if ((typ1->is_atomic != typ2->is_atomic) || (typ1->is_const != typ2->is_const)
-	 || (typ1->is_restrict != typ2->is_restrict) || (typ1->is_volatile != typ2->is_volatile)) {
-		return 0;
-	}
 	switch (typ1->typ) {
 	case TYPE_BUILTIN: return typ1->val.builtin == typ2->val.builtin;
 	case TYPE_ARRAY: return (typ1->val.array.array_sz == typ2->val.array.array_sz) && type_t_equal(typ1->val.array.typ, typ2->val.array.typ);
@@ -867,7 +853,15 @@ int type_t_equal(type_t *typ1, type_t *typ2) {
 	default: return 0;
 	}
 }
+int type_t_equal(type_t *typ1, type_t *typ2) {
+	if ((typ1->is_atomic != typ2->is_atomic) || (typ1->is_const != typ2->is_const)
+	 || (typ1->is_restrict != typ2->is_restrict) || (typ1->is_volatile != typ2->is_volatile)) {
+		return 0;
+	}
+	return type_t_equal_lax(typ1, typ2);
+}
 __KHASH_IMPL(type_set, , type_t*, char, 0, type_t_hash, type_t_equal)
+__KHASH_IMPL(conv_map, , type_t*, string_t*, 1, type_t_hash, type_t_equal_lax)
 
 type_t *type_try_merge(type_t *typ, khash_t(type_set) *set) {
 	int iret;
@@ -1026,6 +1020,9 @@ void type_print(type_t *typ) {
 }
 void struct_print(const struct_t *st) {
 	printf("<" DISP_ADDR_FMT "n_uses=%zu> ", DISP_ADDR_ARG(st) st->nrefs);
+	if (st->is_simple) {
+		printf("<simple> ");
+	}
 	if (st->is_defined) {
 		printf(
 			"%s %s <with %zu members%s> { ",
@@ -1071,7 +1068,7 @@ file_t *file_new(machine_t *target) {
 		free(ret);
 		return NULL;
 	}
-	if (!(ret->decl_map = kh_init(type_map))) {
+	if (!(ret->decl_map = kh_init(decl_map))) {
 		printf("Failed to create a new translation unit structure (declaration map)\n");
 		kh_destroy(struct_map, ret->struct_map);
 		kh_destroy(type_map, ret->type_map);
@@ -1084,7 +1081,7 @@ file_t *file_new(machine_t *target) {
 		kh_destroy(struct_map, ret->struct_map);
 		kh_destroy(type_map, ret->type_map);
 		kh_destroy(type_map, ret->enum_map);
-		kh_destroy(type_map, ret->decl_map);
+		kh_destroy(decl_map, ret->decl_map);
 		free(ret);
 		return NULL;
 	}
@@ -1093,8 +1090,19 @@ file_t *file_new(machine_t *target) {
 		kh_destroy(struct_map, ret->struct_map);
 		kh_destroy(type_map, ret->type_map);
 		kh_destroy(type_map, ret->enum_map);
-		kh_destroy(type_map, ret->decl_map);
+		kh_destroy(decl_map, ret->decl_map);
 		kh_destroy(type_set, ret->type_set);
+		free(ret);
+		return NULL;
+	}
+	if (!(ret->relaxed_type_conversion = kh_init(conv_map))) {
+		printf("Failed to create a new translation unit structure (relaxed type conversion map)\n");
+		kh_destroy(struct_map, ret->struct_map);
+		kh_destroy(type_map, ret->type_map);
+		kh_destroy(type_map, ret->enum_map);
+		kh_destroy(decl_map, ret->decl_map);
+		kh_destroy(type_set, ret->type_set);
+		kh_destroy(const_map, ret->const_map);
 		free(ret);
 		return NULL;
 	}
@@ -1110,8 +1118,9 @@ file_t *file_new(machine_t *target) {
 			}
 			kh_destroy(struct_map, ret->struct_map);
 			kh_destroy(type_map, ret->type_map);
+			kh_destroy(conv_map, ret->relaxed_type_conversion);
 			kh_destroy(type_map, ret->enum_map);
-			kh_destroy(type_map, ret->decl_map);
+			kh_destroy(decl_map, ret->decl_map);
 			kh_destroy(type_set, ret->type_set);
 			kh_destroy(const_map, ret->const_map);
 			free(ret);
@@ -1128,8 +1137,9 @@ file_t *file_new(machine_t *target) {
 			printf("Failed to create a new translation unit structure (failed to add intrinsic type to type_set)\n");
 			kh_destroy(struct_map, ret->struct_map);
 			kh_destroy(type_map, ret->type_map);
+			kh_destroy(conv_map, ret->relaxed_type_conversion);
 			kh_destroy(type_map, ret->enum_map);
-			kh_destroy(type_map, ret->decl_map);
+			kh_destroy(decl_map, ret->decl_map);
 			kh_destroy(type_set, ret->type_set);
 			kh_destroy(const_map, ret->const_map);
 			free(ret);
@@ -1141,15 +1151,16 @@ file_t *file_new(machine_t *target) {
 			}
 			kh_destroy(struct_map, ret->struct_map);
 			kh_destroy(type_map, ret->type_map);
+			kh_destroy(conv_map, ret->relaxed_type_conversion);
 			kh_destroy(type_map, ret->enum_map);
-			kh_destroy(type_map, ret->decl_map);
+			kh_destroy(decl_map, ret->decl_map);
 			kh_destroy(type_set, ret->type_set);
 			kh_destroy(const_map, ret->const_map);
 			free(ret);
 			return NULL;
 		}
 	}
-	// ret is valid
+	// ret is valid and can now be deleted by file_del
 	
 	// Add __builtin_va_list, __int128_t, __uint128_t as typedef
 	char *sdup;
@@ -1183,8 +1194,9 @@ file_t *file_new(machine_t *target) {
 void file_del(file_t *f) {
 	struct_map_del(f->struct_map);
 	type_map_del(f->type_map);
+	conv_map_del(f->relaxed_type_conversion);
 	type_map_del(f->enum_map);
-	type_map_del(f->decl_map);
+	decl_map_del(f->decl_map);
 	type_set_del(f->type_set);
 	const_map_del(f->const_map);
 	for (enum type_builtin_e i = 0; i < LAST_BUILTIN + 1; ++i) {

--- a/wrapperhelper/src/main.c
+++ b/wrapperhelper/src/main.c
@@ -139,7 +139,7 @@ int main(int argc, char **argv) {
 			return 2;
 		}
 		// vector_for(references, req, refs) request_print(req);
-		if (!solve_references(refs, content->decl_map)) {
+		if (!solve_references(refs, content->decl_map, content->relaxed_type_conversion)) {
 			printf("Warning: failed to solve all default requests\n");
 		}
 		// vector_for(references, req, refs) request_print(req);
@@ -171,7 +171,9 @@ int main(int argc, char **argv) {
 		// print content
 		const char *name;
 		struct_t *st;
+		string_t *str;
 		type_t *typ;
+		declaration_t *decl;
 		num_constant_t cst;
 		/* for (enum type_builtin_e i = 0; i < LAST_BUILTIN; ++i) {
 			printf("Builtin %u: %p, ", i, content->builtins[i]);
@@ -187,6 +189,9 @@ int main(int argc, char **argv) {
 			printf("Type: %p = ", typ);
 			type_print(typ);
 			printf("\n")
+		)
+		kh_foreach(content->relaxed_type_conversion, typ, str,
+			printf("Type conversion: %p -> %s\n", typ, string_content(str));
 		)
 		kh_foreach(content->type_map, name, typ,
 			printf("Typedef: %s -> %p = ", name, typ);
@@ -211,9 +216,9 @@ int main(int argc, char **argv) {
 			}
 			printf("\n")
 		)
-		kh_foreach(content->decl_map, name, typ,
-			printf("Declaration: %s -> %p = ", name, typ);
-			type_print(typ);
+		kh_foreach(content->decl_map, name, decl,
+			printf("Declaration: %s -> %p = %u/%p: ", name, decl, decl->storage, decl->typ);
+			type_print(decl->typ);
 			printf("\n")
 		)
 		file_del(content);

--- a/wrapperhelper/src/preproc.c
+++ b/wrapperhelper/src/preproc.c
@@ -2794,6 +2794,28 @@ start_cur_token:
 							ret.tokv.pragma.typ = PRAGMA_ALLOW_INTS;
 							return ret;
 						}
+					} else if (!strcmp(string_content(tok.tokv.str), "mark_simple")) {
+						string_del(tok.tokv.str);
+						tok = ppsrc_next_token(src);
+						if ((tok.tokt != PPTOK_IDENT) && (tok.tokt != PPTOK_IDENT_UNEXP)) {
+							printf("Invalid pragma wrappers explicit_simple directive, skipping until EOL\n");
+							goto preproc_hash_err;
+						}
+						src->st = PPST_NL;
+						ret.tokt = PTOK_PRAGMA;
+						ret.tokv.pragma.typ = PRAGMA_SIMPLE_SU;
+						ret.tokv.pragma.val = tok.tokv.str;
+						tok = ppsrc_next_token(src);
+						while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_INVALID)) {
+							preproc_token_del(&tok);
+							tok = ppsrc_next_token(src);
+						}
+						if (tok.tokt == PPTOK_INVALID) {
+							string_del(ret.tokv.pragma.val);
+							goto start_cur_token;
+						} else {
+							return ret;
+						}
 					} else if (!strcmp(string_content(tok.tokv.str), "type_letters")) {
 						string_del(tok.tokv.str);
 						tok = ppsrc_next_token(src);
@@ -2804,6 +2826,18 @@ start_cur_token:
 						src->st = PPST_PRAGMA_EXPLICIT;
 						ret.tokt = PTOK_PRAGMA;
 						ret.tokv.pragma.typ = PRAGMA_EXPLICIT_CONV;
+						ret.tokv.pragma.val = tok.tokv.str;
+						return ret;
+					} else if (!strcmp(string_content(tok.tokv.str), "type_letters_exact")) {
+						string_del(tok.tokv.str);
+						tok = ppsrc_next_token(src);
+						if ((tok.tokt != PPTOK_IDENT) && (tok.tokt != PPTOK_IDENT_UNEXP)) {
+							printf("Invalid pragma wrappers explicit_simple directive, skipping until EOL\n");
+							goto preproc_hash_err;
+						}
+						src->st = PPST_PRAGMA_EXPLICIT;
+						ret.tokt = PTOK_PRAGMA;
+						ret.tokv.pragma.typ = PRAGMA_EXPLICIT_CONV_STRICT;
 						ret.tokv.pragma.val = tok.tokv.str;
 						return ret;
 					} else {


### PR DESCRIPTION
This PR:
- adds a file specific to ARM64 (to be revisited), with the list of all predefined macros;
- fixes a fatal error when an argument of a function, other than the last one, is an array;
- adds back explicitly simple structures;
- adds strict conversion and changes `type_letters` to be relaxed conversion (which doesn't care about qualifiers);
- change the default behaviour on the generator to always add an `E` character when the function is a `GO[W]M`;
- adds more supported casts in expression evaluation;
- removes "Warning: '...' is already in the declaration map with the same type"