### PR TITLE
[ARM64_DYNAREC] Fixed sse_forget_reg function

### DIFF
--- a/src/dynarec/arm64/dynarec_arm64_helper.c
+++ b/src/dynarec/arm64/dynarec_arm64_helper.c
@@ -1660,12 +1660,11 @@ void sse_forget_reg(dynarec_arm_t* dyn, int ninst, int a)
             STRx_U12(xZR, xEmu, offsetof(x64emu_t, ymm[a]));
             STRx_U12(xZR, xEmu, offsetof(x64emu_t, ymm[a])+8);
         }
-    } else for(int i=0; i<32; ++i)
-        if(((dyn->n.neoncache[i].t == NEON_CACHE_YMMW) || (dyn->n.neoncache[i].t == NEON_CACHE_YMMR)) && (dyn->n.neoncache[i].n==a)) {
-            if(dyn->n.neoncache[i].t == NEON_CACHE_YMMW)
-                VSTR128_U12(i, xEmu, offsetof(x64emu_t, ymm[dyn->n.neoncache[i].n]));
-            fpu_free_reg(dyn, i);
-
+    } else {
+        if(dyn->n.neoncache[dyn->n.ssecache[a].reg].t == NEON_CACHE_XMMW || dyn->n.neoncache[dyn->n.ssecache[a].reg].t == NEON_CACHE_YMMR) {
+            if(dyn->n.neoncache[dyn->n.ssecache[a].reg].t == NEON_CACHE_YMMW)
+                VSTR128_U12(dyn->n.ssecache[a].reg, xEmu, offsetof(x64emu_t, ymm[dyn->n.neoncache[dyn->n.ssecache[a].reg].n]));
+        }
     }
     fpu_free_reg(dyn, dyn->n.ssecache[a].reg);
     dyn->n.ssecache[a].v = -1;


### PR DESCRIPTION
If sse and neon are mapped one-to-one, is it possible not to use a for loop?