### PR TITLE
[WRAPPER] Wrap vkGetPhysicalDeviceExternalTensorPropertiesARM

### DIFF
--- a/src/wrapped/wrappedvulkan_private.h
+++ b/src/wrapped/wrappedvulkan_private.h
@@ -312,6 +312,7 @@ GO(vkGetPhysicalDeviceMemoryProperties2KHR, vFpp)
 GO(vkGetPhysicalDeviceProperties2KHR, vFpp)
 GO(vkGetPhysicalDeviceQueueFamilyProperties2KHR, vFppp)
 GO(vkGetPhysicalDeviceSparseImageFormatProperties2KHR, vFpppp)  //VkSparseImageFormatProperties2 seems OK
+GO(vkGetPhysicalDeviceExternalTensorPropertiesARM, vFpp)
 
 // VK_KHR_get_surface_capabilities2
 GO(vkGetPhysicalDeviceSurfaceCapabilities2KHR, iFppp)


### PR DESCRIPTION
Seems to be another Wine addition.

Vulkan works fine again.