### PR TITLE
Add __localtime64 and __time64 in box32 mode

### DIFF
--- a/src/wrapped32/wrappedlibc.c
+++ b/src/wrapped32/wrappedlibc.c
@@ -2140,6 +2140,13 @@ EXPORT int my32_setrlimit(x64emu_t* emu, int what, uint32_t* pr)
     return setrlimit64(what, &l);
 }
 
+EXPORT void* my32___localtime64(x64emu_t* emu, void* t)
+{
+    static struct tm l = {};
+    l = *localtime(t);
+    return &l;
+}
+
 EXPORT void* my32_localtime(x64emu_t* emu, void* t)
 {
     struct_L_t t_ = {0};

--- a/src/wrapped32/wrappedlibc_private.h
+++ b/src/wrapped32/wrappedlibc_private.h
@@ -1057,6 +1057,7 @@ GO(llistxattr, iEppL)
 // loc2 // type B
 GOWM(localeconv, pEEv)
 GOM(localtime, pEEp)
+GOM(__localtime64, pEEp)
 GOWM(localtime_r, pEEpp)
 GO(lockf, iEiil)
 GO(lockf64, iEiiI)
@@ -1835,6 +1836,7 @@ GO(tempnam, pEpp)
 GOW(textdomain, tEp)
 // tfind    // Weak
 GO(time, LEBL_)
+GO2(__time64, IEp, time)
 GOM(timegm, lEEriiiiiiiiilt_)   //%%
 // timelocal    // Weak
 GO(timerfd_create, iEii)


### PR DESCRIPTION
The change was tested with that snippet of code:
```c
#include <time.h>
#include <stdio.h>

int main() {
  time_t timestamp;
  time(&timestamp);
  struct tm *info = localtime(&timestamp);
  printf("%s", asctime(info));

  timestamp = 52921504606846977ll;
  info = localtime(&timestamp);
  printf("%s", asctime(info));

  timestamp = 9589934592ll;
  info = localtime(&timestamp);
  printf("%s", asctime(info));
}
```
Compiled with `i686-linux-gnu-gcc -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64 sample.c`.