### PR TITLE
[RV64_DYNAREC] Made eflags emulation branchless with xtheadcondmov

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -563,6 +563,9 @@ HWCAP2_AFP
     } else if (p != NULL && !strcasecmp(p, "xtheadmempair")) {
         RV64_Detect_Function();
         rv64_xtheadmempair = 0;
+    } else if (p != NULL && !strcasecmp(p, "xtheadcondmov")) {
+        RV64_Detect_Function();
+        rv64_xtheadcondmov = 0;
     }
 
     printf_log(LOG_INFO, "Dynarec for RISC-V ");

--- a/src/core.c
+++ b/src/core.c
@@ -577,8 +577,8 @@ HWCAP2_AFP
     if(rv64_xtheadbb) printf_log(LOG_INFO, " XTheadBb");
     if(rv64_xtheadbs) printf_log(LOG_INFO, " XTheadBs");
     if (rv64_xtheadmempair) printf_log(LOG_INFO, " XTheadMemPair");
+    if (rv64_xtheadcondmov) printf_log(LOG_INFO, " XTheadCondMov");
     // Disable the display since these are only detected but never used.
-    // if(rv64_xtheadcondmov) printf_log(LOG_INFO, " XTheadCondMov");
     // if(rv64_xtheadmemidx) printf_log(LOG_INFO, " XTheadMemIdx");
     // if(rv64_xtheadfmemidx) printf_log(LOG_INFO, " XTheadFMemIdx");
     // if(rv64_xtheadmac) printf_log(LOG_INFO, " XTheadMac");

--- a/src/dynarec/rv64/dynarec_rv64_00_0.c
+++ b/src/dynarec/rv64/dynarec_rv64_00_0.c
@@ -58,7 +58,7 @@ uintptr_t dynarec64_00_0(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
             FAST_8BIT_OPERATION(wb, gb, x1, ADD(wb, wb, x1));
             GETEB(x1, 0);
             GETGB(x2);
-            emit_add8(dyn, ninst, x1, x2, x4, x5);
+            emit_add8(dyn, ninst, x1, x2, x4, x5, x6);
             EBBACK(x5, 0);
             break;
         case 0x01:
@@ -77,7 +77,7 @@ uintptr_t dynarec64_00_0(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
             FAST_8BIT_OPERATION(gb, wb, x1, ADD(gb, gb, x1));
             GETEB(x1, 0);
             GETGB(x2);
-            emit_add8(dyn, ninst, x2, x1, x4, x5);
+            emit_add8(dyn, ninst, x2, x1, x4, x5, x6);
             GBBACK(x5);
             break;
         case 0x03:
@@ -93,7 +93,7 @@ uintptr_t dynarec64_00_0(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
             SETFLAGS(X_ALL, SF_SET_PENDING);
             u8 = F8;
             ANDI(x1, xRAX, 0xff);
-            emit_add8c(dyn, ninst, x1, u8, x3, x4, x5);
+            emit_add8c(dyn, ninst, x1, u8, x3, x4, x5, x6);
             ANDI(xRAX, xRAX, ~0xff);
             OR(xRAX, xRAX, x1);
             break;

--- a/src/dynarec/rv64/dynarec_rv64_00_2.c
+++ b/src/dynarec/rv64/dynarec_rv64_00_2.c
@@ -58,7 +58,7 @@ uintptr_t dynarec64_00_2(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                     SETFLAGS(X_ALL, SF_SET_PENDING);
                     GETEB(x1, 1);
                     u8 = F8;
-                    emit_add8c(dyn, ninst, x1, u8, x2, x4, x5);
+                    emit_add8c(dyn, ninst, x1, u8, x2, x4, x5, x6);
                     EBBACK(x5, 0);
                     break;
                 case 1: // OR

--- a/src/dynarec/rv64/dynarec_rv64_00_3.c
+++ b/src/dynarec/rv64/dynarec_rv64_00_3.c
@@ -1105,7 +1105,7 @@ uintptr_t dynarec64_00_3(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                     INST_NAME("NEG Eb");
                     SETFLAGS(X_ALL, SF_SET_PENDING);
                     GETEB(x1, 0);
-                    emit_neg8(dyn, ninst, x1, x2, x4);
+                    emit_neg8(dyn, ninst, x1, x2, x4, x5);
                     EBBACK(x5, 0);
                     break;
                 case 4:
@@ -1175,7 +1175,7 @@ uintptr_t dynarec64_00_3(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                     INST_NAME("NEG Ed");
                     SETFLAGS(X_ALL, SF_SET_PENDING);
                     GETED(0);
-                    emit_neg32(dyn, ninst, rex, ed, x3, x4);
+                    emit_neg32(dyn, ninst, rex, ed, x3, x4, x5, x6);
                     WBACK;
                     break;
                 case 4:

--- a/src/dynarec/rv64/dynarec_rv64_0f.c
+++ b/src/dynarec/rv64/dynarec_rv64_0f.c
@@ -1762,7 +1762,7 @@ uintptr_t dynarec64_0F(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
                 GETED(1);
                 GETGD;
                 u8 = F8;
-                emit_shld32c(dyn, ninst, rex, ed, gd, u8, x3, x4);
+                emit_shld32c(dyn, ninst, rex, ed, gd, u8, x3, x4, x5);
                 WBACK;
             } else {
                 FAKEED;
@@ -1824,7 +1824,7 @@ uintptr_t dynarec64_0F(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
                 GETGD;
                 u8 = F8;
                 u8 &= (rex.w ? 0x3f : 0x1f);
-                emit_shrd32c(dyn, ninst, rex, ed, gd, u8, x3, x4);
+                emit_shrd32c(dyn, ninst, rex, ed, gd, u8, x3, x4, x5);
                 WBACK;
             } else {
                 FAKEED;
@@ -2251,7 +2251,7 @@ uintptr_t dynarec64_0F(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
             GETGB(x2);
             if (!(MODREG && wback == gb1 && !!(wb2) == !!(gb2)))
                 MV(x9, ed);
-            emit_add8(dyn, ninst, ed, gd, x4, x5);
+            emit_add8(dyn, ninst, ed, gd, x4, x5, x6);
             if (!(MODREG && wback == gb1 && !!(wb2) == !!(gb2)))
                 MV(gd, x9);
             EBBACK(x5, 0);

--- a/src/dynarec/rv64/dynarec_rv64_64.c
+++ b/src/dynarec/rv64/dynarec_rv64_64.c
@@ -165,7 +165,7 @@ uintptr_t dynarec64_64(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
                     SETFLAGS(X_ALL, SF_SET_PENDING);
                     GETEBO(x1, 1);
                     u8 = F8;
-                    emit_add8c(dyn, ninst, x1, u8, x2, x4, x5);
+                    emit_add8c(dyn, ninst, x1, u8, x2, x4, x5, x6);
                     EBBACK(x5, 0);
                     break;
                 case 1: // OR

--- a/src/dynarec/rv64/dynarec_rv64_66.c
+++ b/src/dynarec/rv64/dynarec_rv64_66.c
@@ -378,7 +378,7 @@ uintptr_t dynarec64_66(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
             SETFLAGS(X_ALL&~X_CF, SF_SUBSET_PENDING);
             gd = xRAX + (opcode&7);
             ZEXTH(x1, gd);
-            emit_inc16(dyn, ninst, x1, x2, x3, x4);
+            emit_inc16(dyn, ninst, x1, x2, x3, x4, x5);
             INSHz(gd, x1, x3, x4, 1, 0);
             break;
         case 0x48:
@@ -1196,7 +1196,7 @@ uintptr_t dynarec64_66(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
                     INST_NAME("NEG Ew");
                     SETFLAGS(X_ALL, SF_SET_PENDING);
                     GETEW(x1, 0);
-                    emit_neg16(dyn, ninst, ed, x2, x4);
+                    emit_neg16(dyn, ninst, ed, x2, x4, x5);
                     EWBACK;
                     break;
                 case 4:
@@ -1289,7 +1289,7 @@ uintptr_t dynarec64_66(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
                     INST_NAME("INC Ew");
                     SETFLAGS(X_ALL&~X_CF, SF_SUBSET_PENDING);
                     GETEW(x1, 0);
-                    emit_inc16(dyn, ninst, x1, x2, x4, x5);
+                    emit_inc16(dyn, ninst, x1, x2, x4, x5, x6);
                     EWBACK;
                     break;
                 case 1:

--- a/src/dynarec/rv64/dynarec_rv64_67.c
+++ b/src/dynarec/rv64/dynarec_rv64_67.c
@@ -78,7 +78,7 @@ uintptr_t dynarec64_67(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
             FAST_8BIT_OPERATION(gb, wb, x1, ADD(gb, gb, x1));
             GETEB32(x2, 0);
             GETGB(x1);
-            emit_add8(dyn, ninst, x1, x2, x3, x4);
+            emit_add8(dyn, ninst, x1, x2, x3, x4, x6);
             GBBACK(x4);
             break;
         case 0x03:

--- a/src/dynarec/rv64/dynarec_rv64_emit_logic.c
+++ b/src/dynarec/rv64/dynarec_rv64_emit_logic.c
@@ -34,15 +34,13 @@ void emit_xor8(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4)
     ANDI(s1, s1, 0xff);
     IFX(X_SF) {
         SRLI(s3, s1, 7);
-        BEQZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_NEZ(s3, F_SF, s4);
     }
     IFX(X_PEND) {
         SB(s1, xEmu, offsetof(x64emu_t, res));
     }
-    IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+    IFX (X_ZF) {
+        SET_FLAGS_EQZ(s1, F_ZF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -62,15 +60,13 @@ void emit_xor8c(dynarec_rv64_t* dyn, int ninst, int s1, int32_t c, int s3, int s
     ANDI(s1, s1, 0xff);
     IFX(X_SF) {
         SRLI(s3, s1, 7);
-        BEQZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_NEZ(s3, F_SF, s4);
     }
     IFX(X_PEND) {
         SB(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -92,8 +88,7 @@ void emit_xor32(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, int s
     // test sign bit before zeroup.
     IFX(X_SF) {
         if (!rex.w) SEXT_W(s1, s1);
-        BGE(s1, xZR, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_LTZ(s1, F_SF, s3, s4);
     }
     if (!rex.w && s1!=s2) {
         ZEROUP(s1);
@@ -104,8 +99,7 @@ void emit_xor32(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, int s
     }
 
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -132,8 +126,7 @@ void emit_xor32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int64_t c, i
     // test sign bit before zeroup.
     IFX(X_SF) {
         if (!rex.w) SEXT_W(s1, s1);
-        BGE(s1, xZR, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_LTZ(s1, F_SF, s3, s4);
     }
     if (!rex.w) {
         ZEROUP(s1);
@@ -144,8 +137,7 @@ void emit_xor32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int64_t c, i
     }
 
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -170,13 +162,11 @@ void emit_xor16(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4, 
     }
     IFX(X_ZF | X_SF) {
         IFX(X_ZF) {
-            BNEZ(s1, 8);
-            ORI(xFlags, xFlags, 1 << F_ZF);
+            SET_FLAGS_EQZ(s1, F_ZF, s4);
         }
         IFX(X_SF) {
             SRLI(s3, s1, 15);
-            BEQZ(s3, 8);
-            ORI(xFlags, xFlags, 1 << F_SF);
+            SET_FLAGS_NEZ(s3, F_SF, s4);
         }
     }
     IFX(X_PF) {
@@ -201,13 +191,11 @@ void emit_or16(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4) {
 
     IFX(X_SF) {
         SRLI(s3, s1, 15);
-        BEQZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_NEZ(s3, F_SF, s4);
     }
 
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -229,8 +217,7 @@ void emit_or32(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, int s3
     // test sign bit before zeroup.
     IFX(X_SF) {
         if (!rex.w) SEXT_W(s1, s1);
-        BGE(s1, xZR, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_LTZ(s1, F_SF, s3, s4);
     }
     if (!rex.w) {
         ZEROUP(s1);
@@ -241,8 +228,7 @@ void emit_or32(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, int s3
     }
 
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -268,8 +254,7 @@ void emit_or32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int64_t c, in
     // test sign bit before zeroup.
     IFX(X_SF) {
         if (!rex.w) SEXT_W(s1, s1);
-        BGE(s1, xZR, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_LTZ(s1, F_SF, s3, s4);
     }
     if (!rex.w) {
         ZEROUP(s1);
@@ -280,8 +265,7 @@ void emit_or32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int64_t c, in
     }
 
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -307,12 +291,10 @@ void emit_and8(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4)
     }
     IFX(X_SF) {
         SRLI(s3, s1, 7);
-        BEQZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_NEZ(s3, F_SF, s4);
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -337,12 +319,10 @@ void emit_and8c(dynarec_rv64_t* dyn, int ninst, int s1, int32_t c, int s3, int s
     }
     IFX(X_SF) {
         SRLI(s3, s1, 7);
-        BEQZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_NEZ(s3, F_SF, s4);
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -364,12 +344,10 @@ void emit_and16(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4) 
     }
     IFX(X_SF) {
         SRLI(s3, s1, 15);
-        BEQZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_NEZ(s3, F_SF, s4);
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -394,12 +372,10 @@ void emit_and32(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, int s
     }
     IFX(X_SF) {
         SRLI(s3, s1, rex.w?63:31);
-        BEQZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_NEZ(s3, F_SF, s4);
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -429,12 +405,10 @@ void emit_and32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int64_t c, i
     }
     IFX(X_SF) {
         SRLI(s3, s1, rex.w?63:31);
-        BEQZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_NEZ(s3, F_SF, s4);
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -458,12 +432,10 @@ void emit_or8(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4)
     }
     IFX(X_SF) {
         SRLI(s3, s1, 7);
-        BEQZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_NEZ(s3, F_SF, s4);
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);

--- a/src/dynarec/rv64/dynarec_rv64_emit_shift.c
+++ b/src/dynarec/rv64/dynarec_rv64_emit_shift.c
@@ -48,8 +48,7 @@ void emit_shl8c(dynarec_rv64_t* dyn, int ninst, int s1, uint32_t c, int s3, int 
 
         SLLI(s1, s1, c+56);
         IFX(X_SF) {
-            BGE(s1, xZR, 8);
-            ORI(xFlags, xFlags, 1 << F_SF);
+            SET_FLAGS_LTZ(s1, F_SF, s3, s4);
         }
         SRLI(s1, s1, 56);
 
@@ -57,8 +56,7 @@ void emit_shl8c(dynarec_rv64_t* dyn, int ninst, int s1, uint32_t c, int s3, int 
             SB(s1, xEmu, offsetof(x64emu_t, res));
         }
         IFX(X_ZF) {
-            BNEZ(s1, 8);
-            ORI(xFlags, xFlags, 1 << F_ZF);
+            SET_FLAGS_EQZ(s1, F_ZF, s3);
         }
         IFX(X_OF) {
             // OF flag is affected only on 1-bit shifts
@@ -139,8 +137,7 @@ void emit_shr8c(dynarec_rv64_t* dyn, int ninst, int s1, uint32_t c, int s3, int 
         SB(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s5);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -175,8 +172,7 @@ void emit_sar8c(dynarec_rv64_t* dyn, int ninst, int s1, uint32_t c, int s3, int 
     // OF nop
     IFX(X_SF) {
         // SF is the same as the original operand
-        BGE(s1, xZR, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_LTZ(s1, F_SF, s3, s4);
     }
 
     SRLI(s1, s1, c);
@@ -186,8 +182,7 @@ void emit_sar8c(dynarec_rv64_t* dyn, int ninst, int s1, uint32_t c, int s3, int 
         SB(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s3);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -219,8 +214,7 @@ void emit_shl8(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4, i
 
     SLLI(s1, s1, 56);
     IFX(X_SF) {
-        BGE(s1, xZR, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_LTZ(s1, F_SF, s3, s4);
     }
     SRLI(s1, s1, 56);
 
@@ -228,8 +222,7 @@ void emit_shl8(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4, i
         SB(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s3);
     }
     IFX(X_OF) {
         // OF flag is affected only on 1-bit shifts
@@ -284,8 +277,7 @@ void emit_shr8(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4, i
         SB(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s3);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -316,8 +308,7 @@ void emit_sar8(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4, i
     // OF nop
     IFX(X_SF) {
         // SF is the same as the original operand
-        BGE(s1, xZR, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_LTZ(s1, F_SF, s3, s4);
     }
 
     SRL(s1, s1, s2);
@@ -327,8 +318,7 @@ void emit_sar8(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4, i
         SB(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s3);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -362,8 +352,7 @@ void emit_shl16c(dynarec_rv64_t* dyn, int ninst, int s1, uint32_t c, int s3, int
 
         SLLI(s1, s1, c+48);
         IFX(X_SF) {
-            BGE(s1, xZR, 8);
-            ORI(xFlags, xFlags, 1 << F_SF);
+            SET_FLAGS_LTZ(s1, F_SF, s3, s4);
         }
         SRLI(s1, s1, 48);
 
@@ -371,8 +360,7 @@ void emit_shl16c(dynarec_rv64_t* dyn, int ninst, int s1, uint32_t c, int s3, int
             SH(s1, xEmu, offsetof(x64emu_t, res));
         }
         IFX(X_ZF) {
-            BNEZ(s1, 8);
-            ORI(xFlags, xFlags, 1 << F_ZF);
+            SET_FLAGS_EQZ(s1, F_ZF, s3);
         }
         IFX(X_OF) {
             // OF flag is affected only on 1-bit shifts
@@ -452,8 +440,7 @@ void emit_shr16c(dynarec_rv64_t* dyn, int ninst, int s1, uint32_t c, int s3, int
         SH(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s3);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -488,8 +475,7 @@ void emit_sar16c(dynarec_rv64_t* dyn, int ninst, int s1, uint32_t c, int s3, int
     // OF nop
     IFX(X_SF) {
         // SF is the same as the original operand
-        BGE(s1, xZR, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_LTZ(s1, F_SF, s3, s4);
     }
 
     SRLI(s1, s1, c);
@@ -499,8 +485,7 @@ void emit_sar16c(dynarec_rv64_t* dyn, int ninst, int s1, uint32_t c, int s3, int
         SH(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s3);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -533,8 +518,7 @@ void emit_shl16(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4, 
 
     SLLI(s1, s1, 48);
     IFX(X_SF) {
-        BGE(s1, xZR, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_LTZ(s1, F_SF, s3, s4);
     }
     SRLI(s1, s1, 48);
 
@@ -542,8 +526,7 @@ void emit_shl16(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4, 
         SH(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s3);
     }
     IFX(X_OF) {
         // OF flag is affected only on 1-bit shifts
@@ -598,8 +581,7 @@ void emit_shr16(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4, 
         SH(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s3);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -630,8 +612,7 @@ void emit_sar16(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4, 
     // OF nop
     IFX(X_SF) {
         // SF is the same as the original operand
-        BGE(s1, xZR, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_LTZ(s1, F_SF, s3, s4);
     }
 
     SRL(s1, s1, s2);
@@ -641,8 +622,7 @@ void emit_sar16(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4, 
         SH(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s3);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -679,8 +659,7 @@ void emit_shl32(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, int s
     }
 
     IFX(X_SF) {
-        BGE(s1, xZR, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_LTZ(s1, F_SF, s3, s4);
     }
     if (!rex.w) {
         ZEROUP(s1);
@@ -689,8 +668,7 @@ void emit_shl32(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, int s
         SDxw(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s3);
     }
     IFX(X_OF) {
         // OF flag is affected only on 1-bit shifts
@@ -738,8 +716,7 @@ void emit_shl32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, uint32_t c, 
     }
 
     IFX(X_SF) {
-        BGE(s1, xZR, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_LTZ(s1, F_SF, s3, s4);
     }
     if (!rex.w) {
         ZEROUP(s1);
@@ -748,8 +725,7 @@ void emit_shl32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, uint32_t c, 
         SDxw(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s3);
     }
     IFX(X_OF) {
         // OF flag is affected only on 1-bit shifts
@@ -799,8 +775,7 @@ void emit_shr32(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, int s
     SRL(s1, s1, s2);
 
     IFX(X_SF) {
-        BGE(s1, xZR, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_LTZ(s1, F_SF, s3, s4);
     }
     if (!rex.w) {
         ZEROUP(s1);
@@ -809,8 +784,7 @@ void emit_shr32(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, int s
         SDxw(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s3);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -864,8 +838,7 @@ void emit_shr32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, uint32_t c, 
     }
 
     IFX(X_SF) {
-        BGE(s1, xZR, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_LTZ(s1, F_SF, s3, s4);
     }
     if (!rex.w && c == 0) {
         ZEROUP(s1);
@@ -874,8 +847,7 @@ void emit_shr32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, uint32_t c, 
         SDxw(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s3);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -923,8 +895,7 @@ void emit_sar32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, uint32_t c, 
 
     // SRAIW sign-extends, so test sign bit before clearing upper bits
     IFX(X_SF) {
-        BGE(s1, xZR, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_LTZ(s1, F_SF, s3, s4);
     }
     if (!rex.w) {
         ZEROUP(s1);
@@ -933,8 +904,7 @@ void emit_sar32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, uint32_t c, 
         SDxw(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s3);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -1148,7 +1118,7 @@ void emit_ror32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, uint32_t c, 
 }
 
 // emit SHRD32 instruction, from s1, fill s2 , constant c, store result in s1 using s3 and s4 as scratch
-void emit_shrd32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, uint32_t c, int s3, int s4)
+void emit_shrd32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, uint32_t c, int s3, int s4, int s5)
 {
     c&=(rex.w?0x3f:0x1f);
     CLEAR_FLAGS();
@@ -1193,15 +1163,13 @@ void emit_shrd32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, uin
     }
     IFX(X_SF) {
         SRLIxw(s3, s1, rex.w?63:31);
-        BEQZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_NEZ(s3, F_SF, s5);
     }
     IFX(X_PEND) {
         SDxw(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s5);
     }
     IFX(X_OF) {
         // the OF flag is set if a sign change occurred
@@ -1266,18 +1234,11 @@ void emit_shrd16c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, uin
         OR(s1, s1, s5);
     }
     ZEXTH(s1, s1);
-
-    IFX(X_SF) {
-        SLLIW(s3, s1, 16);
-        BGE(s3, xZR, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
-    }
     IFX(X_PEND) {
         SH(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s5);
     }
     IFX(X_OF) {
         // the OF flag is set if a sign change occurred
@@ -1289,12 +1250,16 @@ void emit_shrd16c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, uin
             OR(xFlags, xFlags, s3);
         }
     }
+    IFX (X_SF) {
+        SLLIW(s3, s1, 16);
+        SET_FLAGS_LTZ(s3, F_SF, s4, s5);
+    }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
     }
 }
 
-void emit_shld32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, uint32_t c, int s3, int s4)
+void emit_shld32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, uint32_t c, int s3, int s4, int s5)
 {
     c&=(rex.w?0x3f:0x1f);
     CLEAR_FLAGS();
@@ -1337,17 +1302,11 @@ void emit_shld32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, uin
     if (!rex.w) {
         ZEROUP(s1);
     }
-    IFX(X_SF) {
-        SRLIxw(s3, s1, rex.w?63:31);
-        BEQZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
-    }
     IFX(X_PEND) {
         SDxw(s1, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s5);
     }
     IFX(X_OF) {
         // the OF flag is set if a sign change occurred
@@ -1357,6 +1316,10 @@ void emit_shld32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, uin
             SLLI(s3, s3, F_OF2);
             ORI(xFlags, xFlags, s3);
         }
+    }
+    IFX (X_SF) {
+        SRLIxw(s3, s1, rex.w ? 63 : 31);
+        SET_FLAGS_NEZ(s3, F_SF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -1397,15 +1360,6 @@ void emit_shrd32(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, int 
     if (!rex.w) {
         ZEROUP(s1);
     }
-    IFX(X_SF) {
-        SRLIxw(s3, s1, rex.w?63:31);
-        BEQZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
-    }
-    IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
-    }
     IFX(X_OF) {
         ADDI(s5, s5, -1);
         BNEZ_MARK(s5);
@@ -1414,6 +1368,13 @@ void emit_shrd32(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, int 
         SLLI(s3, s3, F_OF2);
         OR(xFlags, xFlags, s3);
         MARK;
+    }
+    IFX (X_ZF) {
+        SET_FLAGS_EQZ(s1, F_ZF, s5);
+    }
+    IFX (X_SF) {
+        SRLIxw(s3, s1, rex.w ? 63 : 31);
+        SET_FLAGS_NEZ(s3, F_SF, s5);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -1453,15 +1414,6 @@ void emit_shld32(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, int 
     if (!rex.w) {
         ZEROUP(s1);
     }
-    IFX(X_SF) {
-        SRLIxw(s3, s1, rex.w?63:31);
-        BEQZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
-    }
-    IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
-    }
     IFX(X_OF) {
         ADDI(s5, s5, -1);
         BNEZ_MARK(s5);
@@ -1470,6 +1422,13 @@ void emit_shld32(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, int 
         SLLI(s3, s3, F_OF2);
         OR(xFlags, xFlags, s3);
         MARK;
+    }
+    IFX (X_ZF) {
+        SET_FLAGS_EQZ(s1, F_ZF, s5);
+    }
+    IFX (X_SF) {
+        SRLIxw(s3, s1, rex.w ? 63 : 31);
+        SET_FLAGS_NEZ(s3, F_SF, s5);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -1524,18 +1483,8 @@ void emit_shld16c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, uin
         OR(s1, s1, s3);
     }
     ZEXTH(s1, s1);
-
-    IFX(X_SF) {
-        SLLIW(s4, s1, 16);
-        BGE(s4, xZR, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
-    }
     IFX(X_PEND) {
         SH(s1, xEmu, offsetof(x64emu_t, res));
-    }
-    IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
     }
     IFX(X_OF) {
         // the OF flag is set if a sign change occurred
@@ -1546,6 +1495,13 @@ void emit_shld16c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, uin
             SLLI(s3, s3, F_OF2);
             OR(xFlags, xFlags, s3);
         }
+    }
+    IFX (X_SF) {
+        SLLIW(s4, s1, 16);
+        SET_FLAGS_LTZ(s4, F_SF, s3, s5);
+    }
+    IFX (X_ZF) {
+        SET_FLAGS_EQZ(s1, F_ZF, s3);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);

--- a/src/dynarec/rv64/dynarec_rv64_emit_tests.c
+++ b/src/dynarec/rv64/dynarec_rv64_emit_tests.c
@@ -46,13 +46,11 @@ void emit_cmp8(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4, i
     }
     IFX(X_SF) {
         SRLI(s3, s6, 7);
-        BEQZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_NEZ(s3, F_SF, s4);
     }
     CALC_SUB_FLAGS(s5, s2, s6, s3, s4, 8);
     IFX(X_ZF) {
-        BNEZ(s6, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s6, F_ZF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s6, s3, s4);
@@ -74,12 +72,10 @@ void emit_cmp8_0(dynarec_rv64_t* dyn, int ninst, int s1, int s3, int s4)
 
     IFX(X_SF) {
         SRLI(s3, s1, 7);
-        BEQZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_NEZ(s3, F_SF, s4);
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -113,13 +109,11 @@ void emit_cmp16(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4, 
     }
     IFX(X_SF) {
         SRLI(s3, s6, 15);
-        BEQZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_NEZ(s3, F_SF, s4);
     }
     CALC_SUB_FLAGS(s5, s2, s6, s3, s4, 16);
     IFX(X_ZF) {
-        BNEZ(s6, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s6, F_ZF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s6, s3, s4);
@@ -141,12 +135,10 @@ void emit_cmp16_0(dynarec_rv64_t* dyn, int ninst, int s1, int s3, int s4)
 
     IFX(X_SF) {
         SRLI(s3, s1, 15);
-        BEQZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_NEZ(s3, F_SF, s4);
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -176,16 +168,14 @@ void emit_cmp32(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, int s
         SDxw(s6, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_SF) {
-        BGE(s6, xZR, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_LTZ(s6, F_SF, s3, s4);
     }
     if (!rex.w) {
         ZEROUP(s6);
     }
     CALC_SUB_FLAGS(s5, s2, s6, s3, s4, rex.w?64:32);
     IFX(X_ZF) {
-        BNEZ(s6, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s6, F_ZF, s4);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s6, s3, s4);
@@ -206,16 +196,14 @@ void emit_cmp32_0(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s3, int
     }
     IFX(X_SF) {
         if (rex.w) {
-            BGE(s1, xZR, 8);
+            SET_FLAGS_LTZ(s1, F_SF, s3, s4);
         } else {
             SRLI(s3, s1, 31);
-            BEQZ(s3, 8);
+            SET_FLAGS_NEZ(s3, F_SF, s4);
         }
-        ORI(xFlags, xFlags, 1 << F_SF);
     }
     IFX(X_ZF) {
-        BNEZ(s1, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s1, F_ZF, s3);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s1, s3, s4);
@@ -238,12 +226,10 @@ void emit_test8(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4, 
     }
     IFX(X_SF) {
         SRLI(s4, s3, 7);
-        BEQZ(s4, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_NEZ(s4, F_SF, s5);
     }
     IFX(X_ZF) {
-        BNEZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s3, F_ZF, s5);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s3, s4, s5);
@@ -267,12 +253,10 @@ void emit_test16(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4,
     }
     IFX(X_SF) {
         SRLI(s4, s3, 15);
-        BEQZ(s4, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SET_FLAGS_NEZ(s4, F_SF, s5);
     }
     IFX(X_ZF) {
-        BNEZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s3, F_ZF, s5);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s3, s4, s5);
@@ -298,13 +282,11 @@ void emit_test32(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, int 
         if (!rex.w) ZEROUP(s3);
     }
     IFX(X_SF) {
-        SRLI(s4, s3, rex.w?63:31);
-        BEQZ(s4, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SRLI(s4, s3, rex.w ? 63 : 31);
+        SET_FLAGS_NEZ(s4, F_SF, s5);
     }
     IFX(X_ZF) {
-        BNEZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s3, F_ZF, s5);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s3, s4, s5);
@@ -335,13 +317,11 @@ void emit_test32c(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int64_t c, 
         SDxw(s3, xEmu, offsetof(x64emu_t, res));
     }
     IFX(X_SF) {
-        SRLI(s4, s3, rex.w?63:31);
-        BEQZ(s4, 8);
-        ORI(xFlags, xFlags, 1 << F_SF);
+        SRLI(s4, s3, rex.w ? 63 : 31);
+        SET_FLAGS_NEZ(s4, F_SF, s5);
     }
     IFX(X_ZF) {
-        BNEZ(s3, 8);
-        ORI(xFlags, xFlags, 1 << F_ZF);
+        SET_FLAGS_EQZ(s3, F_ZF, s5);
     }
     IFX(X_PF) {
         emit_pf(dyn, ninst, s3, s4, s5);


### PR DESCRIPTION
A small (~3%) performance improvement was observed in coremark.