### PR TITLE
[DYNAREC] Appended instruction name to symbol

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -925,7 +925,7 @@ void LoadLogEnv()
                 box64_dynarec_perf_map = p[0] - '0';
         }
         if (box64_dynarec_perf_map)
-            printf_log(LOG_INFO, "Dynarec will generate map file for Linux perf tool\n");
+            printf_log(LOG_INFO, "Dynarec will generate map file /tmp/perf-%d.map for Linux perf tool\n", getpid());
     }
     p = getenv("BOX64_DYNAREC_DF");
     if(p) {

--- a/src/dynarec/arm64/dynarec_arm64_functions.c
+++ b/src/dynarec/arm64/dynarec_arm64_functions.c
@@ -850,7 +850,7 @@ void inst_name_pass3(dynarec_native_t* dyn, int ninst, const char* name, rex_t r
         dyn->gdbjit_block = GdbJITBlockAddLine(dyn->gdbjit_block, (dyn->native_start + dyn->insts[ninst].address), inst_name);
     }
     if (box64_dynarec_perf_map && box64_dynarec_perf_map_fd != -1) {
-        writePerfMap(dyn->insts[ninst].x64.addr, dyn->native_start + dyn->insts[ninst].address, dyn->insts[ninst].size / 4);
+        writePerfMap(dyn->insts[ninst].x64.addr, dyn->native_start + dyn->insts[ninst].address, dyn->insts[ninst].size / 4, name);
     }
 }
 

--- a/src/dynarec/dynarec_native.c
+++ b/src/dynarec/dynarec_native.c
@@ -842,12 +842,12 @@ void* FillBlock64(dynablock_t* block, uintptr_t addr, int alternate, int is32bit
     return (void*)block;
 }
 
-void writePerfMap(uintptr_t func_addr, uintptr_t code_addr, size_t code_size)
+void writePerfMap(uintptr_t func_addr, uintptr_t code_addr, size_t code_size, const char* inst_name)
 {
     char pbuf[128];
     uint64_t sz = 0;
     uintptr_t start = 0;
     const char* symbname = FindNearestSymbolName(FindElfAddress(my_context, func_addr), (void*)func_addr, &start, &sz);
-    snprintf(pbuf, sizeof(pbuf), "0x%lx %ld %s\n", code_addr, code_size, symbname);
+    snprintf(pbuf, sizeof(pbuf), "0x%lx %ld %s:%s\n", code_addr, code_size, symbname, inst_name);
     write(box64_dynarec_perf_map_fd, pbuf, strlen(pbuf));
 }

--- a/src/dynarec/la64/dynarec_la64_functions.c
+++ b/src/dynarec/la64/dynarec_la64_functions.c
@@ -399,7 +399,7 @@ void inst_name_pass3(dynarec_native_t* dyn, int ninst, const char* name, rex_t r
         dyn->gdbjit_block = GdbJITBlockAddLine(dyn->gdbjit_block, (dyn->native_start + dyn->insts[ninst].address), inst_name);
     }
     if (box64_dynarec_perf_map && box64_dynarec_perf_map_fd != -1) {
-        writePerfMap(dyn->insts[ninst].x64.addr, dyn->native_start + dyn->insts[ninst].address, dyn->insts[ninst].size / 4);
+        writePerfMap(dyn->insts[ninst].x64.addr, dyn->native_start + dyn->insts[ninst].address, dyn->insts[ninst].size / 4, name);
     }
 }
 

--- a/src/dynarec/rv64/dynarec_rv64_functions.c
+++ b/src/dynarec/rv64/dynarec_rv64_functions.c
@@ -773,7 +773,7 @@ void inst_name_pass3(dynarec_native_t* dyn, int ninst, const char* name, rex_t r
         dyn->gdbjit_block = GdbJITBlockAddLine(dyn->gdbjit_block, (dyn->native_start + dyn->insts[ninst].address), inst_name);
     }
     if (box64_dynarec_perf_map && box64_dynarec_perf_map_fd != -1) {
-        writePerfMap(dyn->insts[ninst].x64.addr, dyn->native_start + dyn->insts[ninst].address, dyn->insts[ninst].size / 4);
+        writePerfMap(dyn->insts[ninst].x64.addr, dyn->native_start + dyn->insts[ninst].address, dyn->insts[ninst].size / 4, name);
     }
 }
 

--- a/src/include/dynarec_native.h
+++ b/src/include/dynarec_native.h
@@ -26,6 +26,6 @@ void addInst(instsize_t* insts, size_t* size, int x64_size, int native_size);
 void CancelBlock64(int need_lock);
 void* FillBlock64(dynablock_t* block, uintptr_t addr, int alternate, int is32bits);
 
-void writePerfMap(uintptr_t func_addr, uintptr_t code_addr, size_t code_size);
+void writePerfMap(uintptr_t func_addr, uintptr_t code_addr, size_t code_size, const char* inst_name);
 
 #endif //__DYNAREC_ARM_H_


### PR DESCRIPTION
Hi,

To find benchmark some workload high branch-misses:
```
export BOX64_DYNAREC_PERFMAP=1
perf record -e branches -e branch-misses box64 scimark4-x64
```

To find Symbol `0x000000fff5417170` around:
```
Samples: 22K of event 'branch-misses:u', Event count (approx.): 225354432
Overhead  Command       Shared Object          Symbol
  29.42%  scimark4-x64  perf-22759.map         [.] 0x000000fff5417174
  29.02%  scimark4-x64  perf-22759.map         [.] 0x000000fff5417170
```

There might be some opportunity to reduce the branch-misses:
```
...
0xfff5417160 2 Random_nextDouble:TEST Ed, Gd
0xfff5417168 4 Random_nextDouble:CMOVS Gd, Ed
0xfff5417178 1 Random_nextDouble:TEST Ed, Gd
0xfff541717c 1 Random_nextDouble:MOV Ed, Gd
...
```

Please review my patch.

Thanks,
Leslie Zhai