### PR TITLE
Fix undefined reference to `epoll_pwait2' for LA64 ABI 1.0

### DIFF
--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -2203,7 +2203,7 @@ EXPORT int my_epoll_pwait2(int epfd, void* events, int maxevents, const struct t
 {
     struct epoll_event _events[maxevents];
     //AlignEpollEvent(_events, events, maxevents);
-    #ifdef ANDROID
+    #if defined(ANDROID) || defined(LA64_ABI_1)
     // epoll_pwait2 doesn't exist, to tranforming timeout to int, and from nanosecods to milliseconds...
     int tout = -1;
     if(timeout) {


### PR DESCRIPTION
Hi,

Linux kernel 5.11 (February, 2021) added the epoll_pwait2 system call, but LA64 ABI 1.0 kernel is 4.19.0, so `epoll_pwait2` is not available.

Please review my patch.

Thanks,
Leslie Zhai