### PR TITLE
Corrected arguments of my_epoll_pwait2

### DIFF
--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -2201,7 +2201,7 @@ EXPORT int32_t my_epoll_pwait(x64emu_t* emu, int32_t epfd, void* events, int32_t
         UnalignEpollEvent(events, _events, ret);
     return ret;
 }
-EXPORT int my_epoll_pwait2(int epfd, void* events, int maxevents, struct timespec *timeout, sigset_t * sigmask)
+EXPORT int my_epoll_pwait2(x64emu_t* emu, int epfd, void* events, int maxevents, struct timespec *timeout, sigset_t * sigmask)
 {
     struct epoll_event _events[maxevents];
     //AlignEpollEvent(_events, events, maxevents);


### PR DESCRIPTION
Box64 segfaults on this call. I updated it in accordance with the specification in the header file:
```
GOM(epoll_ctl, iFEiiip)
GOM(epoll_pwait, iFEipiip)
GOM(epoll_pwait2, iFEipipp)
GOM(epoll_wait, iFEipii)
```
With this change an example program ran successfully.
On a side note, why wasn't this typo detected by the script validating the wrappers?