### PR TITLE
Add the LASX in log tips and add the Loongson 3A6000 compiled opinion

### DIFF
--- a/ReleaseCMake/CMakeLists.txt
+++ b/ReleaseCMake/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.13)
 
 cmake_policy(SET CMP0065 NEW)
 
-SET(CMAKE_C_FLAGS_RELEASE  "-O0 -g")
-SET(CMAKE_CXX_FLAGS_RELEASE  "-O0 -g")
+SET(CMAKE_C_FLAGS_RELEASE  "-O3")
+SET(CMAKE_CXX_FLAGS_RELEASE  "-O3")
 
 option(RPI3ARM64 "Set to ON if targeting an RaspberryPI3 device with multiarch arm64 and armhf" ${RPI3ARM64})
 option(RPI4ARM64 "Set to ON if targeting an RaspberryPI4 device with multiarch arm64 and armhf" ${RPI4ARM64})

--- a/src/core.c
+++ b/src/core.c
@@ -513,9 +513,9 @@ HWCAP2_AFP
         uint32_t cpucfg2 = 0, idx = 2;
         asm volatile("cpucfg %0, %1" : "=r"(cpucfg2) : "r"(idx));
         if ((cpucfg2 >> 6) & 0b1) {
-            printf_log(LOG_INFO, "with extension LSX");
+            printf_log(LOG_INFO, "with extension LSX LASX");
         } else {
-            printf_log(LOG_INFO, "\nMissing LSX extension support, disabling Dynarec\n");
+            printf_log(LOG_INFO, "\nMissing LSX or LASX extension support, disabling Dynarec\n");
             box64_dynarec = 0;
             return;
         }


### PR DESCRIPTION
在core.c中将Dynarec for LoongArch的log输出由"with extension LSX"改为"with extension LSX LASX"，让编译者知道Box64同时有LSX与LASX优化
在CMakeLists.txt中添加LS3A6000编译选项，可以让龙芯3A6000及后续产品运行Box64具有更好性能，使用LoongArch ISA v1.1指令集。在编译中设置opinion为-D LS3A6000=1 -D CMAKE_BUILD_TYPE=RelWithDebInfo以启用。（Box64为不同版本树莓派与瑞芯微香橙派有不同版本编译选项）
新增ReleaseCMake文件夹，内有开启了O3优化的CMakeList（默认List是-O0 -g），适合追求转译性能的人。