### PR TITLE
[RBTREE] Refine the naming scheme 

### DIFF
--- a/src/box64context.c
+++ b/src/box64context.c
@@ -357,7 +357,7 @@ void FreeBox64Context(box64context_t** context)
     FreeMapSymbols(&ctx->uniques);
 
 #ifdef DYNAREC
-    //dynarec_log(LOG_INFO, "BOX64 Dynarec at exit: Max DB=%d, righter=%d\n", ctx->max_db_size, rb_get_righter(ctx->db_sizes));
+    //dynarec_log(LOG_INFO, "BOX64 Dynarec at exit: Max DB=%d, rightmost=%d\n", ctx->max_db_size, rb_get_rightmost(ctx->db_sizes));
     rbtree_delete(ctx->db_sizes);
 #endif
 

--- a/src/custommem.c
+++ b/src/custommem.c
@@ -604,7 +604,7 @@ void* map128_customMalloc(size_t size, int is32bits)
             testAllBlocks();
             if(BOX64ENV(log)>=LOG_DEBUG) {
                 printf_log(LOG_NONE, "Used 32bits address space map:\n");
-                uintptr_t addr = rb_get_lefter(mapallmem);
+                uintptr_t addr = rb_get_leftmost(mapallmem);
                 while(addr<0x100000000LL) {
                     uintptr_t bend;
                     uint32_t val;
@@ -715,7 +715,7 @@ void* internal_customMalloc(size_t size, int is32bits)
             testAllBlocks();
             if(BOX64ENV(log)>=LOG_DEBUG) {
                 printf_log(LOG_NONE, "Used 32bits address space map:\n");
-                uintptr_t addr = rb_get_lefter(mapallmem);
+                uintptr_t addr = rb_get_leftmost(mapallmem);
                 while(addr<0x100000000LL) {
                     uintptr_t bend;
                     uint32_t val;

--- a/src/dynarec/dynablock.c
+++ b/src/dynarec/dynablock.c
@@ -61,7 +61,7 @@ dynablock_t* InvalidDynablock(dynablock_t* db, int need_lock)
         if(db_size && my_context) {
             uint32_t n = rb_dec(my_context->db_sizes, db_size, db_size+1);
             if(!n && (db_size >= my_context->max_db_size)) {
-                my_context->max_db_size = rb_get_righter(my_context->db_sizes);
+                my_context->max_db_size = rb_get_rightmost(my_context->db_sizes);
                 dynarec_log(LOG_INFO, "BOX64 Dynarec: lower max_db=%d\n", my_context->max_db_size);
             }
         }
@@ -103,7 +103,7 @@ void FreeDynablock(dynablock_t* db, int need_lock)
         if(db_size && my_context) {
             uint32_t n = rb_dec(my_context->db_sizes, db_size, db_size+1);
             if(!n && (db_size >= my_context->max_db_size)) {
-                my_context->max_db_size = rb_get_righter(my_context->db_sizes);
+                my_context->max_db_size = rb_get_rightmost(my_context->db_sizes);
                 dynarec_log(LOG_INFO, "BOX64 Dynarec: lower max_db=%d\n", my_context->max_db_size);
             }
         }

--- a/src/include/rbtree.h
+++ b/src/include/rbtree.h
@@ -274,7 +274,7 @@ int rb_set_64(rbtree_t* tree, uintptr_t start, uintptr_t end, uint64_t data);
 int rb_unset(rbtree_t* tree, uintptr_t start, uintptr_t end);
 
 /**
- * rb_get_righter() - Retrieves the start value of the right-most node in a red-black tree.
+ * rb_get_rightmost() - Retrieves the start value of the right-most node in a red-black tree.
  * @tree: Pointer to the red-black tree whose right-most node's start value is to be retrieved.
  *
  * This function traverses the red-black tree from the root to the right-most node, which is the node
@@ -304,17 +304,17 @@ uint64_t rb_inc(rbtree_t* tree, uintptr_t start, uintptr_t end);
  * Returns the new value for the node (or 0 if non-existant / removed)
  */
 
-uintptr_t rb_get_righter(rbtree_t* tree);
+uintptr_t rb_get_rightmost(rbtree_t* tree);
 
 /**
- * rb_get_lefter() - Retrieves the start value of the left-most node in a red-black tree.
+ * rb_get_leftmost() - Retrieves the start value of the left-most node in a red-black tree.
  * @tree: Pointer to the red-black tree whose left-most node's start value is to be retrieved.
  *
  * This function traverses the red-black tree from the root to the left-most node, which is the node
  * with the lowest key value in the tree. 
  * Return: The start value of the left-most node if the tree is not empty; otherwise, 0.
  */
-uintptr_t rb_get_lefter(rbtree_t* tree);
+uintptr_t rb_get_leftmost(rbtree_t* tree);
 
 /**
  * @brief Print a rbtree (for debugging purpose)

--- a/src/tools/env.c
+++ b/src/tools/env.c
@@ -720,7 +720,7 @@ void RemoveMapping(uintptr_t addr, size_t length)
         if(mapping == (mapping_t*)rb_get_64(envmap, addr+length))
             return; // still present, don't purge mapping
         // Will traverse the tree to find any left over
-        uintptr_t start = rb_get_lefter(envmap);
+        uintptr_t start = rb_get_leftmost(envmap);
         uintptr_t end;
         uint64_t val;
         do {

--- a/src/tools/rbtree.c
+++ b/src/tools/rbtree.c
@@ -32,8 +32,8 @@ struct rbtree {
     const char* name;
     bool is_unstable;
     // Cache 
-    rbnode *righter; 
-    rbnode *lefter;
+    rbnode *rightmost; 
+    rbnode *leftmost;
     // TODO: Refine the naming scheme
 };
 
@@ -42,8 +42,8 @@ rbtree_t* rbtree_init(const char* name) {
     tree->root = NULL;
     tree->is_unstable = false;
     tree->name = name?name:"(rbtree)";
-    tree->righter = NULL;
-    tree->lefter = NULL;
+    tree->rightmost = NULL;
+    tree->leftmost = NULL;
     return tree;
 }
 
@@ -83,16 +83,16 @@ static int add_range_next_to(rbtree_t *tree, rbnode *prev, uintptr_t start, uint
         node->meta = IS_BLACK;
         tree->root = node;
         tree->is_unstable = false;
-        tree->lefter = node;
-        tree->righter = node;
+        tree->leftmost = node;
+        tree->rightmost = node;
         return 0;
     }
     
     // Update cache
-    if (start < tree->lefter->start) // new left most
-        tree->lefter = node;
-    else if (start > tree->righter->start) // new right most
-        tree->righter = node;
+    if (start < tree->leftmost->start) // new left most
+        tree->leftmost = node;
+    else if (start > tree->rightmost->start) // new right most
+        tree->rightmost = node;
 
     node->parent = prev;
     if (prev->start < start) {
@@ -266,10 +266,10 @@ static int remove_node(rbtree_t *tree, rbnode *node) {
     }
     tree->is_unstable = true;
     // Update cache
-    if (node == tree->lefter)
-        tree->lefter = succ_node(node);
-    else if (node == tree->righter)
-        tree->righter = pred_node(node);
+    if (node == tree->leftmost)
+        tree->leftmost = succ_node(node);
+    else if (node == tree->rightmost)
+        tree->rightmost = pred_node(node);
     
     if (node->left && node->right) {
         // Swap node and its successor
@@ -1137,18 +1137,18 @@ uint64_t rb_dec(rbtree_t *tree, uintptr_t start, uintptr_t end) {
     return data;
 }
 
-uintptr_t rb_get_righter(rbtree_t* tree)
+uintptr_t rb_get_rightmost(rbtree_t* tree)
 {
-dynarec_log(LOG_DEBUG, "rb_get_righter(%s);\n", tree->name);
+dynarec_log(LOG_DEBUG, "rb_get_rightmost(%s);\n", tree->name);
     if (!tree->root) return 0;
-    return tree->righter->start;
+    return tree->rightmost->start;
 }
 
-uintptr_t rb_get_lefter(rbtree_t* tree)
+uintptr_t rb_get_leftmost(rbtree_t* tree)
 {
-dynarec_log(LOG_DEBUG, "rb_get_lefter(%s);\n", tree->name);
+dynarec_log(LOG_DEBUG, "rb_get_leftmost(%s);\n", tree->name);
     if (!tree->root) return 0;
-    return tree->lefter->start;
+    return tree->leftmost->start;
 }
 
 #include <stdio.h>
@@ -1206,7 +1206,7 @@ static void cache_check(const rbtree_t *tree) {
     while (right_node->right)
         right_node = right_node->right;
 
-    if (tree->righter != right_node){
+    if (tree->rightmost != right_node){
         printf_log(LOG_NONE, "<invalid rightmost node>\n");
         return;
     }
@@ -1216,7 +1216,7 @@ static void cache_check(const rbtree_t *tree) {
     while (left_node->left)
         left_node = left_node->left;
 
-    if (tree->lefter != left_node){
+    if (tree->leftmost != left_node){
         printf_log(LOG_NONE, "<invalid leftmost node>\n");
         return;
     }


### PR DESCRIPTION
Replaced all occurrences of `rb_get_righter` with `rb_get_rightmost` and `rb_get_lefter` with `rb_get_leftmost` for improved semantic clarity.

Also updated related function declarations, definitions, and usage across:
- rbtree.c
- rbtree.h
- custommem.c
- dynablock.c
- env.c
- box64context.c