### PR TITLE
[LA64_DYNAREC] Fix LOCK ADC wrong ed (#2069)

### DIFF
--- a/src/dynarec/la64/dynarec_la64_f0.c
+++ b/src/dynarec/la64/dynarec_la64_f0.c
@@ -410,7 +410,7 @@ uintptr_t dynarec64_F0(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
             GETGD;
             SMDMB();
             if (MODREG) {
-                ed = xRAX + (nextop & 7) + (rex.b << 3);
+                ed = TO_LA64((nextop & 7) + (rex.b << 3));
                 emit_adc32(dyn, ninst, rex, ed, gd, x3, x4, x5, x6);
             } else {
                 addr = geted(dyn, addr, ninst, nextop, &wback, x2, x1, &fixedaddress, rex, LOCK_LOCK, 0, 0);


### PR DESCRIPTION
Hi,

Sorry for introduced the issue!

Passed testcase for `LOCK ADC`:

```
#include <stdio.h>
#include <stdint.h>
#include <assert.h>

void test_lock_adc32(uint32_t n, uint32_t m, uint32_t expected_eax, uint32_t expected_edx) {
  uint32_t eax;
  uint32_t edx;
  __asm__ __volatile__ (
      "movl  %[n], %%edx\n"
      "movl  %[m], %%eax\n"
      "addl  %[m], %%eax\n"
      "lock; adcl  %[n], %%edx\n"
      "movl  %%eax, %[eax]\n"
      "movl  %%edx, %[edx]\n"
      : [eax] "=r" (eax), [edx] "=r" (edx)
      : [n] "r" (n), [m] "r" (m)
      : "eax", "edx", "memory");
  printf("eax=0x%x\n", eax);
  printf("edx=0x%x\n", edx);
  assert(eax == expected_eax && edx == expected_edx);
}

int main(int argc, char* argv[]) {
  test_lock_adc32(0x0, 0xFFFFFFFF, 0xFFFFFFFE, 0x1);
  return 0;
}
```

Please review my patch.

Thanks,
Leslie Zhai