### PR TITLE
[LA64_DYNAREC] Added LEA opcode

### DIFF
--- a/src/dynarec/la64/dynarec_la64_67.c
+++ b/src/dynarec/la64/dynarec_la64_67.c
@@ -144,6 +144,17 @@ uintptr_t dynarec64_67(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
                 SMWRITELOCK(lock);
             }
             break;
+        case 0x8D:
+            INST_NAME("LEA Gd, Ed");
+            nextop = F8;
+            GETGD;
+            if (MODREG) { // reg <= reg? that's an invalid operation
+                DEFAULT;
+            } else { // mem <= reg
+                addr = geted32(dyn, addr, ninst, nextop, &ed, gd, x1, &fixedaddress, rex, NULL, 0, 0);
+                ZEROUP2(gd, ed);
+            }
+            break;
         case 0xF7:
             nextop = F8;
             switch ((nextop >> 3) & 7) {


### PR DESCRIPTION
Hi,

Passed real world demo[1]:
```
export BOX64_DYNAREC_MISSING=1
./build/box64 /yourpath/linux-x64-jdk23/bin/java -cp "libs/*:." -Dorg.lwjgl.librarypath=./libs/native MinecraftDemo
```

Please review my patch.

[1] https://github.com/LWJGL/lwjgl3/tree/master/modules/samples/src/test/java/org/lwjgl/demo/glfw

Thanks,
Leslie Zhai