### PR TITLE
Debian shlibdeps exclude fixes

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -21,4 +21,5 @@ override_dh_shlibdeps:
 	--exclude=libcrypto.so.1.1 \
 	--exclude=libmbedx509.so.1 \
 	--exclude=libcrypto.so.1.0.0 \
-	--exclude=libssl.1.0.0
+	--exclude=libssl.so.1.0.0 \
+	--exclude=box64-bash


### PR DESCRIPTION
* Fix a typo in `libssl.1.0.0` where `.so` was missing.
* Add `box64-bash` to the list of x64 binary files excluded from shlibdeps.

Fixes these errors building the Debian package:
```
dpkg-shlibdeps: error: cannot find library libtinfo.so.6 needed by debian/box64/usr/bin/box64-bash (ELF format: 'elf64-little' abi: 'ELF:64:l:amd64:0'; RPATH: '')
dpkg-shlibdeps: error: cannot find library libdl.so.2 needed by debian/box64/usr/bin/box64-bash (ELF format: 'elf64-little' abi: 'ELF:64:l:amd64:0'; RPATH: '')
dpkg-shlibdeps: error: cannot find library libc.so.6 needed by debian/box64/usr/bin/box64-bash (ELF format: 'elf64-little' abi: 'ELF:64:l:amd64:0'; RPATH: '')
dpkg-shlibdeps: error: cannot find library libcrypto.so.1.0.0 needed by debian/box64/usr/lib/box64-x86_64-linux-gnu/libssl.so.1.0.0 (ELF format: 'elf64-little' abi: 'ELF:64:l:amd64:0'; RPATH: '')
dpkg-shlibdeps: error: cannot find library libc.so.6 needed by debian/box64/usr/lib/box64-x86_64-linux-gnu/libssl.so.1.0.0 (ELF format: 'elf64-little' abi: 'ELF:64:l:amd64:0'; RPATH: '')
```
