### PR TITLE
[DOCS] Align usage.json and env.h

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -171,6 +171,14 @@ Add --no-sandbox argument to the guest program.
 
 ## Compatibility
 
+### BOX64_AVX
+
+Expose AVX extension to CPUID and cpuinfo file.
+
+ * 0: Do not expose AVX capabilities. 
+ * 1: Expose AVX, BMI1, F16C and VAES extensions to CPUID and cpuinfo file. 
+ * 2: All in 1, plus AVX2, BMI2, FMA, ADX,VPCLMULQDQ and RDRAND extensions. 
+
 ### BOX64_BASH
 
 Path to the bash executable.
@@ -462,9 +470,9 @@ Set the address where the program is loaded, only active for PIE guest programs.
 
 ### BOX64_LOG
 
-Enable or disable Box64 logs.
+Enable or disable Box64 logs, default value is 0 if stdout is not terminal, 1 otherwise.
 
- * 0: Disable Box64 logs. [Default]
+ * 0: Disable Box64 logs. 
  * 1: Enable minimal Box64 logs. 
  * 2: Enable debug level Box64 logs. 
  * 3: Enable verbose level Box64 logs. 
@@ -473,7 +481,7 @@ Enable or disable Box64 logs.
 
 Disable the Box64 banner.
 
- * 0: Show the Box64 banner. [Default]
+ * 0: Show the Box64 banner. 
  * 1: Do not show the Box64 banner. 
 
 ### BOX64_NOSIGSEGV
@@ -566,6 +574,13 @@ Only available on box64 build with trace. Adds trace of all instructions execute
  * 0xXXXXXXX-0xYYYYYYY: Enable trace output for the range of address (inclusive-exclusive). 
 
 ## Performance
+
+### BOX64_DYNAREC
+
+Enable/disable the Dynamic Recompiler (a.k.a DynaRec). This option defaults to 1 if it's enabled in the build options for a supported architecture.
+
+ * 0: Disable DynaRec. 
+ * 1: Enable DynaRec. 
 
 ### BOX64_DYNAREC_ALIGNED_ATOMICS
 
@@ -683,6 +698,13 @@ Tweak the memory barriers to reduce the performance impact by strong memory emua
  * 0: Use regular safe barrier. 
  * 1: Use weak barriers to have more performance boost. [Default]
  * 2: All in 1, plus disabled the last write barriers. 
+
+### BOX64_MMAP32
+
+Force 32-bit compatible memory mappings on 64-bit programs that run 32-bit code (like Wine WOW64), can improve performance.
+
+ * 0: Do not force 32-bit memory mappings. 
+ * 1: Force 32-bit memory mappings. [Default]
 
 ### BOX64_NODYNAREC
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -173,7 +173,7 @@ Add --no-sandbox argument to the guest program.
 
 ### BOX64_AVX
 
-Expose AVX extension to CPUID and cpuinfo file.
+Expose AVX extension to CPUID and cpuinfo file. Default value is 2 on Arm64 because it's fully implemented in DynaRec, 0 otherwise.
 
  * 0: Do not expose AVX capabilities. 
  * 1: Expose AVX, BMI1, F16C and VAES extensions to CPUID and cpuinfo file. 

--- a/docs/box64.pod
+++ b/docs/box64.pod
@@ -75,7 +75,7 @@ Arguments to pass to the guest program, only valid if there is no existing argum
 
 =item B<BOX64_AVX> =I<0|1|2>
 
-Expose AVX extension to CPUID and cpuinfo file.
+Expose AVX extension to CPUID and cpuinfo file. Default value is 2 on Arm64 because it's fully implemented in DynaRec, 0 otherwise.
 
  * 0 : Do not expose AVX capabilities. 
  * 1 : Expose AVX, BMI1, F16C and VAES extensions to CPUID and cpuinfo file. 

--- a/docs/box64.pod
+++ b/docs/box64.pod
@@ -73,6 +73,15 @@ Arguments to pass to the guest program, only valid if there is no existing argum
  * XXXX YYYY ZZZZ : Pass arguments XXXX, YYYY and ZZZZ to the guest program. 
 
 
+=item B<BOX64_AVX> =I<0|1|2>
+
+Expose AVX extension to CPUID and cpuinfo file.
+
+ * 0 : Do not expose AVX capabilities. 
+ * 1 : Expose AVX, BMI1, F16C and VAES extensions to CPUID and cpuinfo file. 
+ * 2 : All in 1, plus AVX2, BMI2, FMA, ADX,VPCLMULQDQ and RDRAND extensions. 
+
+
 =item B<BOX64_BASH> =I<XXXX>
 
 Path to the bash executable.
@@ -126,6 +135,14 @@ Dump elfloader debug information.
 
  * 0 : Do not dump elfloader debug information. [Default]
  * 1 : Dump elfloader debug information. 
+
+
+=item B<BOX64_DYNAREC> =I<0|1>
+
+Enable/disable the Dynamic Recompiler (a.k.a DynaRec). This option defaults to 1 if it's enabled in the build options for a supported architecture.
+
+ * 0 : Disable DynaRec. 
+ * 1 : Enable DynaRec. 
 
 
 =item B<BOX64_DYNAREC_ALIGNED_ATOMICS> =I<0|1>
@@ -484,9 +501,9 @@ Set the address where the program is loaded, only active for PIE guest programs.
 
 =item B<BOX64_LOG> =I<0|1|2|3>
 
-Enable or disable Box64 logs.
+Enable or disable Box64 logs, default value is 0 if stdout is not terminal, 1 otherwise.
 
- * 0 : Disable Box64 logs. [Default]
+ * 0 : Disable Box64 logs. 
  * 1 : Enable minimal Box64 logs. 
  * 2 : Enable debug level Box64 logs. 
  * 3 : Enable verbose level Box64 logs. 
@@ -509,11 +526,19 @@ Maximum CPU cores exposed.
  * XXXX : Use XXXX CPU cores. 
 
 
+=item B<BOX64_MMAP32> =I<0|1>
+
+Force 32-bit compatible memory mappings on 64-bit programs that run 32-bit code (like Wine WOW64), can improve performance.
+
+ * 0 : Do not force 32-bit memory mappings. 
+ * 1 : Force 32-bit memory mappings. [Default]
+
+
 =item B<BOX64_NOBANNER> =I<0|1>
 
 Disable the Box64 banner.
 
- * 0 : Show the Box64 banner. [Default]
+ * 0 : Show the Box64 banner. 
  * 1 : Do not show the Box64 banner. 
 
 

--- a/docs/gen/usage.json
+++ b/docs/gen/usage.json
@@ -51,6 +51,28 @@
     ]
   },
   {
+    "name": "BOX64_AVX",
+    "description": "Expose AVX extension to CPUID and cpuinfo file.",
+    "category": "Compatibility",
+    "options": [
+      {
+        "key": "0",
+        "description": "Do not expose AVX capabilities.",
+        "default": false
+      },
+      {
+        "key": "1",
+        "description": "Expose AVX, BMI1, F16C and VAES extensions to CPUID and cpuinfo file.",
+        "default": false
+      },
+      {
+        "key": "2",
+        "description": "All in 1, plus AVX2, BMI2, FMA, ADX,VPCLMULQDQ and RDRAND extensions.",
+        "default": false
+      }
+    ]
+  },
+  {
     "name": "BOX64_BASH",
     "description": "Path to the bash executable.",
     "category": "Compatibility",
@@ -160,6 +182,23 @@
       {
         "key": "1",
         "description": "Dump elfloader debug information.",
+        "default": false
+      }
+    ]
+  },
+  {
+    "name": "BOX64_DYNAREC",
+    "description": "Enable/disable the Dynamic Recompiler (a.k.a DynaRec). This option defaults to 1 if it's enabled in the build options for a supported architecture.",
+    "category": "Performance",
+    "options": [
+      {
+        "key": "0",
+        "description": "Disable DynaRec.",
+        "default": false
+      },
+      {
+        "key": "1",
+        "description": "Enable DynaRec.",
         "default": false
       }
     ]
@@ -970,13 +1009,13 @@
   },
   {
     "name": "BOX64_LOG",
-    "description": "Enable or disable Box64 logs.",
+    "description": "Enable or disable Box64 logs, default value is 0 if stdout is not terminal, 1 otherwise.",
     "category": "Debugging",
     "options": [
       {
         "key": "0",
         "description": "Disable Box64 logs.",
-        "default": true
+        "default": false
       },
       {
         "key": "1",
@@ -1035,6 +1074,23 @@
     ]
   },
   {
+    "name": "BOX64_MMAP32",
+    "description": "Force 32-bit compatible memory mappings on 64-bit programs that run 32-bit code (like Wine WOW64), can improve performance.",
+    "category": "Performance",
+    "options": [
+      {
+        "key": "0",
+        "description": "Do not force 32-bit memory mappings.",
+        "default": false
+      },
+      {
+        "key": "1",
+        "description": "Force 32-bit memory mappings.",
+        "default": true
+      }
+    ]
+  },
+  {
     "name": "BOX64_NOBANNER",
     "description": "Disable the Box64 banner.",
     "category": "Debugging",
@@ -1042,7 +1098,7 @@
       {
         "key": "0",
         "description": "Show the Box64 banner.",
-        "default": true
+        "default": false
       },
       {
         "key": "1",

--- a/docs/gen/usage.json
+++ b/docs/gen/usage.json
@@ -52,7 +52,7 @@
   },
   {
     "name": "BOX64_AVX",
-    "description": "Expose AVX extension to CPUID and cpuinfo file.",
+    "description": "Expose AVX extension to CPUID and cpuinfo file. Default value is 2 on Arm64 because it's fully implemented in DynaRec, 0 otherwise.",
     "category": "Compatibility",
     "options": [
       {

--- a/src/emu/x64syscall.c
+++ b/src/emu/x64syscall.c
@@ -870,12 +870,11 @@ void EXPORT x64Syscall(x64emu_t *emu)
             break;
         #endif
         case 449:
-            #ifdef __NR_futex_waitv
-            if(BOX64ENV(futex_waitv))
-                S_RAX = syscall(__NR_futex_waitv, R_RDI, R_RSI, R_RDX, R_R10, R_R8);
-            else
+            #if defined(__NR_futex_waitv) && !defined(BAD_SIGNAL)
+            S_RAX = syscall(__NR_futex_waitv, R_RDI, R_RSI, R_RDX, R_R10, R_R8);
+            #else
+            S_RAX = -ENOSYS;
             #endif
-                S_RAX = -ENOSYS;
             break;
         default:
             printf_log(LOG_INFO, "Warning: Unsupported Syscall 0x%02Xh (%d)\n", s, s);
@@ -1156,16 +1155,12 @@ long EXPORT my_syscall(x64emu_t *emu)
             return faccessat(S_ESI, (void*)R_RDX, (mode_t)R_RCX, S_R8d);
         #endif
         case 449:
-            #ifdef __NR_futex_waitv
-            if(BOX64ENV(futex_waitv))
-                return syscall(__NR_futex_waitv, R_RSI, R_RDX, R_RCX, R_R8, R_R9);
-            else
+            #if defined(__NR_futex_waitv) && !defined(BAD_SIGNAL)
+            return syscall(__NR_futex_waitv, R_RSI, R_RDX, R_RCX, R_R8, R_R9);
+            #else
+            errno = ENOSYS;
+            return -1;
             #endif
-                {
-                    errno = ENOSYS;
-                    return -1;
-                }
-            break;
         default:
             if(!(warned&(1<<s))) {
                 printf_log(LOG_INFO, "Warning: Unsupported libc Syscall 0x%02X (%d)\n", s, s);

--- a/src/emu/x86syscall_32.c
+++ b/src/emu/x86syscall_32.c
@@ -491,12 +491,11 @@ void EXPORT x86Syscall(x64emu_t *emu)
             }
             break;
         case 449:
-            #ifdef __NR_futex_waitv
-            if(BOX64ENV(futex_waitv))
-                S_RAX = syscall(__NR_futex_waitv, R_EBX, R_ECX, R_EDX, R_ESI, R_EDI);
-            else
+            #if defined(__NR_futex_waitv) && !defined(BAD_SIGNAL)
+            S_RAX = syscall(__NR_futex_waitv, R_EBX, R_ECX, R_EDX, R_ESI, R_EDI);
+            #else
+            S_RAX = -ENOSYS;
             #endif
-                S_RAX = -ENOSYS;
             break;
         default:
             printf_log(LOG_INFO, "Warning: Unsupported Syscall 0x%02Xh (%d)\n", s, s);
@@ -715,16 +714,12 @@ uint32_t EXPORT my32_syscall(x64emu_t *emu, uint32_t s, ptr_t* b)
 #endif
 #endif
         case 449:
-            #ifdef __NR_futex_waitv
-            if(BOX64ENV(futex_waitv))
-                return syscall(__NR_futex_waitv, u32(0), u32(4), u32(8), u32(12), u32(16));
-            else
+            #if defined(__NR_futex_waitv) && !defined(BAD_SIGNAL)
+            return syscall(__NR_futex_waitv, u32(0), u32(4), u32(8), u32(12), u32(16));
+            #else
+            errno = ENOSYS;
+            return -1;
             #endif
-                {
-                    errno = ENOSYS;
-                    return -1;
-                }
-            break;
         default:
             if((s>>6)<sizeof(warned)/sizeof(warned[0])) {
                 if(!(warned[s>>6]&(1<<(s&0x3f)))) {

--- a/src/include/env.h
+++ b/src/include/env.h
@@ -143,19 +143,10 @@ extern char* ftrace_name;
     BOOLEAN(BOX64_DYNAREC, dynarec, 0)
 #endif
 
-#ifdef BAD_SIGNAL
-#define ENVSUPER4() \
-    BOOLEAN(BOX64_FUTEX_WAITV, futex_waitv, 0)
-#else
-#define ENVSUPER4() \
-    BOOLEAN(BOX64_FUTEX_WAITV, futex_waitv, 1)
-#endif
-
 #define ENVSUPER() \
     ENVSUPER1()    \
     ENVSUPER2()    \
-    ENVSUPER3()    \
-    ENVSUPER4()
+    ENVSUPER3()
 
 typedef struct box64env_s {
 #define INTEGER(NAME, name, default, min, max) int name;

--- a/src/include/env.h
+++ b/src/include/env.h
@@ -40,7 +40,7 @@ extern char* ftrace_name;
     INTEGER(BOX64_CPUTYPE, cputype, 0, 0, 1)                               \
     BOOLEAN(BOX64_CRASHHANDLER, dummy_crashhandler, 1)                     \
     BOOLEAN(BOX64_DLSYM_ERROR, dlsym_error, 0)                             \
-    INTEGER(BOX64_DUMP, dump, 0, 0, 2)                                     \
+    BOOLEAN(BOX64_DUMP, dump, 0)                                           \
     BOOLEAN(BOX64_DYNAREC_ALIGNED_ATOMICS, dynarec_aligned_atomics, 0)     \
     INTEGER(BOX64_DYNAREC_BIGBLOCK, dynarec_bigblock, 2, 0, 3)             \
     BOOLEAN(BOX64_DYNAREC_BLEEDING_EDGE, dynarec_bleeding_edge, 1)         \
@@ -89,7 +89,8 @@ extern char* ftrace_name;
     INTEGER(BOX64_LOG, log, DEFAULT_LOG_LEVEL, 0, 3)                       \
     INTEGER(BOX64_MALLOC_HACK, malloc_hack, 0, 0, 2)                       \
     INTEGER(BOX64_MAXCPU, new_maxcpu, 0, 0, 100)                           \
-    BOOLEAN(BOX64_NOBANNER, nobanner, BOX64_NOBANNER_DEFAULT)    \
+    BOOLEAN(BOX64_MMAP32, mmap32, 1)                                       \
+    BOOLEAN(BOX64_NOBANNER, nobanner, BOX64_NOBANNER_DEFAULT)              \
     STRING(BOX64_NODYNAREC, nodynarec)                                     \
     BOOLEAN(BOX64_NOGTK, nogtk, 0)                                         \
     BOOLEAN(BOX64_NOPULSE, nopulse, 0)                                     \
@@ -150,20 +151,11 @@ extern char* ftrace_name;
     BOOLEAN(BOX64_FUTEX_WAITV, futex_waitv, 1)
 #endif
 
-#if defined(SD845) || defined(SD888) || defined(SD8G2) || defined(TEGRAX1)
-#define ENVSUPER5() \
-    BOOLEAN(BOX64_MMAP32, mmap32, 1)
-#else
-#define ENVSUPER5() \
-    BOOLEAN(BOX64_MMAP32, mmap32, 0)
-#endif
-
 #define ENVSUPER() \
     ENVSUPER1()    \
     ENVSUPER2()    \
     ENVSUPER3()    \
-    ENVSUPER4()    \
-    ENVSUPER5()
+    ENVSUPER4()
 
 typedef struct box64env_s {
 #define INTEGER(NAME, name, default, min, max) int name;


### PR DESCRIPTION
Thanks @sehraf for the checker (#2631), I added and improved most of the missing things. Now the checker outputs:
```
BOX64_LD_PRELOAD              : missing env.h entry
```

... which is fine as this one is special and not managed by the env module.

Important changes:

1. `BOX64_MMAP32` is now enabled by default.
2. `BOX64_FUTEX_WAITV` is removed, only configurable at compilation time.