### PR TITLE
[WRAPPERHELPER] Forgot to add the Makefile

### DIFF
--- a/wrapperhelper/Makefile
+++ b/wrapperhelper/Makefile
@@ -226,6 +226,7 @@ endef
 $(eval $(call compile_wrapperhelper_c,,cstring,cstring))
 $(eval $(call compile_wrapperhelper_c,,generator,generator))
 $(eval $(call compile_wrapperhelper_c,,lang,lang))
+$(eval $(call compile_wrapperhelper_c,,log,log))
 $(eval $(call compile_wrapperhelper_c,,machine,machine))
 $(eval $(call compile_wrapperhelper_c,,main,main))
 $(eval $(call compile_wrapperhelper_c,,parse,parse))

--- a/wrapperhelper/Makefile
+++ b/wrapperhelper/Makefile
@@ -234,6 +234,7 @@ $(eval $(call compile_wrapperhelper_c,,prepare,prepare))
 $(eval $(call compile_wrapperhelper_c,,preproc,preproc))
 $(eval $(call compile_wrapperhelper_c,,vector,vector))
 $(call wrapperhelper_o,,machine,machine): src/machine.gen
+$(call wrapperhelper_o,,generator,generator): CFLAGS+= -fno-analyzer # Too slow
 $(call wrapperhelper_o,,preproc,preproc): CFLAGS+= -fno-analyzer
 $(call wrapperhelper_o,,parse,parse): CFLAGS+= -fno-analyzer
 


### PR DESCRIPTION
This PR updates the `wrapperhelper/Makefile` to also include `log.c`, and remove the analysis of the generator file which speeds up build time.