### PR TITLE
[RBTREE] Unify naming and prevent unintended symbol exposure

### DIFF
--- a/src/box64context.c
+++ b/src/box64context.c
@@ -287,7 +287,7 @@ box64context_t *NewBox64Context(int argc)
     initAllHelpers(context);
     
     #ifdef DYNAREC
-    context->db_sizes = init_rbtree("db_sizes");
+    context->db_sizes = rbtree_init("db_sizes");
     #endif
 
     return context;
@@ -391,7 +391,7 @@ void FreeBox64Context(box64context_t** context)
 
 #ifdef DYNAREC
     //dynarec_log(LOG_INFO, "BOX64 Dynarec at exit: Max DB=%d, righter=%d\n", ctx->max_db_size, rb_get_righter(ctx->db_sizes));
-    delete_rbtree(ctx->db_sizes);
+    rbtree_delete(ctx->db_sizes);
 #endif
 
     finiAllHelpers(ctx);

--- a/src/custommem.c
+++ b/src/custommem.c
@@ -60,13 +60,13 @@ static pthread_mutex_t     mutex_prot;
 static pthread_mutex_t     mutex_blocks;
 #endif
 //#define TRACE_MEMSTAT
-rbtree* memprot = NULL;
+rbtree_t* memprot = NULL;
 int have48bits = 0;
 static int inited = 0;
 
-rbtree*  mapallmem = NULL;
-static rbtree*  mmapmem = NULL;
-static rbtree*  blockstree = NULL;
+rbtree_t*  mapallmem = NULL;
+static rbtree_t*  mmapmem = NULL;
+static rbtree_t*  blockstree = NULL;
 
 typedef struct blocklist_s {
     void*               block;
@@ -1937,12 +1937,12 @@ void init_custommem_helper(box64context_t* ctx)
     if(inited) // already initialized
         return;
     inited = 1;
-    blockstree = init_rbtree("blockstree");
+    blockstree = rbtree_init("blockstree");
     // if there is some blocks already
     if(n_blocks)
         for(int i=0; i<n_blocks; ++i)
             rb_set(blockstree, (uintptr_t)p_blocks[i].block, (uintptr_t)p_blocks[i].block+p_blocks[i].size, i);
-    memprot = init_rbtree("memprot");
+    memprot = rbtree_init("memprot");
     sigfillset(&critical_prot);
     init_mutexes();
 #ifdef DYNAREC
@@ -1967,9 +1967,9 @@ void init_custommem_helper(box64context_t* ctx)
 #endif
     pthread_atfork(NULL, NULL, atfork_child_custommem);
     // init mapallmem list
-    mapallmem = init_rbtree("mapallmem");
+    mapallmem = rbtree_init("mapallmem");
     // init mmapmem list
-    mmapmem = init_rbtree("mapmem");
+    mmapmem = rbtree_init("mapmem");
     // Load current MMap
     loadProtectionFromMap();
     reserveHighMem();
@@ -2056,13 +2056,13 @@ void fini_custommem_helper(box64context_t *ctx)
     kh_destroy(lockaddress, lockaddress);
     lockaddress = NULL;
 #endif
-    delete_rbtree(memprot);
+    rbtree_delete(memprot);
     memprot = NULL;
-    delete_rbtree(mmapmem);
+    rbtree_delete(mmapmem);
     mmapmem = NULL;
-    delete_rbtree(mapallmem);
+    rbtree_delete(mapallmem);
     mapallmem = NULL;
-    delete_rbtree(blockstree);
+    rbtree_delete(blockstree);
     blockstree = NULL;
 
     for(int i=0; i<n_blocks; ++i)

--- a/src/include/box64context.h
+++ b/src/include/box64context.h
@@ -35,7 +35,7 @@ typedef struct library_s library_t;
 typedef struct linkmap_s linkmap_t;
 typedef struct linkmap32_s linkmap32_t;
 typedef struct kh_threadstack_s kh_threadstack_t;
-typedef struct rbtree rbtree;
+typedef struct rbtree rbtree_t;
 typedef struct atfork_fnc_s {
     uintptr_t prepare;
     uintptr_t parent;
@@ -172,7 +172,7 @@ typedef struct box64context_s {
     pthread_mutex_t     mutex_bridge;
     #endif
     uintptr_t           max_db_size;    // the biggest (in x86_64 instructions bytes) built dynablock
-    rbtree*             db_sizes;
+    rbtree_t*             db_sizes;
     int                 trace_dynarec;
     pthread_mutex_t     mutex_lock;     // this is for the Test interpreter
     #if defined(__riscv) || defined(__loongarch64)

--- a/src/include/rbtree.h
+++ b/src/include/rbtree.h
@@ -1,19 +1,17 @@
-#include <stdint.h>
-
 #ifndef RBTREE_H
 #define RBTREE_H
 
-typedef struct rbtree rbtree;
+#include <stdint.h>
 
-rbtree* init_rbtree(const char* name);
-void delete_rbtree(rbtree *tree);
+typedef struct rbtree rbtree_t;
 
-uint32_t rb_get(rbtree *tree, uintptr_t addr);
-int rb_get_end(rbtree* tree, uintptr_t addr, uint32_t* val, uintptr_t* end);
-int rb_set(rbtree *tree, uintptr_t start, uintptr_t end, uint32_t data);
-int rb_unset(rbtree *tree, uintptr_t start, uintptr_t end);
-uintptr_t rb_get_righter(rbtree *tree);
+rbtree_t* rbtree_init(const char* name);
+void rbtree_delete(rbtree_t* tree);
 
-void print_rbtree(const rbtree *tree);
+uint32_t rb_get(rbtree_t* tree, uintptr_t addr);
+int rb_get_end(rbtree_t* tree, uintptr_t addr, uint32_t* val, uintptr_t* end);
+int rb_set(rbtree_t* tree, uintptr_t start, uintptr_t end, uint32_t data);
+int rb_unset(rbtree_t* tree, uintptr_t start, uintptr_t end);
+uintptr_t rb_get_righter(rbtree_t* tree);
 
 #endif // RBTREE_H


### PR DESCRIPTION
Red-black tree operations now consistently use the `rbtree_` prefix, and internal functions remain unexposed. Tested on RV64GC, resulting in a 498-byte reduction in the `.text` section size.