### PR TITLE
[CI] Fixed xuantie-qemu build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
             elif [[ ${{ matrix.platform }} == 'RISCV' ]]; then
               echo BOX64_PLATFORM_MARCRO="-DRV64=ON" >> $GITHUB_ENV
               echo "BOX64_COMPILER=riscv64-linux-gnu-gcc" >> $GITHUB_ENV
-              sudo apt-get -y install git gcc-riscv64-linux-gnu cmake make python3 ninja-build
+              sudo apt-get -y install git gcc-riscv64-linux-gnu cmake make python3 ninja-build libglib2.0-dev
             elif [[ ${{ matrix.platform }} == 'LARCH64' ]]; then
               sudo mkdir /usr/local/larch
               wget -O- -q https://github.com/loongson/build-tools/releases/download/2023.08.08/CLFS-loongarch64-8.1-x86_64-cross-tools-gcc-glibc.tar.xz | sudo tar -C /usr/local/larch --strip-components=1 --xz -xf -


### PR DESCRIPTION
Not sure what changed, but `libglib2.0-dev` is a requirement now.