### PR TITLE
Fixed an edge case in `rb_unset`

### DIFF
--- a/src/tools/rbtree.c
+++ b/src/tools/rbtree.c
@@ -810,7 +810,9 @@ dynarec_log(LOG_DEBUG, "unset: %s 0x%lx, 0x%lx);\n", tree->name, start, end);
         } else if (prev->end == end) {
             prev->end = start;
             return 0;
-        } // else fallthrough
+        } else {
+            prev->end = start;
+        }
     }
     while (next && (next->start < end) && (next->end <= end)) {
         // Remove the entire node


### PR DESCRIPTION
This PR fixes an edge case in `rb_unset`, where unsetting a range `start:end` with a node overlapping from the left would not unset the overlap:
```
before
+--------+---------+
|   42   | (unset) |
+--------+---------+
     ^ start       ^ end

after (bug)
+--------+---------+
|   42   | (unset) |
+--------+---------+
     ^ start       ^ end

after (fixed)
+----+-------------+
| 42 |   (unset)   |
+----+-------------+
     ^ start       ^ end
```