### PR TITLE
fix: env BOX64_EMULATED_LIBS triggers sigsegv

### DIFF
--- a/src/tools/env.c
+++ b/src/tools/env.c
@@ -188,7 +188,7 @@ static void applyCustomRules()
         snprintf(pathname, sizeof(pathname), "/tmp/perf-%d.map", getpid());
         SET_BOX64ENV(dynarec_perf_map_fd, open(pathname, O_CREAT | O_RDWR | O_APPEND, S_IRUSR | S_IWUSR));
     }
-    if (box64env.emulated_libs) {
+    if (box64env.emulated_libs && my_context) {
         AppendList(&my_context->box64_emulated_libs, box64env.emulated_libs, 0);
     }
     if (!box64env.libgl) {


### PR DESCRIPTION
`BOX64_EMULATED_LIBS=libfake.so gdb --args ./box64.real --help`

```
Program received signal SIGSEGV, Segmentation fault.
AddPath (path=path@entry=0x7fffffcbf8 "libfake.so", collection=collection@entry=0x20, 
    folder=folder@entry=0) at ./src/tools/pathcoll.c:91
91      ./src/tools/pathcoll.c: 没有那个文件或目录.
(gdb) bt
#0  AddPath (path=path@entry=0x7fffffcbf8 "libfake.so", collection=collection@entry=0x20, 
    folder=folder@entry=0) at ./src/tools/pathcoll.c:91
#1  0x0000000034870154 in AppendList (collection=0x20, List=<optimized out>, folder=folder@entry=0)
    at ./src/tools/pathcoll.c:141
#2  0x0000000034874050 in applyCustomRules () at ./src/tools/env.c:193
#3  0x0000000034878530 in LoadEnvVariables () at ./src/tools/env.c:624
#4  0x0000000034831f20 in initialize (argc=2, argv=0x7fffffe028, env=0x7fffffe040, emulator=0x1, 
    emulator@entry=0x7fffffdec8, elfheader=0x9, elfheader@entry=0x7fffffded0, exec=exec@entry=1)
    at ./src/core.c:924
#5  0x000000003482e344 in main (argc=<optimized out>, argv=<optimized out>, env=<optimized out>)
    at ./src/main.c:7

```