### PR TITLE
[LA64_DYNAREC] Added more 660F opcodes

### DIFF
--- a/src/dynarec/la64/dynarec_la64_660f.c
+++ b/src/dynarec/la64/dynarec_la64_660f.c
@@ -339,7 +339,7 @@ uintptr_t dynarec64_660F(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                     GETEX(q1, 0, 0);
                     GETGX_empty(q0);
                     v0 = fpu_get_scratch(dyn);
-                    VREPLGR2VR_D(v0, xZR);
+                    VXOR_V(v0, v0, v0);
                     VABSD_B(q0, q1, v0);
                     break;
                 case 0x1D:
@@ -348,7 +348,7 @@ uintptr_t dynarec64_660F(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                     GETEX(q1, 0, 0);
                     GETGX_empty(q0);
                     v0 = fpu_get_scratch(dyn);
-                    VREPLGR2VR_D(v0, xZR);
+                    VXOR_V(v0, v0, v0);
                     VABSD_H(q0, q1, v0);
                     break;
                 case 0x2B:

--- a/src/dynarec/la64/dynarec_la64_660f.c
+++ b/src/dynarec/la64/dynarec_la64_660f.c
@@ -323,15 +323,13 @@ uintptr_t dynarec64_660F(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int 
                     GETEX(q1, 0, 0);
                     v0 = fpu_get_scratch(dyn);
                     v1 = fpu_get_scratch(dyn);
-                    VMULWEV_W_H(v0, q0, q1);
-                    VMULWOD_W_H(v1, q0, q1);
-                    VSRAI_W(v0, v0, 14);
-                    VSRAI_W(v1, v1, 14);
-                    VADDI_WU(v0, v0, 1);
-                    VADDI_WU(v1, v1, 1);
-                    VSRANI_H_W(v1, v0, 1);
-                    VSHUF4I_W(v1, v1, 0xd8);
-                    VSHUF4I_H(q0, v1, 0xd8);
+                    VEXT2XV_W_H(v0, q0);
+                    VEXT2XV_W_H(v1, q1);
+                    XVMUL_W(v0, v0, v1);
+                    XVSRLI_W(v0, v0, 14);
+                    XVADDI_WU(v0, v0, 1);
+                    XVSRLNI_H_W(v0, v0, 1);
+                    XVPERMI_D(q0, v0, 0b1000);
                     break;
                 case 0x1C:
                     INST_NAME("PABSB Gx,Ex");

--- a/src/dynarec/la64/dynarec_la64_helper.h
+++ b/src/dynarec/la64/dynarec_la64_helper.h
@@ -314,6 +314,8 @@
         ed = i;                                                                                     \
     }
 
+#define VEXTRINS_IMM_4_0(n, m) ((n & 0xf) << 4 | (m & 0xf))
+
 // Get GX as a quad (might use x1)
 #define GETGX(a, w)                             \
     gd = ((nextop & 0x38) >> 3) + (rex.r << 3); \

--- a/src/dynarec/la64/la64_emitter.h
+++ b/src/dynarec/la64/la64_emitter.h
@@ -1821,7 +1821,9 @@ LSX instruction starts with V, LASX instruction starts with XV.
 #define VEXT2XV_WU_HU(vd, vj)        EMIT(type_2R(0b0111011010011111001101, vj, vd))
 #define VEXT2XV_DU_HU(vd, vj)        EMIT(type_2R(0b0111011010011111001110, vj, vd))
 #define VEXT2XV_DU_WU(vd, vj)        EMIT(type_2R(0b0111011010011111001111, vj, vd))
-#define VREPLGR2VR_D(vd, rj)         EMIT(type_2R(0b0111001010011111000011, rj, vd))
+#define XVADDI_WU(vd, vj, imm5)      EMIT(type_2RI5(0b01110110100010110, imm5, vj, vd))
+#define XVSRLNI_H_W(vd, vj, imm5)    EMIT(type_2RI5(0b01110111010000001, imm5, vj, vd))
+#define XVSRLI_W(vd, vj, imm5)       EMIT(type_2RI5(0b01110111001100001, imm5, vj, vd))
 
 ////////////////////////////////////////////////////////////////////////////////
 // (undocumented) LBT extension instructions

--- a/src/dynarec/la64/la64_emitter.h
+++ b/src/dynarec/la64/la64_emitter.h
@@ -1287,6 +1287,7 @@ LSX instruction starts with V, LASX instruction starts with XV.
 #define VBITSET_H(vd, vj, vk)        EMIT(type_3R(0b01110001000011101, vk, vj, vd))
 #define VBITSET_W(vd, vj, vk)        EMIT(type_3R(0b01110001000011110, vk, vj, vd))
 #define VBITSET_D(vd, vj, vk)        EMIT(type_3R(0b01110001000011111, vk, vj, vd))
+#define VBITSEL_V(vd, vj, vk, va)    EMIT(type_4R(0b000011010001, va, vk, vj, vd))
 #define VBITREV_B(vd, vj, vk)        EMIT(type_3R(0b01110001000100000, vk, vj, vd))
 #define VBITREV_H(vd, vj, vk)        EMIT(type_3R(0b01110001000100001, vk, vj, vd))
 #define VBITREV_W(vd, vj, vk)        EMIT(type_3R(0b01110001000100010, vk, vj, vd))
@@ -1369,9 +1370,11 @@ LSX instruction starts with V, LASX instruction starts with XV.
 #define VSLE_HU(vd, vj, vk)          EMIT(type_3R(0b01110000000001001, vk, vj, vd))
 #define VSLE_WU(vd, vj, vk)          EMIT(type_3R(0b01110000000001010, vk, vj, vd))
 #define VSLE_DU(vd, vj, vk)          EMIT(type_3R(0b01110000000001011, vk, vj, vd))
+#define VSLEI_DU(vd, vj, imm5)       EMIT(type_2RI5(0b01110010100001011, imm5, vj, vd))
 #define VSLT_B(vd, vj, vk)           EMIT(type_3R(0b01110000000001100, vk, vj, vd))
 #define VSLT_H(vd, vj, vk)           EMIT(type_3R(0b01110000000001101, vk, vj, vd))
 #define VSLT_W(vd, vj, vk)           EMIT(type_3R(0b01110000000001110, vk, vj, vd))
+#define VSLTI_W(vd, vj, imm5)        EMIT(type_2RI5(0b01110010100001110, imm5, vj, vd))
 #define VSLT_D(vd, vj, vk)           EMIT(type_3R(0b01110000000001111, vk, vj, vd))
 #define VSLT_BU(vd, vj, vk)          EMIT(type_3R(0b01110000000010000, vk, vj, vd))
 #define VSLT_HU(vd, vj, vk)          EMIT(type_3R(0b01110000000010001, vk, vj, vd))
@@ -1818,6 +1821,7 @@ LSX instruction starts with V, LASX instruction starts with XV.
 #define VEXT2XV_WU_HU(vd, vj)        EMIT(type_2R(0b0111011010011111001101, vj, vd))
 #define VEXT2XV_DU_HU(vd, vj)        EMIT(type_2R(0b0111011010011111001110, vj, vd))
 #define VEXT2XV_DU_WU(vd, vj)        EMIT(type_2R(0b0111011010011111001111, vj, vd))
+#define VREPLGR2VR_D(vd, rj)         EMIT(type_2R(0b0111001010011111000011, rj, vd))
 
 ////////////////////////////////////////////////////////////////////////////////
 // (undocumented) LBT extension instructions


### PR DESCRIPTION
Hi,

[dav1d benchmark](https://archive.fosdem.org/2021/stands.fosdem.org/stands/box86/performances/):
```
./dav1d -i Chimera-AV1-8bit-480x270-552kbps.ivf --muxer null
```

before:
```
Decoded 8929/8929 frames (100.0%) - 3.67/23.98 fps (0.15x)

real	40m35.251s
user	40m20.151s
```

after:
```
Decoded 8929/8929 frames (100.0%) - 89.06/23.98 fps (3.71x)

real	1m40.299s
user	1m39.578s
```

Please review my patch.

Thanks,
Leslie Zhai