### PR TITLE
[WRAPPER] add missing Android specific shmem symbols

### DIFF
--- a/src/wrapped/wrappedandroidshmem_private.h
+++ b/src/wrapped/wrappedandroidshmem_private.h
@@ -2,6 +2,10 @@
 #error Meh....
 #endif
 
+GO(libandroid_shmdt, iFp)
+GO(libandroid_shmctl, iFiip)
+GO(libandroid_shmat, pFipi)
+GO(libandroid_shmget, iFiLi)
 GO(shmctl, iFiip)
 GO(shmget, iFiLi)
 GO(shmat, pFipi)

--- a/src/wrapped/wrappedlibc_private.h
+++ b/src/wrapped/wrappedlibc_private.h
@@ -2668,10 +2668,12 @@ GOWM(_ITM_memcpyRnWt, vFppL)  //%noE
 #ifdef ANDROID
 GOM(__libc_init, vFEpppp)
 GO(__errno, pFv)
+GO(android_set_abort_message, vFp)
 #else
 // Those symbols don't exist in non-Android builds
 //GOM(__libc_init, 
 //GO(__errno, 
+//GO(android_set_abort_message, vFp)
 #endif
 #ifdef STATICBUILD
 GO(dummy_pFLp, pFLp)

--- a/src/wrapped/wrappedvulkan_private.h
+++ b/src/wrapped/wrappedvulkan_private.h
@@ -458,6 +458,9 @@ GO(vkReleaseProfilingLockKHR, vFp)
 // VK_NV_cooperative_matrix
 GO(vkGetPhysicalDeviceCooperativeMatrixPropertiesNV, iFppp)
 
+// VK_NV_cooperative_vector
+GO(vkGetPhysicalDeviceCooperativeVectorPropertiesNV, iFpp)
+
 // VK_KHR_fragment_shading_rate
 GO(vkCmdSetFragmentShadingRateKHR, vFppp)
 GO(vkGetPhysicalDeviceFragmentShadingRatesKHR, iFppp)


### PR DESCRIPTION
This commit fixes these errors (only specific to Android):

```[BOX64] Error: Symbol libandroid_shmget not found, cannot apply R_X86_64_JUMP_SLOT @0x3f050abe98 (0xa6b36) in /data/data/com.termux/files/usr/opt/proton-box64/lib/wine/x86_64-unix/winex11.so
[BOX64] Error: Symbol libandroid_shmat not found, cannot apply R_X86_64_JUMP_SLOT @0x3f050abea0 (0xa6b46) in /data/data/com.termux/files/usr/opt/proton-box64/lib/wine/x86_64-unix/winex11.so
[BOX64] Error: Symbol libandroid_shmctl not found, cannot apply R_X86_64_JUMP_SLOT @0x3f050abeb8 (0xa6b76) in /data/data/com.termux/files/usr/opt/proton-box64/lib/wine/x86_64-unix/winex11.so
[BOX64] Error: Symbol libandroid_shmdt not found, cannot apply R_X86_64_JUMP_SLOT @0x3f050abec0 (0xa6b86) in /data/data/com.termux/files/usr/opt/proton-box64/lib/wine/x86_64-unix/winex11.so

Hopefully I did not mess things up.