### PR TITLE
[LA64_DYNAREC] Initial implement missing opcode for VMOVD Gx, Ed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1015,6 +1015,8 @@ if(LARCH64_DYNAREC)
     "${BOX64_ROOT}/src/dynarec/la64/dynarec_la64_660f.c"
     "${BOX64_ROOT}/src/dynarec/la64/dynarec_la64_f0.c"
     "${BOX64_ROOT}/src/dynarec/la64/dynarec_la64_f20f.c"
+    "${BOX64_ROOT}/src/dynarec/la64/dynarec_la64_avx.c"
+    "${BOX64_ROOT}/src/dynarec/la64/dynarec_la64_avx_66_0f.c"
     )
 endif()
 

--- a/src/dynarec/la64/dynarec_la64_00.c
+++ b/src/dynarec/la64/dynarec_la64_00.c
@@ -1696,6 +1696,25 @@ uintptr_t dynarec64_00(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
             *need_epilog = 0;
             *ok = 0;
             break;
+        case 0xC5:
+            nextop = F8;
+            if (rex.is32bits && !(MODREG)) {
+                DEFAULT;
+            } else {
+                vex_t vex = { 0 };
+                vex.rex = rex;
+                u8 = nextop;
+                vex.p = u8 & 0b00000011;
+                vex.l = (u8 >> 2) & 1;
+                vex.v = ((~u8) >> 3) & 0b1111;
+                vex.rex.r = (u8 & 0b10000000) ? 0 : 1;
+                vex.rex.b = 0;
+                vex.rex.x = 0;
+                vex.rex.w = 0;
+                vex.m = VEX_M_0F;
+                addr = dynarec64_AVX(dyn, addr, ip, ninst, vex, ok, need_epilog);
+            }
+            break;
         case 0xC6:
             INST_NAME("MOV Eb, Ib");
             nextop = F8;

--- a/src/dynarec/la64/dynarec_la64_avx.c
+++ b/src/dynarec/la64/dynarec_la64_avx.c
@@ -1,0 +1,63 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <errno.h>
+
+#include "debug.h"
+#include "box64context.h"
+#include "dynarec.h"
+#include "emu/x64emu_private.h"
+#include "emu/x64run_private.h"
+#include "x64run.h"
+#include "x64emu.h"
+#include "box64stack.h"
+#include "callback.h"
+#include "emu/x64run_private.h"
+#include "x64trace.h"
+#include "dynarec_native.h"
+
+#include "la64_printer.h"
+#include "dynarec_la64_private.h"
+#include "dynarec_la64_functions.h"
+#include "../dynarec_helper.h"
+
+static const char* avx_prefix_string(uint16_t p)
+{
+    switch (p) {
+        case VEX_P_NONE: return "0";
+        case VEX_P_66: return "66";
+        case VEX_P_F2: return "F2";
+        case VEX_P_F3: return "F3";
+        default: return "??";
+    }
+}
+static const char* avx_map_string(uint16_t m)
+{
+    switch (m) {
+        case VEX_M_NONE: return "0";
+        case VEX_M_0F: return "0F";
+        case VEX_M_0F38: return "0F38";
+        case VEX_M_0F3A: return "0F3A";
+        default: return "??";
+    }
+}
+
+uintptr_t dynarec64_AVX(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ninst, vex_t vex, int* ok, int* need_epilog)
+{
+    (void)ip;
+    (void)need_epilog;
+
+    uint8_t opcode = PK(0);
+    rex_t rex = vex.rex;
+
+    if ((vex.m == VEX_M_0F) && (vex.p == VEX_P_66)) {
+        addr = dynarec64_AVX_66_0F(dyn, addr, ip, ninst, vex, ok, need_epilog);
+    } else {
+        DEFAULT;
+    }
+
+    if ((*ok == -1) && (box64_dynarec_log >= LOG_INFO || box64_dynarec_dump || box64_dynarec_missing == 1)) {
+        dynarec_log(LOG_NONE, "Dynarec unimplemented AVX opcode size %d prefix %s map %s opcode %02X ", 128 << vex.l, avx_prefix_string(vex.p), avx_map_string(vex.m), opcode);
+    }
+    return addr;
+}

--- a/src/dynarec/la64/dynarec_la64_avx_66_0f.c
+++ b/src/dynarec/la64/dynarec_la64_avx_66_0f.c
@@ -1,0 +1,85 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <errno.h>
+
+#include "debug.h"
+#include "box64context.h"
+#include "dynarec.h"
+#include "emu/x64emu_private.h"
+#include "emu/x64run_private.h"
+#include "x64run.h"
+#include "x64emu.h"
+#include "box64stack.h"
+#include "callback.h"
+#include "emu/x64run_private.h"
+#include "x64trace.h"
+#include "dynarec_native.h"
+#include "my_cpuid.h"
+#include "emu/x87emu_private.h"
+#include "emu/x64shaext.h"
+
+#include "la64_printer.h"
+#include "dynarec_la64_private.h"
+#include "dynarec_la64_functions.h"
+#include "../dynarec_helper.h"
+
+uintptr_t dynarec64_AVX_66_0F(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ninst, vex_t vex, int* ok, int* need_epilog)
+{
+    (void)ip; (void)need_epilog;
+
+    uint8_t opcode = F8;
+    uint8_t nextop, u8;
+    uint8_t gd, ed;
+    uint8_t wback, wb1, wb2;
+    uint8_t eb1, eb2, gb1, gb2;
+    int32_t i32, i32_;
+    int cacheupd = 0;
+    int v0, v1, v2;
+    int q0, q1, q2;
+    int d0, d1, d2;
+    int s0;
+    uint64_t tmp64u, tmp64u2;
+    int64_t j64;
+    int64_t fixedaddress;
+    int unscaled;
+    MAYUSE(wb1);
+    MAYUSE(wb2);
+    MAYUSE(eb1);
+    MAYUSE(eb2);
+    MAYUSE(gb1);
+    MAYUSE(gb2);
+    MAYUSE(q0);
+    MAYUSE(q1);
+    MAYUSE(d0);
+    MAYUSE(d1);
+    MAYUSE(s0);
+    MAYUSE(j64);
+    MAYUSE(cacheupd);
+    #if STEP > 1
+    static const int8_t mask_shift8[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+    #endif
+
+
+    rex_t rex = vex.rex;
+
+    switch(opcode) {
+        case 0x6E:
+            INST_NAME("VMOVD Gx, Ed");
+            nextop = F8;
+            GETGX_empty(v0);
+            GETED(0);
+            if (rex.w) {
+                MOVGR2FR_D(v0, ed);
+                FFINT_D_L(v0, v0);
+            } else {
+                VXOR_V(v0, v0, v0);
+                VINSGR2VR_W(v0, ed, 0);
+            }
+            YMM0(gd);
+            break;
+        default:
+            DEFAULT;
+    }
+    return addr;
+}

--- a/src/dynarec/la64/dynarec_la64_helper.c
+++ b/src/dynarec/la64/dynarec_la64_helper.c
@@ -888,6 +888,15 @@ static void sse_reflectcache(dynarec_la64_t* dyn, int ninst, int s1)
         }
 }
 
+// AVX Helpers
+void ymm_mark_zero(dynarec_la64_t* dyn, int ninst, int a)
+{
+#if STEP == 0
+    dyn->insts[ninst].ymm0_add |= (1 << a);
+#endif
+    avx_mark_zero(dyn, ninst, a);
+}
+
 void fpu_pushcache(dynarec_la64_t* dyn, int ninst, int s1, int not07)
 {
     int start = not07 ? 8 : 0;

--- a/src/dynarec/la64/dynarec_la64_helper.h
+++ b/src/dynarec/la64/dynarec_la64_helper.h
@@ -357,6 +357,8 @@
         BSTRINS_D(wback, ed, wb2 + 7, wb2); \
     }
 
+#define YMM0(a) ymm_mark_zero(dyn, ninst, a);
+
 // Get direction with size Z and based of F_DF flag, on register r ready for load/store fetching
 // using s as scratch.
 // F_DF is not in LBT4.eflags, don't worry
@@ -776,6 +778,9 @@ void* la64_next(x64emu_t* emu, uintptr_t addr);
 #define dynarec64_F0   STEPNAME(dynarec64_F0)
 #define dynarec64_F20F STEPNAME(dynarec64_F20F)
 
+#define dynarec64_AVX       STEPNAME(dynarec64_AVX)
+#define dynarec64_AVX_66_0F     STEPNAME(dynarec64_AVX_66_0F)
+
 #define geted               STEPNAME(geted)
 #define geted32             STEPNAME(geted32)
 #define jump_to_epilog      STEPNAME(jump_to_epilog)
@@ -860,6 +865,7 @@ void* la64_next(x64emu_t* emu, uintptr_t addr);
 #define sse_get_reg_empty STEPNAME(sse_get_reg_empty)
 #define sse_forget_reg    STEPNAME(sse_forget_reg)
 #define sse_reflect_reg   STEPNAME(sse_reflect_reg)
+#define ymm_mark_zero     STEPNAME(ymm_mark_zero)
 
 #define fpu_pushcache       STEPNAME(fpu_pushcache)
 #define fpu_popcache        STEPNAME(fpu_popcache)
@@ -984,6 +990,10 @@ void sse_forget_reg(dynarec_la64_t* dyn, int ninst, int a);
 // Push current value to the cache
 void sse_reflect_reg(dynarec_la64_t* dyn, int ninst, int a);
 
+// avx helpers
+// mark an ymm upper part has zero (forgetting upper part if needed)
+void ymm_mark_zero(dynarec_la64_t* dyn, int ninst, int a);
+
 void CacheTransform(dynarec_la64_t* dyn, int ninst, int cacheupd, int s1, int s2, int s3);
 
 void la64_move64(dynarec_la64_t* dyn, int ninst, int reg, int64_t val);
@@ -1005,6 +1015,9 @@ uintptr_t dynarec64_67(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
 uintptr_t dynarec64_660F(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ninst, rex_t rex, int* ok, int* need_epilog);
 uintptr_t dynarec64_F0(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ninst, rex_t rex, int rep, int* ok, int* need_epilog);
 uintptr_t dynarec64_F20F(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ninst, rex_t rex, int* ok, int* need_epilog);
+
+uintptr_t dynarec64_AVX(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ninst, vex_t vex, int* ok, int* need_epilog);
+uintptr_t dynarec64_AVX_66_0F(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ninst, vex_t vex, int* ok, int* need_epilog);
 
 #if STEP < 3
 #define PASS3(A)

--- a/src/dynarec/la64/la64_emitter.h
+++ b/src/dynarec/la64/la64_emitter.h
@@ -1840,6 +1840,7 @@ LSX instruction starts with V, LASX instruction starts with XV.
 #define VEXT2XV_WU_HU(vd, vj)        EMIT(type_2R(0b0111011010011111001101, vj, vd))
 #define VEXT2XV_DU_HU(vd, vj)        EMIT(type_2R(0b0111011010011111001110, vj, vd))
 #define VEXT2XV_DU_WU(vd, vj)        EMIT(type_2R(0b0111011010011111001111, vj, vd))
+#define VINSGR2VR_W(vd, rj, ui2)     EMIT(type_2RI2(0b01110010111010111110, ui2, rj, vd))
 
 ////////////////////////////////////////////////////////////////////////////////
 // (undocumented) LBT extension instructions


### PR DESCRIPTION
Hi,

Testcase:

```
export BOX64_DYNAREC_MISSING=1
/yourpath/build/box64 /yourpath/x64/jdk8/bin/java -version

0x60030297: Dynarec stopped because of Opcode C5 F9 6E C1 C5 F9 70 C0 00 C4 E3 7D 18 C0 01
```

After implemented `VMOVD Gx, Ed`:

```
0x6003029b: Dynarec stopped because of Opcode C5 F9 70 C0 00 C4 E3 7D 18 C0 01 C5 FE 6F F8
Dynarec unimplemented AVX opcode size 128 prefix 66 map 0F opcode 70
```

I would implement `VPSHUFD Gx, Ex, Ib` in other patchset trying be equivalent to `VZIP` etc.[2]

Please review my initial patch.

[1] Linux/x64 JDK8:  https://www.azul.com/downloads/?version=java-8-lts&os=linux&architecture=x86-64-bit&package=jdk#zulu
[2] https://github.com/ptitSeb/box64/blob/main/src/dynarec/arm64/dynarec_arm64_avx_66_0f.c#L830

Thanks,
Leslie Zhai