### PR TITLE
Use `setProtection_mmap` in `NewBrick`

### DIFF
--- a/src/tools/bridge.c
+++ b/src/tools/bridge.c
@@ -55,7 +55,7 @@ brick_t* NewBrick(void* old)
     if(ptr == MAP_FAILED) {
         printf_log(LOG_NONE, "Warning, cannot allocate 0x%lx aligned bytes for bridge, will probably crash later\n", NBRICK*sizeof(onebridge_t));
     }
-    setProtection((uintptr_t)ptr, NBRICK * sizeof(onebridge_t), PROT_READ | PROT_WRITE | PROT_EXEC | PROT_NOPROT);
+    setProtection_mmap((uintptr_t)ptr, NBRICK * sizeof(onebridge_t), PROT_READ | PROT_WRITE | PROT_EXEC | PROT_NOPROT);
     dynarec_log(LOG_INFO, "New Bridge brick at %p (size 0x%zx)\n", ptr, NBRICK*sizeof(onebridge_t));
     if(box64_is32bits) load_addr_32bits = ptr + NBRICK*sizeof(onebridge_t);
     ret->b = ptr;


### PR DESCRIPTION
`NewBrick()` currently uses `setProtection()` after `box_mmap()`, which fails to mark the region with the `MEM_MMAP` label. As a result, `getMmapped()` returns 0, even though the memory was allocated via mmap.