### PR TITLE
[WRAPPER] Added 2 more functions to libc (for #2731)

### DIFF
--- a/src/emu/x64printer.c
+++ b/src/emu/x64printer.c
@@ -6400,6 +6400,8 @@ void x64Print(x64emu_t* emu, char* buff, size_t buffsz, const char* func, int ti
         snprintf(buff, buffsz, "%04d|%p: Calling %s(%" PRIi32 ", %" PRIp ", %" PRIi32 ", %" PRIp ", %" PRIp ")", tid, *(void**)(R_RSP), func, (int32_t)R_RDI, (void*)R_RSI, (int32_t)R_RDX, (void*)R_RCX, (void*)R_R8);
 #endif
 #if !defined(STATICBUILD)
+    } else if (w == iFEpu) {
+        snprintf(buff, buffsz, "%04d|%p: Calling %s(%" PRIp ", %" PRIu32 ")", tid, *(void**)(R_RSP), func, (void*)R_RDI, (uint32_t)R_RSI);
     } else if (w == iFlip) {
         snprintf(buff, buffsz, "%04d|%p: Calling %s(%" PRIi64 ", %" PRIi32 ", %" PRIp ")", tid, *(void**)(R_RSP), func, (intptr_t)R_RDI, (int32_t)R_RSI, (void*)R_RDX);
     } else if (w == iFLLi) {

--- a/src/wrapped/generated/functions_list.txt
+++ b/src/wrapped/generated/functions_list.txt
@@ -3485,6 +3485,7 @@
 #!defined(NOALIGN) iFEipiip
 #!defined(NOALIGN) iFEipipp
 #!defined(STATICBUILD) lFiN
+#!defined(STATICBUILD) iFEpu
 #!defined(STATICBUILD) iFlip
 #!defined(STATICBUILD) iFLLi
 #!defined(STATICBUILD) iFLLii
@@ -4620,6 +4621,8 @@ wrappedlibc:
   - __sigsetjmp
   - backtrace
   - sigsetjmp
+- iFpu:
+  - delete_module
 - iFpL:
   - munmap
 - iFpp:
@@ -4704,6 +4707,8 @@ wrappedlibc:
   - vdprintf
 - iFpLi:
   - mprotect
+- iFpLp:
+  - init_module
 - iFppi:
   - ftw
   - ftw64

--- a/src/wrapped/generated/wrappedlibctypes.h
+++ b/src/wrapped/generated/wrappedlibctypes.h
@@ -33,6 +33,7 @@ typedef void (*vFpA_t)(void*, va_list);
 typedef int32_t (*iFip_t)(int32_t, void*);
 typedef int32_t (*iFup_t)(uint32_t, void*);
 typedef int32_t (*iFpi_t)(void*, int32_t);
+typedef int32_t (*iFpu_t)(void*, uint32_t);
 typedef int32_t (*iFpL_t)(void*, uintptr_t);
 typedef int32_t (*iFpp_t)(void*, void*);
 typedef int32_t (*iFpV_t)(void*, ...);
@@ -53,6 +54,7 @@ typedef int32_t (*iFipp_t)(int32_t, void*, void*);
 typedef int32_t (*iFipV_t)(int32_t, void*, ...);
 typedef int32_t (*iFipA_t)(int32_t, void*, va_list);
 typedef int32_t (*iFpLi_t)(void*, uintptr_t, int32_t);
+typedef int32_t (*iFpLp_t)(void*, uintptr_t, void*);
 typedef int32_t (*iFppi_t)(void*, void*, int32_t);
 typedef int32_t (*iFppp_t)(void*, void*, void*);
 typedef int32_t (*iFppV_t)(void*, void*, ...);
@@ -164,6 +166,7 @@ typedef int32_t (*iFppipppp_t)(void*, void*, int32_t, void*, void*, void*, void*
 	GO(__sigsetjmp, iFpi_t) \
 	GO(backtrace, iFpi_t) \
 	GO(sigsetjmp, iFpi_t) \
+	GO(delete_module, iFpu_t) \
 	GO(munmap, iFpL_t) \
 	GO(__vprintf_chk, iFpp_t) \
 	GO(dl_iterate_phdr, iFpp_t) \
@@ -228,6 +231,7 @@ typedef int32_t (*iFppipppp_t)(void*, void*, int32_t, void*, void*, void*, void*
 	GO(dprintf, iFipV_t) \
 	GO(vdprintf, iFipA_t) \
 	GO(mprotect, iFpLi_t) \
+	GO(init_module, iFpLp_t) \
 	GO(ftw, iFppi_t) \
 	GO(ftw64, iFppi_t) \
 	GO(__cxa_atexit, iFppp_t) \

--- a/src/wrapped/generated/wrapper.c
+++ b/src/wrapped/generated/wrapper.c
@@ -3572,6 +3572,7 @@ typedef int32_t (*iFEipipp_t)(x64emu_t*, int32_t, void*, int32_t, void*, void*);
 
 #if !defined(STATICBUILD)
 typedef intptr_t (*lFiN_t)(int32_t, ...);
+typedef int32_t (*iFEpu_t)(x64emu_t*, void*, uint32_t);
 typedef int32_t (*iFlip_t)(intptr_t, int32_t, void*);
 typedef int32_t (*iFLLi_t)(uintptr_t, uintptr_t, int32_t);
 typedef int32_t (*iFLLii_t)(uintptr_t, uintptr_t, int32_t, int32_t);
@@ -7130,6 +7131,7 @@ void iFEipipp(x64emu_t *emu, uintptr_t fcn) { iFEipipp_t fn = (iFEipipp_t)fcn; R
 
 #if !defined(STATICBUILD)
 void lFiN(x64emu_t *emu, uintptr_t fcn) { lFiN_t fn = (lFiN_t)fcn; R_RAX=(intptr_t)fn((int32_t)R_RDI, (void*)R_RSI); }
+void iFEpu(x64emu_t *emu, uintptr_t fcn) { iFEpu_t fn = (iFEpu_t)fcn; R_RAX=(uint32_t)fn(emu, (void*)R_RDI, (uint32_t)R_RSI); }
 void iFlip(x64emu_t *emu, uintptr_t fcn) { iFlip_t fn = (iFlip_t)fcn; R_RAX=(uint32_t)fn((intptr_t)R_RDI, (int32_t)R_RSI, (void*)R_RDX); }
 void iFLLi(x64emu_t *emu, uintptr_t fcn) { iFLLi_t fn = (iFLLi_t)fcn; R_RAX=(uint32_t)fn((uintptr_t)R_RDI, (uintptr_t)R_RSI, (int32_t)R_RDX); }
 void iFLLii(x64emu_t *emu, uintptr_t fcn) { iFLLii_t fn = (iFLLii_t)fcn; R_RAX=(uint32_t)fn((uintptr_t)R_RDI, (uintptr_t)R_RSI, (int32_t)R_RDX, (int32_t)R_RCX); }

--- a/src/wrapped/generated/wrapper.h
+++ b/src/wrapped/generated/wrapper.h
@@ -3530,6 +3530,7 @@ void iFEipipp(x64emu_t *emu, uintptr_t fnc);
 
 #if !defined(STATICBUILD)
 void lFiN(x64emu_t *emu, uintptr_t fnc);
+void iFEpu(x64emu_t *emu, uintptr_t fnc);
 void iFlip(x64emu_t *emu, uintptr_t fnc);
 void iFLLi(x64emu_t *emu, uintptr_t fnc);
 void iFLLii(x64emu_t *emu, uintptr_t fnc);

--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -2722,6 +2722,18 @@ EXPORT int32_t my___cxa_thread_atexit_impl(x64emu_t* emu, void* dtor, void* obj,
     return 0;
 }
 
+EXPORT int32_t my_delete_module(x64emu_t* emu, const char* name, unsigned int flags)
+{
+    (void)emu;
+    return syscall(__NR_delete_module, name, flags);
+}
+
+EXPORT int32_t my_init_module(x64emu_t* emu, void* module_image, unsigned long size, const char* param_values)
+{
+    (void)emu;
+    return syscall(__NR_init_module, module_image, size, param_values);
+}
+
 EXPORT int32_t my___register_atfork(x64emu_t *emu, void* prepare, void* parent, void* child, void* handle)
 {
     (void)emu;

--- a/src/wrapped/wrappedlibc_private.h
+++ b/src/wrapped/wrappedlibc_private.h
@@ -220,7 +220,7 @@ GOW(dcngettext, pFpppLi)
 //GO(delete_module, 
 //GO(des_setparity, 
 #else
-//GO(delete_module, 
+GOM(delete_module, iFEpu)
 GO(des_setparity, vFp)
 #endif
 GO(__dgettext, pFpp)
@@ -833,7 +833,7 @@ GO(inet_ntop, pFippu)
 GOW(inet_pton, iFipp)
 //GO(__inet_pton_length, 
 GO(initgroups, iFpu)
-//GO(init_module, 
+GOM(init_module, iFEpLp)
 GO(initstate, pFupL)
 GO(initstate_r, iFupLp)
 GO(innetgr, iFpppp)


### PR DESCRIPTION
Seems to be workin

```
$ BOX64_LOG=2 ./module test.ko test | grep init_module
[BOX64]             Apply STB_GLOBAL R_X86_64_JUMP_SLOT 0x100004050 with sym=init_module(optver 2: init_module@GLIBC_2.2.5) (0x1000010d6 -> 0x300101c0 / box64)
55679|0x1000013d8: Calling init_module(0x5bc7d040, 13825, 0x1000020a6) => return 0xFFFFFFFF
init_module failed: Operation not permitted
```

#2731