### PR TITLE
[DYNAREC] Implement perf map

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -245,6 +245,11 @@ The GDBJIT debugging support, only available with the compilation option GDBJIT=
 * 1 : Dynarec will generate GDBJIT debuginfo.
 * 2 : Dynarec will generate detailed GDBJIT debuginfo with internal state.
 
+#### BOX64_DYNAREC_PERFMAP *
+Dynarec generate map file for Linux perf tool.
+* 0 : Dynarec will not generate perf map. (Default)
+* 1 : Dynarec will generate perf map.
+
 #### BOX64_DYNAREC_MISSING *
 Dynarec print the missing opcodes
 * 0 : not print the missing opcode (Default, unless DYNAREC_LOG>=1 or DYNAREC_DUMP>=1 is used)

--- a/docs/box64.pod
+++ b/docs/box64.pod
@@ -375,6 +375,13 @@ The GDBJIT debugging support, only available with the compilation option GDBJIT=
     * 1 : Dynarec will generate GDBJIT debuginfo.
     * 2 : Dynarec will generate detailed GDBJIT debuginfo with internal state.
 
+=item B<BOX64_DYNAREC_PERFMAP>=I<0|1>
+
+Dynarec generate map file for Linux perf tool.
+
+    * 0 : Dynarec will not generate perf map. (Default)
+    * 1 : Dynarec will generate perf map.
+
 =item B<BOX64_SSE_FLUSHTO0>=I<0|1>
 
 Handling of SSE Flush to 0 flags

--- a/src/dynarec/arm64/dynarec_arm64_functions.c
+++ b/src/dynarec/arm64/dynarec_arm64_functions.c
@@ -850,9 +850,7 @@ void inst_name_pass3(dynarec_native_t* dyn, int ninst, const char* name, rex_t r
         dyn->gdbjit_block = GdbJITBlockAddLine(dyn->gdbjit_block, (dyn->native_start + dyn->insts[ninst].address), inst_name);
     }
     if (box64_dynarec_perf_map && box64_dynarec_perf_map_fd != -1) {
-        buf[128];
-        snprintf(buf, sizeof(buf), "0x%lx %ld %s\n", dyn->native_start + dyn->insts[ninst].address, dyn->insts[ninst].size / 4, name);
-        write(box64_dynarec_perf_map_fd, buf, strlen(buf));
+        writePerfMap(dyn->insts[ninst].x64.addr, dyn->native_start + dyn->insts[ninst].address, dyn->insts[ninst].size / 4);
     }
 }
 

--- a/src/dynarec/arm64/dynarec_arm64_functions.c
+++ b/src/dynarec/arm64/dynarec_arm64_functions.c
@@ -734,7 +734,7 @@ static register_mapping_t register_mappings[] = {
 
 void inst_name_pass3(dynarec_native_t* dyn, int ninst, const char* name, rex_t rex)
 {
-    if (!box64_dynarec_dump && !box64_dynarec_gdbjit) return;
+    if (!box64_dynarec_dump && !box64_dynarec_gdbjit && !box64_dynarec_perf_map) return;
 
     static char buf[512];
     int length = sprintf(buf, "barrier=%d state=%d/%d/%d(%d:%d->%d:%d), %s=%X/%X, use=%X, need=%X/%X, sm=%d(%d/%d)",
@@ -848,6 +848,11 @@ void inst_name_pass3(dynarec_native_t* dyn, int ninst, const char* name, rex_t r
             inst_name = buf2;
         }
         dyn->gdbjit_block = GdbJITBlockAddLine(dyn->gdbjit_block, (dyn->native_start + dyn->insts[ninst].address), inst_name);
+    }
+    if (box64_dynarec_perf_map && box64_dynarec_perf_map_fd != -1) {
+        buf[128];
+        snprintf(buf, sizeof(buf), "0x%lx %ld %s\n", dyn->native_start + dyn->insts[ninst].address, dyn->insts[ninst].size / 4, name);
+        write(box64_dynarec_perf_map_fd, buf, strlen(buf));
     }
 }
 

--- a/src/dynarec/dynarec_native.c
+++ b/src/dynarec/dynarec_native.c
@@ -841,3 +841,13 @@ void* FillBlock64(dynablock_t* block, uintptr_t addr, int alternate, int is32bit
     //block->done = 1;
     return (void*)block;
 }
+
+void writePerfMap(uintptr_t func_addr, uintptr_t code_addr, size_t code_size)
+{
+    char pbuf[128];
+    uint64_t sz = 0;
+    uintptr_t start = 0;
+    const char* symbname = FindNearestSymbolName(FindElfAddress(my_context, func_addr), (void*)func_addr, &start, &sz);
+    snprintf(pbuf, sizeof(pbuf), "0x%lx %ld %s\n", code_addr, code_size, symbname);
+    write(box64_dynarec_perf_map_fd, pbuf, strlen(pbuf));
+}

--- a/src/dynarec/la64/dynarec_la64_functions.c
+++ b/src/dynarec/la64/dynarec_la64_functions.c
@@ -26,6 +26,7 @@
 #include "custommem.h"
 #include "bridge.h"
 #include "gdbjit.h"
+#include "elfloader.h"
 
 #define XMM0 0
 #define XMM8 16
@@ -398,9 +399,7 @@ void inst_name_pass3(dynarec_native_t* dyn, int ninst, const char* name, rex_t r
         dyn->gdbjit_block = GdbJITBlockAddLine(dyn->gdbjit_block, (dyn->native_start + dyn->insts[ninst].address), inst_name);
     }
     if (box64_dynarec_perf_map && box64_dynarec_perf_map_fd != -1) {
-        buf[128];
-        snprintf(buf, sizeof(buf), "0x%lx %ld %s\n", dyn->native_start + dyn->insts[ninst].address, dyn->insts[ninst].size / 4, name);
-        write(box64_dynarec_perf_map_fd, buf, strlen(buf));
+        writePerfMap(dyn->insts[ninst].x64.addr, dyn->native_start + dyn->insts[ninst].address, dyn->insts[ninst].size / 4);
     }
 }
 

--- a/src/dynarec/la64/dynarec_la64_functions.c
+++ b/src/dynarec/la64/dynarec_la64_functions.c
@@ -331,7 +331,7 @@ static register_mapping_t register_mappings[] = {
 
 void inst_name_pass3(dynarec_native_t* dyn, int ninst, const char* name, rex_t rex)
 {
-    if (!box64_dynarec_dump && !box64_dynarec_gdbjit) return;
+    if (!box64_dynarec_dump && !box64_dynarec_gdbjit && !box64_dynarec_perf_map) return;
 
     static char buf[512];
     int length = sprintf(buf, "barrier=%d state=%d/%d(%d), %s=%X/%X, use=%X, need=%X/%X, fuse=%d, sm=%d(%d/%d)",
@@ -396,6 +396,11 @@ void inst_name_pass3(dynarec_native_t* dyn, int ninst, const char* name, rex_t r
             inst_name = buf2;
         }
         dyn->gdbjit_block = GdbJITBlockAddLine(dyn->gdbjit_block, (dyn->native_start + dyn->insts[ninst].address), inst_name);
+    }
+    if (box64_dynarec_perf_map && box64_dynarec_perf_map_fd != -1) {
+        buf[128];
+        snprintf(buf, sizeof(buf), "0x%lx %ld %s\n", dyn->native_start + dyn->insts[ninst].address, dyn->insts[ninst].size / 4, name);
+        write(box64_dynarec_perf_map_fd, buf, strlen(buf));
     }
 }
 

--- a/src/dynarec/rv64/dynarec_rv64_functions.c
+++ b/src/dynarec/rv64/dynarec_rv64_functions.c
@@ -698,7 +698,7 @@ static register_mapping_t register_mappings[] = {
 
 void inst_name_pass3(dynarec_native_t* dyn, int ninst, const char* name, rex_t rex)
 {
-    if (!box64_dynarec_dump && !box64_dynarec_gdbjit) return;
+    if (!box64_dynarec_dump && !box64_dynarec_gdbjit && !box64_dynarec_perf_map) return;
 
     static char buf[512];
     int length = sprintf(buf, "barrier=%d state=%d/%d(%d), %s=%X/%X, use=%X, need=%X/%X, fuse=%d, sm=%d(%d/%d), sew@entry=%d, sew@exit=%d",
@@ -771,6 +771,11 @@ void inst_name_pass3(dynarec_native_t* dyn, int ninst, const char* name, rex_t r
             inst_name = buf2;
         }
         dyn->gdbjit_block = GdbJITBlockAddLine(dyn->gdbjit_block, (dyn->native_start + dyn->insts[ninst].address), inst_name);
+    }
+    if (box64_dynarec_perf_map && box64_dynarec_perf_map_fd != -1) {
+        buf[128];
+        snprintf(buf, sizeof(buf), "0x%lx %ld %s\n", dyn->native_start + dyn->insts[ninst].address, dyn->insts[ninst].size / 4, name);
+        write(box64_dynarec_perf_map_fd, buf, strlen(buf));
     }
 }
 

--- a/src/dynarec/rv64/dynarec_rv64_functions.c
+++ b/src/dynarec/rv64/dynarec_rv64_functions.c
@@ -773,9 +773,7 @@ void inst_name_pass3(dynarec_native_t* dyn, int ninst, const char* name, rex_t r
         dyn->gdbjit_block = GdbJITBlockAddLine(dyn->gdbjit_block, (dyn->native_start + dyn->insts[ninst].address), inst_name);
     }
     if (box64_dynarec_perf_map && box64_dynarec_perf_map_fd != -1) {
-        buf[128];
-        snprintf(buf, sizeof(buf), "0x%lx %ld %s\n", dyn->native_start + dyn->insts[ninst].address, dyn->insts[ninst].size / 4, name);
-        write(box64_dynarec_perf_map_fd, buf, strlen(buf));
+        writePerfMap(dyn->insts[ninst].x64.addr, dyn->native_start + dyn->insts[ninst].address, dyn->insts[ninst].size / 4);
     }
 }
 

--- a/src/include/debug.h
+++ b/src/include/debug.h
@@ -43,6 +43,8 @@ extern int box64_dynarec_missing;
 extern int box64_dynarec_aligned_atomics;
 extern int box64_dynarec_nativeflags;
 extern int box64_dynarec_df;
+extern int box64_dynarec_perf_map;
+extern int box64_dynarec_perf_map_fd;
 #ifdef ARM64
 extern int arm64_asimd;
 extern int arm64_aes;

--- a/src/include/dynarec_native.h
+++ b/src/include/dynarec_native.h
@@ -26,4 +26,6 @@ void addInst(instsize_t* insts, size_t* size, int x64_size, int native_size);
 void CancelBlock64(int need_lock);
 void* FillBlock64(dynablock_t* block, uintptr_t addr, int alternate, int is32bits);
 
+void writePerfMap(uintptr_t func_addr, uintptr_t code_addr, size_t code_size);
+
 #endif //__DYNAREC_ARM_H_


### PR DESCRIPTION
Hi,

To find out DynaRec jit "hot" code:
```
perf record -e cpu-cycles box64 scimark4-x64
```
scimark:  https://math.nist.gov/scimark2/download_c.html

Before no perf map no Symbol:
```
Samples: 133K of event 'cpu-cycles:u', Event count (approx.): 66380844254
Overhead  Command       Shared Object          Symbol
   2.38%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c3888
   2.35%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c388c
   1.18%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c62ec
   1.14%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c62fc
   0.96%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c62ac
   0.94%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c0c7c
   0.88%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c0c6c
   0.82%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c0b7c
   0.80%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c0b74
   0.78%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c0cdc
   0.76%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c60ec
   0.73%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c0c74
   0.68%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c0b78
   0.62%  scimark4-x64  perf-19878.map         [.] 0x000000fff42bcec0
   0.62%  scimark4-x64  perf-19878.map         [.] 0x000000fff42bceb0
   0.57%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c0c78
   0.57%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c0c80
   0.56%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c6114
   0.54%  scimark4-x64  perf-19878.map         [.] 0x000000fff42bcef0
   0.52%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c0bf4
   0.52%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c625c
   0.50%  scimark4-x64  perf-19878.map         [.] 0x000000fff42c65c4
...
```

After generated perf map just use x86 INST NAME as the Symbol name:
```
Samples: 133K of event 'cpu-cycles:u', Event count (approx.): 66395424841
Overhead  Command       Shared Object          Symbol
   2.39%  scimark4-x64  perf-20589.map         [.] 0x000000fff306388c
   2.31%  scimark4-x64  perf-20589.map         [.] 0x000000fff3063888
   1.14%  scimark4-x64  perf-20589.map         [.] 0x000000fff30662ec
   1.13%  scimark4-x64  perf-20589.map         [.] 0x000000fff30662fc
   0.95%  scimark4-x64  perf-20589.map         [.] ADD Ed, Ib
   0.93%  scimark4-x64  perf-20589.map         [.] 0x000000fff3060c7c
   0.89%  scimark4-x64  perf-20589.map         [.] 0x000000fff3060c6c
   0.86%  scimark4-x64  perf-20589.map         [.] RET
   0.82%  scimark4-x64  perf-20589.map         [.] 0x000000fff3060b7c
   0.81%  scimark4-x64  perf-20589.map         [.] MOVSD Ex, Gx
   0.78%  scimark4-x64  perf-20589.map         [.] JZ ib
   0.75%  scimark4-x64  perf-20589.map         [.] 0x000000fff3060b74
   0.75%  scimark4-x64  perf-20589.map         [.] 0x000000fff3060c74
   0.67%  scimark4-x64  perf-20589.map         [.] ADDSD Gx, Ex
   0.62%  scimark4-x64  perf-20589.map         [.] SUBSD Gx, Ex
   0.61%  scimark4-x64  perf-20589.map         [.] UNPCKHPD Gx, Ex
   0.60%  scimark4-x64  perf-20589.map         [.] MULSD Gx, Ex
   0.57%  scimark4-x64  perf-20589.map         [.] JZ ib
   0.56%  scimark4-x64  perf-20589.map         [.] ADD Ed, Gd
   0.55%  scimark4-x64  perf-20589.map         [.] 0x000000fff306625c
   0.53%  scimark4-x64  perf-20589.map         [.] ADDSD Gx, Ex
...
```

Please review my patch and give some suggestion.

Thanks,
Leslie Zhai