### PR TITLE
[DYNAREC] Tweaking indirect jumps for CALL/RET to use the return address stack

### DIFF
--- a/src/dynarec/arm64/arm64_emitter.h
+++ b/src/dynarec/arm64/arm64_emitter.h
@@ -505,6 +505,7 @@ int convert_bitmask(uint64_t bitmask);
 #define BR_gen(Z, op, A, M, Rn, Rm)       (0b1101011<<25 | (Z)<<24 | (op)<<21 | 0b11111<<16 | (A)<<11 | (M)<<10 | (Rn)<<5 | (Rm))
 #define BR(Rn)                            EMIT(BR_gen(0, 0b00, 0, 0, Rn, 0))
 #define BLR(Rn)                           EMIT(BR_gen(0, 0b01, 0, 0, Rn, 0))
+#define RET(Rn)                           EMIT(BR_gen(0, 0b10, 0, 0, Rn, 0))
 
 #define CB_gen(sf, op, imm19, Rt)       ((sf)<<31 | 0b011010<<25 | (op)<<24 | (imm19)<<5 | (Rt))
 #define CBNZx(Rt, imm19)                EMIT(CB_gen(1, 1, ((imm19)>>2)&0x7FFFF, Rt))

--- a/src/dynarec/la64/dynarec_la64_helper.c
+++ b/src/dynarec/la64/dynarec_la64_helper.c
@@ -571,7 +571,7 @@ void jump_to_next(dynarec_la64_t* dyn, uintptr_t ip, int reg, int ninst, int is3
 // MOVx(x3, 15);    no access to PC reg
 #endif
     SMEND();
-    JIRL(xRA, x2, 0x0); // save LR...
+    JIRL((dyn->insts[ninst].x64.has_callret ? xRA : xZR), x2, 0x0); // save LR...
 }
 
 void ret_to_epilog(dynarec_la64_t* dyn, int ninst, rex_t rex)
@@ -584,11 +584,11 @@ void ret_to_epilog(dynarec_la64_t* dyn, int ninst, rex_t rex)
     SMEND();
     if (box64_dynarec_callret) {
         // pop the actual return address from RV64 stack
-        LD_D(x2, xSP, 0);     // native addr
+        LD_D(xRA, xSP, 0);     // native addr
         LD_D(x6, xSP, 8);     // x86 addr
         ADDI_D(xSP, xSP, 16); // pop
         BNE(x6, xRIP, 2 * 4); // is it the right address?
-        BR(x2);
+        BR(xRA);
         // not the correct return address, regular jump, but purge the stack first, it's unsync now...
         ADDI_D(xSP, xSavedSP, -16);
     }
@@ -609,7 +609,7 @@ void ret_to_epilog(dynarec_la64_t* dyn, int ninst, rex_t rex)
     BSTRPICK_D(x2, xRIP, JMPTABL_START0 + JMPTABL_SHIFT0 - 1, JMPTABL_START0);
     ALSL_D(x3, x2, x3, 3);
     LD_D(x2, x3, 0);
-    BR(x2); // save LR
+    BR(x2);
     CLEARIP();
 }
 
@@ -629,11 +629,11 @@ void retn_to_epilog(dynarec_la64_t* dyn, int ninst, rex_t rex, int n)
     SMEND();
     if (box64_dynarec_callret) {
         // pop the actual return address from RV64 stack
-        LD_D(x2, xSP, 0);     // native addr
+        LD_D(xRA, xSP, 0);     // native addr
         LD_D(x6, xSP, 8);     // x86 addr
         ADDI_D(xSP, xSP, 16); // pop
         BNE(x6, xRIP, 2 * 4); // is it the right address?
-        BR(x2);
+        BR(xRA);
         // not the correct return address, regular jump, but purge the stack first, it's unsync now...
         ADDI_D(xSP, xSavedSP, -16);
     }
@@ -654,7 +654,7 @@ void retn_to_epilog(dynarec_la64_t* dyn, int ninst, rex_t rex, int n)
     BSTRPICK_D(x2, xRIP, JMPTABL_START0 + JMPTABL_SHIFT0 - 1, JMPTABL_START0);
     ALSL_D(x3, x2, x3, 3);
     LD_D(x2, x3, 0);
-    BR(x2); // save LR
+    BR(x2);
     CLEARIP();
 }
 

--- a/src/dynarec/rv64/rv64_emitter.h
+++ b/src/dynarec/rv64/rv64_emitter.h
@@ -157,9 +157,9 @@ f28–31  ft8–11  FP temporaries                  Caller
 // Unconditionnal branch to r+i12, no return address set
 #define BR_I12(r, imm12) EMIT(JALR_gen(xZR, r, (imm12) & 0b111111111111))
 // Unconditionnal branch to r, return address set to xRA
-#define JALR(r) EMIT(JALR_gen(xRA, r, 0))
+#define JALR(rd, rs) EMIT(JALR_gen(rd, rs, 0))
 // Unconditionnal branch to r+i12, return address set to xRA
-#define JALR_I12(r, imm12) EMIT(JALR_gen(xRA, r, (imm12) & 0b111111111111))
+#define JALR_I12(rd, rs, imm12) EMIT(JALR_gen(rd, rs, (imm12) & 0b111111111111))
 
 // rd = rs1 + imm12
 #define ADDI(rd, rs1, imm12) EMIT(I_type((imm12) & 0b111111111111, rs1, 0b000, rd, 0b0010011))


### PR DESCRIPTION
This PR pushed the CALL/RET optimization even further. The idea is to utilize the Return Address Stack or RAS in the hardware.

For example, on AArch64, for x86 `CALL`, emit `BLR`, and for x86 `RET`, emit `RET LR`. This would hint the hardware to push the return address onto the RAS for x86 `CALL` and pop and compare the return address for x86 `RET`.

Other changes are there to prevent unrelated indirect jumps from polluting the RAS.