### PR TITLE
Fix compilation error in my_x11_xevent.c (#1938) and  dynarec_rv64_helper.c

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_helper.c
+++ b/src/dynarec/rv64/dynarec_rv64_helper.c
@@ -2694,11 +2694,12 @@ void vector_loadmask(dynarec_rv64_t* dyn, int ninst, int vreg, uint64_t imm, int
                     ADDI(s1, xZR, 1);
                     VMV_S_X(vreg, s1);
                     return;
-                case 2:
+                case 2: {
                     int scratch = fpu_get_scratch(dyn);
                     VMV_V_I(scratch, 1);
                     VSLIDE1UP_VX(vreg, scratch, xZR, VECTOR_UNMASKED);
                     return;
+                }
                 case 3:
                     VMV_V_I(vreg, 1);
                     return;

--- a/src/libtools/my_x11_xevent.c
+++ b/src/libtools/my_x11_xevent.c
@@ -256,7 +256,7 @@ void convertXEvent(my_XEvent_32_t* dst, my_XEvent_t* src)
             dst->xcookie.cookie = src->xcookie.cookie;
             dst->xcookie.data = to_ptrv_silent(src->xcookie.data);  // in case data are not initialized
             break;
-        default:
+        default: {
             register_events_t* head = register_events_head;
             while(head) {
                 if(type>=head->start_event && type<=head->end_event) {
@@ -269,6 +269,7 @@ void convertXEvent(my_XEvent_32_t* dst, my_XEvent_t* src)
                 head = head->next;
             }
             printf_log(LOG_INFO, "Warning, unsupported 32bits XEvent type=%d\n", type);
+        }    
     }
 }
 void unconvertXEvent(my_XEvent_t* dst, my_XEvent_32_t* src)
@@ -492,7 +493,7 @@ void unconvertXEvent(my_XEvent_t* dst, my_XEvent_32_t* src)
             dst->xcookie.data = from_ptrv(src->xcookie.data);
             break;
 
-        default:
+        default: {
             register_events_t* head = register_events_head;
             while(head) {
                 if(type>=head->start_event && type<=head->end_event) {
@@ -505,6 +506,7 @@ void unconvertXEvent(my_XEvent_t* dst, my_XEvent_32_t* src)
                 head = head->next;
             }
             printf_log(LOG_INFO, "Warning, unsupported 32bits (un)XEvent type=%d\n", type);
+        }
     }
 }
 


### PR DESCRIPTION
Resolved a compilation error due to variable declaration within a switch-case statement without enclosing braces. 
This error occurred with older GCC compilers, which require declarations to be part of a block within switch-case constructs.


