### PR TITLE
[LA64_DYNAREC] Act like INT 3

### DIFF
--- a/src/dynarec/la64/dynarec_la64_00.c
+++ b/src/dynarec/la64/dynarec_la64_00.c
@@ -1858,6 +1858,7 @@ uintptr_t dynarec64_00(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
                     CALL(native_int3, -1);
                     LOAD_XEMU_CALL();
                     MARK;
+                    BRK(0x5);
                     jump_to_epilog(dyn, addr, 0, ninst);
                     *need_epilog = 0;
                     *ok = 0;

--- a/src/dynarec/la64/la64_emitter.h
+++ b/src/dynarec/la64/la64_emitter.h
@@ -274,6 +274,8 @@ f24-f31  fs0-fs7   Static registers                Callee
 #define DMB_ISHLD() DBAR_R_RW()
 #define DMB_ISHST() DBAR_W_RW()
 
+#define BRK(hint) EMIT(type_hint(0b00000000001010100, hint))
+
 // GR[rd] = GR[rj] & GR[rk]
 #define AND(rd, rj, rk) EMIT(type_3R(0b00000000000101001, rk, rj, rd))
 // GR[rd] = GR[rj] | GR[rk]


### PR DESCRIPTION
Hi,

Testcase:
```
#include <stdio.h>
#include <stdlib.h>

int main(int argc, char* argv[]) {
  __asm__ __volatile__ ("int3\n");
  char* p = getenv("BOX64_IGNOREINT3");
  if (p && p[0] == '1') {
    printf("You can see me\n");
  } else {
    printf("You can *NOT* see me\n");
  }
  return 0;
}
```

Before:
```
You can *NOT* see me
```

After applied the patch:
```
export BOX64_IGNOREINT3=1
You can see me

export BOX64_IGNOREINT3=0
Trace/breakpoint trap
```

Please review my patch.

Thanks,
Leslie Zhai