### PR TITLE
Fixed a bug in the wrapper helper due to variadic arguments

### DIFF
--- a/wrapperhelper/src/preproc.c
+++ b/wrapperhelper/src/preproc.c
@@ -499,6 +499,7 @@ static VECTOR(preproc) *preproc_solve_macro(loginfo_t *li,
 					return NULL;
 				}
 			}
+			vector_pop_nodel_slice(preprocs, margs, vector_size(preprocs, margs) - m->nargs - 1);
 		}
 	}
 	// Avoid 0-allocations


### PR DESCRIPTION
This PR fixes the parsing of headers with code such as:
```c
#define bug(...)
bug(1, 2)
```
in the wrapper helper. The bug is due to a double-free of all arguments after the implicit `__VA_LIST__` argument.