### PR TITLE
[WRAPPED] Added monstartup

### DIFF
--- a/src/wrapped/wrappedlibc_private.h
+++ b/src/wrapped/wrappedlibc_private.h
@@ -1325,9 +1325,9 @@ GOWD(modfl, DFDp, modf)
 //GOW(moncontrol, 
 //GO(__monstartup, 
 #ifdef STATICBUILD
-//GO(monstartup, vFLL)
+//GOW(monstartup, vFLL)
 #else
-GO(monstartup, vFLL)
+GOW(monstartup, vFLL)
 #endif
 //DATA(__morecore, 
 GOW(mount, iFpppLp)

--- a/src/wrapped/wrappedlibc_private.h
+++ b/src/wrapped/wrappedlibc_private.h
@@ -1324,7 +1324,7 @@ GOWD(modfl, DFDp, modf)
 //GOW(modify_ldt, 
 //GOW(moncontrol, 
 //GO(__monstartup, 
-//GOW(monstartup, 
+GO(monstartup, iFpp)
 //DATA(__morecore, 
 GOW(mount, iFpppLp)
 GO(mprobe, iFp)

--- a/src/wrapped/wrappedlibc_private.h
+++ b/src/wrapped/wrappedlibc_private.h
@@ -1327,7 +1327,7 @@ GOWD(modfl, DFDp, modf)
 #ifdef STATICBUILD
 //GO(monstartup, iFpp)
 #else
-GO(monstartup, iFpp)
+GO(monstartup, vFLL)
 #endif
 //DATA(__morecore, 
 GOW(mount, iFpppLp)

--- a/src/wrapped/wrappedlibc_private.h
+++ b/src/wrapped/wrappedlibc_private.h
@@ -1325,7 +1325,7 @@ GOWD(modfl, DFDp, modf)
 //GOW(moncontrol, 
 //GO(__monstartup, 
 #ifdef STATICBUILD
-//GO(monstartup, iFpp)
+//GO(monstartup, vFLL)
 #else
 GO(monstartup, vFLL)
 #endif

--- a/src/wrapped/wrappedlibc_private.h
+++ b/src/wrapped/wrappedlibc_private.h
@@ -1324,7 +1324,11 @@ GOWD(modfl, DFDp, modf)
 //GOW(modify_ldt, 
 //GOW(moncontrol, 
 //GO(__monstartup, 
+#ifdef STATICBUILD
+//GO(monstartup, iFpp)
+#else
 GO(monstartup, iFpp)
+#endif
 //DATA(__morecore, 
 GOW(mount, iFpppLp)
 GO(mprobe, iFp)


### PR DESCRIPTION
Hi,

before:
```
Error: Symbol monstartup not found, cannot apply R_X86_64_JUMP_SLOT @0x3f096d4ef0 (0x4b346) in /yourpath/x64.so
Error: relocating Plt symbols in elf x64.so
Error initializing needed lib /yourpath/x64.so
Exception in thread "main" java.lang.ExceptionInInitializerError: initialization failed with java.lang.UnsatisfiedLinkError: /yourpath/x64.so: Cannot dlopen("/yourpath/x64.so"/0xffec4ba3b0, 1)
```

after:
work :)

Please review my patch.

Thanks,
Leslie Zhai