### PR TITLE
[WRAPPERHELPER] Added predefined mark-simple and conversions

### DIFF
--- a/wrapperhelper/example-libc.h
+++ b/wrapperhelper/example-libc.h
@@ -128,9 +128,3 @@
 #include <wchar.h>
 #include <wctype.h>
 #include <wordexp.h>
-
-#pragma wrappers type_letters S FILE*
-#pragma wrappers mark_simple FTS
-#pragma wrappers mark_simple FTS64
-#pragma wrappers mark_simple glob_t
-#pragma wrappers mark_simple glob64_t


### PR DESCRIPTION
This PR moves the `#pragma wrappers` in `example-libc.h` into the `parse.c` file, i.e. adds predefined mark-simple structures (`glob_t`...) and conversions (`FILE*` is `S`, `xcb_connection_t*` is `b`).