### PR TITLE
[WRAPPED] Always return ENOSYS in the deprecated sysctl

### DIFF
--- a/src/wrapped/generated/functions_list.txt
+++ b/src/wrapped/generated/functions_list.txt
@@ -3405,7 +3405,7 @@
 #!defined(STATICBUILD) WFpLLu
 #!defined(STATICBUILD) iFEipup
 #!defined(STATICBUILD) iFEiipup
-#!defined(STATICBUILD) iFpipppL
+#!defined(STATICBUILD) iFEpipppL
 #!defined(STATICBUILD) lFpLpdddddd
 #() vFEv -> vFE
 #() iFEv -> iFE
@@ -4734,6 +4734,9 @@ wrappedlibc:
   - lsearch
 - vFiipupV:
   - error_at_line
+- iFpipppL:
+  - __sysctl
+  - sysctl
 - iFpLiLpp:
   - __vsnprintf_chk
 - iFpLiLpV:

--- a/src/wrapped/generated/wrappedlibctypes.h
+++ b/src/wrapped/generated/wrappedlibctypes.h
@@ -102,6 +102,7 @@ typedef void* (*pFpLLiN_t)(void*, uintptr_t, uintptr_t, int32_t, ...);
 typedef void* (*pFppLLp_t)(void*, void*, uintptr_t, uintptr_t, void*);
 typedef void* (*pFpppLp_t)(void*, void*, void*, uintptr_t, void*);
 typedef void (*vFiipupV_t)(int32_t, int32_t, void*, uint32_t, void*, ...);
+typedef int32_t (*iFpipppL_t)(void*, int32_t, void*, void*, void*, uintptr_t);
 typedef int32_t (*iFpLiLpp_t)(void*, uintptr_t, int32_t, uintptr_t, void*, void*);
 typedef int32_t (*iFpLiLpV_t)(void*, uintptr_t, int32_t, uintptr_t, void*, ...);
 typedef int32_t (*iFpppppp_t)(void*, void*, void*, void*, void*, void*);
@@ -326,6 +327,8 @@ typedef int32_t (*iFppipppp_t)(void*, void*, int32_t, void*, void*, void*, void*
 	GO(lfind, pFpppLp_t) \
 	GO(lsearch, pFpppLp_t) \
 	GO(error_at_line, vFiipupV_t) \
+	GO(__sysctl, iFpipppL_t) \
+	GO(sysctl, iFpipppL_t) \
 	GO(__vsnprintf_chk, iFpLiLpp_t) \
 	GO(__snprintf_chk, iFpLiLpV_t) \
 	GO(__swprintf_chk, iFpLiLpV_t) \

--- a/src/wrapped/generated/wrapper.c
+++ b/src/wrapped/generated/wrapper.c
@@ -3492,7 +3492,7 @@ typedef int32_t (*iFLLii_t)(uintptr_t, uintptr_t, int32_t, int32_t);
 typedef uint16_t (*WFpLLu_t)(void*, uintptr_t, uintptr_t, uint32_t);
 typedef int32_t (*iFEipup_t)(x64emu_t*, int32_t, void*, uint32_t, void*);
 typedef int32_t (*iFEiipup_t)(x64emu_t*, int32_t, int32_t, void*, uint32_t, void*);
-typedef int32_t (*iFpipppL_t)(void*, int32_t, void*, void*, void*, uintptr_t);
+typedef int32_t (*iFEpipppL_t)(x64emu_t*, void*, int32_t, void*, void*, void*, uintptr_t);
 typedef intptr_t (*lFpLpdddddd_t)(void*, uintptr_t, void*, double, double, double, double, double, double);
 #endif
 
@@ -6964,7 +6964,7 @@ void iFLLii(x64emu_t *emu, uintptr_t fcn) { iFLLii_t fn = (iFLLii_t)fcn; R_RAX=(
 void WFpLLu(x64emu_t *emu, uintptr_t fcn) { WFpLLu_t fn = (WFpLLu_t)fcn; R_RAX=(unsigned short)fn((void*)R_RDI, (uintptr_t)R_RSI, (uintptr_t)R_RDX, (uint32_t)R_RCX); }
 void iFEipup(x64emu_t *emu, uintptr_t fcn) { iFEipup_t fn = (iFEipup_t)fcn; R_RAX=(uint32_t)fn(emu, (int32_t)R_RDI, (void*)R_RSI, (uint32_t)R_RDX, (void*)R_RCX); }
 void iFEiipup(x64emu_t *emu, uintptr_t fcn) { iFEiipup_t fn = (iFEiipup_t)fcn; R_RAX=(uint32_t)fn(emu, (int32_t)R_RDI, (int32_t)R_RSI, (void*)R_RDX, (uint32_t)R_RCX, (void*)R_R8); }
-void iFpipppL(x64emu_t *emu, uintptr_t fcn) { iFpipppL_t fn = (iFpipppL_t)fcn; R_RAX=(uint32_t)fn((void*)R_RDI, (int32_t)R_RSI, (void*)R_RDX, (void*)R_RCX, (void*)R_R8, (uintptr_t)R_R9); }
+void iFEpipppL(x64emu_t *emu, uintptr_t fcn) { iFEpipppL_t fn = (iFEpipppL_t)fcn; R_RAX=(uint32_t)fn(emu, (void*)R_RDI, (int32_t)R_RSI, (void*)R_RDX, (void*)R_RCX, (void*)R_R8, (uintptr_t)R_R9); }
 void lFpLpdddddd(x64emu_t *emu, uintptr_t fcn) { lFpLpdddddd_t fn = (lFpLpdddddd_t)fcn; R_RAX=(intptr_t)fn((void*)R_RDI, (uintptr_t)R_RSI, (void*)R_RDX, emu->xmm[0].d[0], emu->xmm[1].d[0], emu->xmm[2].d[0], emu->xmm[3].d[0], emu->xmm[4].d[0], emu->xmm[5].d[0]); }
 #endif
 
@@ -8988,7 +8988,6 @@ int isSimpleWrapper(wrapper_t fun) {
 	if (fun == &iFLLi) return 1;
 	if (fun == &iFLLii) return 1;
 	if (fun == &WFpLLu) return 1;
-	if (fun == &iFpipppL) return 1;
 	if (fun == &lFpLpdddddd) return 7;
 #endif
 	return 0;
@@ -11003,7 +11002,6 @@ int isSimpleWrapper(wrapper_t fun) {
 	if (fun == &iFLLi) return 65;
 	if (fun == &iFLLii) return 193;
 	if (fun == &WFpLLu) return 129;
-	if (fun == &iFpipppL) return 33;
 	if (fun == &lFpLpdddddd) return 7;
 #endif
 	return 0;

--- a/src/wrapped/generated/wrapper.h
+++ b/src/wrapped/generated/wrapper.h
@@ -3450,7 +3450,7 @@ void iFLLii(x64emu_t *emu, uintptr_t fnc);
 void WFpLLu(x64emu_t *emu, uintptr_t fnc);
 void iFEipup(x64emu_t *emu, uintptr_t fnc);
 void iFEiipup(x64emu_t *emu, uintptr_t fnc);
-void iFpipppL(x64emu_t *emu, uintptr_t fnc);
+void iFEpipppL(x64emu_t *emu, uintptr_t fnc);
 void lFpLpdddddd(x64emu_t *emu, uintptr_t fnc);
 #endif
 

--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -1531,6 +1531,24 @@ EXPORT void* my_tsearch(x64emu_t* emu, void* key, void* root, void* fnc)
     (void)emu;
     return tsearch(key, root, findcompareFct(fnc));
 }
+
+EXPORT int my___sysctl(x64emu_t* emu, int* name, int nlen, void* oldval, size_t* oldlenp, void* newval, size_t newlen)
+{
+    return ENOSYS;
+}
+
+EXPORT int my_sysctl(x64emu_t* emu, int* name, int nlen, void* oldval, size_t* oldlenp, void* newval, size_t newlen)
+{
+    /* Glibc 2.32 Release note.
+      The deprecated <sys/sysctl.h> header and the sysctl function have been
+      removed.  To support old binaries, the sysctl function continues to
+      exist as a compatibility symbol (on those architectures which had it),
+      but always fails with ENOSYS.  This reflects the removal of the system
+      call from all architectures, starting with Linux 5.5.
+    */
+    return ENOSYS;
+}
+
 EXPORT void my_tdestroy(x64emu_t* emu, void* root, void* fnc)
 {
     (void)emu;

--- a/src/wrapped/wrappedlibc_private.h
+++ b/src/wrapped/wrappedlibc_private.h
@@ -2152,8 +2152,8 @@ GOM(sysconf, lFEi)
 //DATA(_sys_errlist, 8)
 //DATA(sys_errlist, 8)
 #else
-GO(__sysctl, iFpipppL)
-GOW(sysctl, iFpipppL)
+GOM(__sysctl, iFEpipppL)
+GOWM(sysctl, iFEpipppL)
 DATA(_sys_errlist, 8)
 DATA(sys_errlist, 8)
 #endif


### PR DESCRIPTION
On some newer architectures, like LoongArch, there is no `sysctl()` symbol.