### PR TITLE
Add the '--gst' option to the wrapper helper

### DIFF
--- a/wrapperhelper/src/lang.c
+++ b/wrapperhelper/src/lang.c
@@ -1176,7 +1176,8 @@ void type_print(type_t *typ) {
 void struct_print(const struct_t *st) {
 	printf("<" DISP_ADDR_FMT "n_uses=%zu> ", DISP_ADDR_ARG(st) st->nrefs);
 	if (st->is_simple) {
-		printf("<simple> ");
+		printf("<simple> %s %s <don't care>", st->is_struct ? "struct" : "union", st->tag ? string_content(st->tag) : "<no tag>");
+		return;
 	}
 	if (st->is_defined) {
 		printf(

--- a/wrapperhelper/src/main.c
+++ b/wrapperhelper/src/main.c
@@ -13,8 +13,8 @@
 
 static void help(char *arg0) {
 	printf("Usage: %s --help\n"
-	       "       %s {-I/path/to/include}* [--prepare|--preproc|--proc] [--arch <arch>|-32|-64|--32|--64] <filename_in>\n"
-	       "       %s {-I/path/to/include}* [[--emu <arch>] [--target <arch>]|-32|-64|--32|--64] <filename_in> <filename_reqs> <filename_out>\n"
+	       "       %s {-I/path/to/include}* [--gst] [--prepare|--preproc|--proc] [--arch <arch>|-32|-64|--32|--64] <filename_in>\n"
+	       "       %s {-I/path/to/include}* [--gst] [[--emu <arch>] [--target <arch>]|-32|-64|--32|--64] <filename_in> <filename_reqs> <filename_out>\n"
 	       "\n"
 	       "  --prepare  Dump all preprocessor tokens (prepare phase)\n"
 	       "  --preproc  Dump all processor tokens (preprocessor phase)\n"
@@ -33,7 +33,9 @@ static void help(char *arg0) {
 	       "  -32  --32        Use the x86 architecture as arch/emulated, aarch64 as target\n"
 	       "  -64  --64        Use the x86_64 architecture as arch/emulated, aarch64 as target\n"
 	       "\n"
-	       "  <arch> is one of 'x86', 'x86_64', 'aarch64'\n",
+	       "  <arch> is one of 'x86', 'x86_64', 'aarch64'\n"
+	       "\n"
+	       "  --gst            Mark all structures with a tag starting with '_G' and ending with 'Class' as simple\n",
 	       arg0, arg0, arg0);
 }
 
@@ -49,6 +51,8 @@ enum bits_state {
 	BITS_32,
 	BITS_64,
 };
+
+int is_gst = 0;
 
 int main(int argc, char **argv) {
 	setbuf(stdout, NULL);
@@ -75,6 +79,8 @@ int main(int argc, char **argv) {
 			ms = MAIN_PREPROC;
 		} else if (!strcmp(argv[i], "--proc")) {
 			ms = MAIN_PROC;
+		} else if (!strcmp(argv[i], "--gst")) {
+			is_gst = 1;
 		} else if (!strcmp(argv[i], "-pthread")) {
 			// Ignore
 		} else if (!strcmp(argv[i], "-I") && (i + 1 < argc)) {

--- a/wrapperhelper/src/parse.c
+++ b/wrapperhelper/src/parse.c
@@ -1431,6 +1431,8 @@ static int eval_expression(loginfo_t *li, machine_t *target, expr_t *e, khash_t(
 	}
 }
 
+extern int is_gst; // If 1, mark structures _G*Class as simple
+
 // declaration-specifier with storage != NULL
 // specifier-qualifier-list + static_assert-declaration with storage == NULL
 static int parse_declaration_specifier(machine_t *target, khash_t(struct_map) *struct_map, khash_t(type_map) *type_map, khash_t(type_map) *enum_map,
@@ -2047,6 +2049,13 @@ parse_cur_token_decl:
 			typ->val.st->nmembers = vector_size(st_members, members);
 			typ->val.st->members = vector_steal(st_members, members);
 			typ->val.st->is_defined = 1;
+			if (is_gst
+			       && typ->val.st->tag
+			       && (string_len(typ->val.st->tag) >= 7)
+			       && !strncmp(string_content(typ->val.st->tag), "_G", 2)
+			       && !strcmp(string_content(typ->val.st->tag) + string_len(typ->val.st->tag) - 5, "Class")) {
+				typ->val.st->is_simple = 1;
+			}
 			*tok = proc_next_token(prep);
 			goto parse_cur_token_decl;
 		} else {


### PR DESCRIPTION
This PR adds the `--gst` option to the wrapper helper, which automatically marks every structure starting with `_G` and ending with `Class` as simple.
This option is very rough in its current state, and may not be very usable. Note that the behavioural change is completely removed if `--gst` is not provided when running the binary.