### PR TITLE
[ARM64_DYNAREC] Generate corresponding hint instruction for PAUSE

### DIFF
--- a/src/dynarec/arm64/arm64_emitter.h
+++ b/src/dynarec/arm64/arm64_emitter.h
@@ -540,6 +540,7 @@ int convert_bitmask(uint64_t bitmask);
 #define BL(imm26)                       EMIT(BL_gen(((imm26)>>2)&0x3ffffff))
 
 #define NOP                             EMIT(0b11010101000000110010000000011111)
+#define WFE                             EMIT(0b11010101000000110010000001011111)
 
 #define CSINC_gen(sf, Rm, cond, Rn, Rd)     ((sf)<<31 | 0b11010100<<21 | (Rm)<<16 | (cond)<<12 | 1<<10 | (Rn)<<5 | (Rd))
 #define CSINCx(Rd, Rn, Rm, cond)            EMIT(CSINC_gen(1, Rm, cond, Rn, Rd))

--- a/src/dynarec/arm64/dynarec_arm64_00.c
+++ b/src/dynarec/arm64/dynarec_arm64_00.c
@@ -1416,6 +1416,13 @@ uintptr_t dynarec64_00(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int nin
             }
             break;
         case 0x90:
+            if (rep == 2) {
+                INST_NAME("PAUSE");
+                WFE;
+            } else {
+                INST_NAME("NOP");
+            }
+            break;
         case 0x91:
         case 0x92:
         case 0x93:
@@ -1423,15 +1430,11 @@ uintptr_t dynarec64_00(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int nin
         case 0x95:
         case 0x96:
         case 0x97:
-            gd = xRAX+(opcode&0x07)+(rex.b<<3);
-            if(gd==xRAX) {
-                INST_NAME("NOP");
-            } else {
-                INST_NAME("XCHG EAX, Reg");
-                MOVxw_REG(x2, xRAX);
-                MOVxw_REG(xRAX, gd);
-                MOVxw_REG(gd, x2);
-            }
+            INST_NAME("XCHG EAX, Reg");
+            gd = xRAX + (opcode & 0x07) + (rex.b << 3);
+            MOVxw_REG(x2, xRAX);
+            MOVxw_REG(xRAX, gd);
+            MOVxw_REG(gd, x2);
             break;
 
         case 0x98:


### PR DESCRIPTION
This PR significantly improves the performance of spinlocks on Apple M2, but has no effects on the D2000.

Test program:
```c
#include <stdint.h>
#include <stdbool.h>
#include <math.h>
#include <fenv.h>
#include <stdio.h>
#include <pthread.h>
#include <emmintrin.h>

void spin_lock(int *p)
{ 
    while(!__sync_bool_compare_and_swap(p, 0, 1)) {
        __builtin_ia32_pause();
    }
}

void spin_unlock(int volatile *p)
{
    asm volatile ("":::"memory");
    *p = 0;
}

#define NUM_THREADS 10
#define NUM_ITERATIONS 2000000

int lock = 0;
int counter = 0;

void* increment_counter(void* arg) {
    for (int i = 0; i < NUM_ITERATIONS; ++i) {
        spin_lock(&lock);
        counter++;
        spin_unlock(&lock);
    }
    return NULL;
}

int main() {
    pthread_t threads[NUM_THREADS];
    for (int i = 0; i < NUM_THREADS; ++i) {
        if (pthread_create(&threads[i], NULL, increment_counter, NULL) != 0) {
            perror("pthread_create failed");
            return 1;
        }
    }

    for (int i = 0; i < NUM_THREADS; ++i) {
        pthread_join(threads[i], NULL);
    }
    
    printf("Final counter value: %d\n", counter);
    return 0;
}

```

Performance on the Apple M2

```
ksco@Ubuntu:~$ export BOX64_LOG=0
ksco@Ubuntu:~$ time ./box64_original spinlock_test 
Box64 with Dynarec v0.3.1 b8ed1b96 built on Nov 24 2024 16:10:53
Final counter value: 20000000

real	0m6.855s
user	0m54.229s
sys	0m0.021s
ksco@Ubuntu:~$ time ./box64_with_wfe spinlock_test 
Box64 with Dynarec v0.3.1 e34550d4 built on Nov 24 2024 17:27:23
Final counter value: 20000000

real	0m0.399s
user	0m2.600s
sys	0m0.067s
ksco@Ubuntu:~$ uname -a
Linux Ubuntu 6.11.9-orbstack-00279-g4cf512143f2e #60 SMP Mon Nov 18 05:48:29 UTC 2024 aarch64 aarch64 aarch64 GNU/Linux
ksco@Ubuntu:~$ 
```