### PR TITLE
[WRAPPERHELPER] Better wrapper helper

### DIFF
--- a/wrapperhelper/Makefile
+++ b/wrapperhelper/Makefile
@@ -233,7 +233,6 @@ $(eval $(call compile_wrapperhelper_c,,parse,parse))
 $(eval $(call compile_wrapperhelper_c,,prepare,prepare))
 $(eval $(call compile_wrapperhelper_c,,preproc,preproc))
 $(eval $(call compile_wrapperhelper_c,,vector,vector))
-$(eval $(call compile_wrapperhelper_c,,log,log))
 $(call wrapperhelper_o,,machine,machine): src/machine.gen
 $(call wrapperhelper_o,,generator,generator): CFLAGS+= -fno-analyzer # Too slow
 $(call wrapperhelper_o,,preproc,preproc): CFLAGS+= -fno-analyzer

--- a/wrapperhelper/src/main.c
+++ b/wrapperhelper/src/main.c
@@ -8,6 +8,7 @@
 #include "lang.h"
 #include "machine.h"
 #include "parse.h"
+#include "prepare.h"
 #include "khash.h"
 
 static void help(char *arg0) {
@@ -237,6 +238,7 @@ int main(int argc, char **argv) {
 			log_error_nopos("failed to parse the file\n");
 			del_machines();
 			del_str2kw();
+			prepare_cleanup();
 			return 0;
 		}
 		
@@ -246,6 +248,7 @@ int main(int argc, char **argv) {
 			file_del(emu_content);
 			del_machines();
 			del_str2kw();
+			prepare_cleanup();
 			return 2;
 		}
 		file_t *target_content = parse_file(target, in_file, f); // Takes ownership of f
@@ -254,6 +257,7 @@ int main(int argc, char **argv) {
 			file_del(emu_content);
 			del_machines();
 			del_str2kw();
+			prepare_cleanup();
 			return 0;
 		}
 		
@@ -264,6 +268,7 @@ int main(int argc, char **argv) {
 			file_del(target_content);
 			del_machines();
 			del_str2kw();
+			prepare_cleanup();
 			return 2;
 		}
 		VECTOR(references) *refs = references_from_file(ref_file, ref);
@@ -272,6 +277,7 @@ int main(int argc, char **argv) {
 			file_del(target_content);
 			del_machines();
 			del_str2kw();
+			prepare_cleanup();
 			return 2;
 		}
 		// vector_for(references, req, refs) request_print(req);
@@ -294,6 +300,7 @@ int main(int argc, char **argv) {
 			vector_del(references, refs);
 			del_machines();
 			del_str2kw();
+			prepare_cleanup();
 			return 2;
 		}
 		output_from_references(out, refs);
@@ -303,6 +310,7 @@ int main(int argc, char **argv) {
 		file_del(target_content);
 		del_machines();
 		del_str2kw();
+		prepare_cleanup();
 		return 0; }
 		
 	case MAIN_PROC: {
@@ -315,6 +323,7 @@ int main(int argc, char **argv) {
 			log_error_nopos("failed to parse the file\n");
 			del_machines();
 			del_str2kw();
+			prepare_cleanup();
 			return 0;
 		}
 		// print content
@@ -373,6 +382,7 @@ int main(int argc, char **argv) {
 		file_del(content);
 		del_machines();
 		del_str2kw();
+		prepare_cleanup();
 		return 0; }
 		
 	case MAIN_PREPARE:
@@ -380,6 +390,7 @@ int main(int argc, char **argv) {
 		dump_prepare(in_file, f); // Takes ownership of f
 		del_machines();
 		del_str2kw();
+		prepare_cleanup();
 		return 0;
 		
 	case MAIN_PREPROC: {
@@ -390,9 +401,13 @@ int main(int argc, char **argv) {
 		dump_preproc(arch, in_file, f); // Takes ownership of f
 		del_machines();
 		del_str2kw();
+		prepare_cleanup();
 		return 0; }
 	}
 	
 	log_internal_nopos("failed to run mode %u\n", ms);
+	del_machines();
+	del_str2kw();
+	prepare_cleanup();
 	return 2;
 }

--- a/wrapperhelper/src/prepare.h
+++ b/wrapperhelper/src/prepare.h
@@ -19,4 +19,6 @@ void prepare_set_line(prepare_t *src, char *filename, size_t lineno); // Takes o
 void prepare_mark_nocomment(prepare_t *src); // Change the state (usually from COMMENT) to NONE
 int pre_next_newline_token(prepare_t *src, string_t *buf); // In a comment append everything until the EOL or EOF to the buffer
 
+void prepare_cleanup(void); // Frees loginfo filenames
+
 #endif // PREPARE_H

--- a/wrapperhelper/src/vector.c
+++ b/wrapperhelper/src/vector.c
@@ -3,6 +3,7 @@
 VECTOR_IMPL(voidp, (void))
 VECTOR_IMPL(char, (void))
 VECTOR_IMPL(charp, (void))
+VECTOR_IMPL(ccharp, (void))
 static void stringp_del(string_t **s) { return string_del(*s); }
 VECTOR_IMPL(string, stringp_del)
 

--- a/wrapperhelper/src/vector.h
+++ b/wrapperhelper/src/vector.h
@@ -208,6 +208,7 @@ int            vector_push_vec_impl(VECTOR(voidp) *v1, VECTOR(voidp) *v2, size_t
 
 VECTOR_DECLARE(char, char)
 VECTOR_DECLARE(charp, char*)
+VECTOR_DECLARE(ccharp, const char*)
 VECTOR_DECLARE(string, string_t*)
 
 #endif // VECTOR_H


### PR DESCRIPTION
This PR adds support for `#pragma once` in the wrapper helper, reducing the number of errors; it also fixes a duplicated line in the Makefile causing a link-time error, improves a bit the box32-mode output, and ignores newlines in macro expansions. This allows `openssl/ssl.h` to be parsed correctly.