### PR TITLE
fix: Ensure ed equals x3 in "VPMASKMOVD/Q Ex, Vx, Gx"

### DIFF
--- a/src/dynarec/arm64/dynarec_arm64_avx_66_0f38.c
+++ b/src/dynarec/arm64/dynarec_arm64_avx_66_0f38.c
@@ -1297,6 +1297,10 @@ uintptr_t dynarec64_AVX_66_0F38(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip
                         s0 = -1;
                         v1 = fpu_get_scratch(dyn, ninst);
                         addr = geted(dyn, addr, ninst, nextop, &ed, x3, &fixedaddress, NULL, 0, 0, rex, NULL, 0, 0);
+                        if(ed!=x3) {
+                            MOVz_REG(x3, ed);
+                            ed = x3;
+                        }
                         EORx_REG(x4, x4, x4);
                     } else {
                         GETGY(v0, 0, vex.v, s0, -1); v2 = ymm_get_reg(dyn, ninst, x1, vex.v, 0, gd, s0, -1);

--- a/src/dynarec/arm64/dynarec_arm64_avx_66_0f38.c
+++ b/src/dynarec/arm64/dynarec_arm64_avx_66_0f38.c
@@ -1221,6 +1221,10 @@ uintptr_t dynarec64_AVX_66_0F38(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip
                     if(!l) {
                         GETGX_empty_VX(v0, v2);
                         addr = geted(dyn, addr, ninst, nextop, &ed, x3, &fixedaddress, NULL, 0, 0, rex, NULL, 0, 0);
+                        if(ed!=x3) {
+                            MOVz_REG(x3, ed);
+                            ed = x3;
+                        }
                         v1 = fpu_get_scratch(dyn, ninst);
                     } else {
                         GETGY_empty_VY(v0, v2, 0, -1, -1);


### PR DESCRIPTION
I encountered a CEF-based application that failed to launch properly. After debugging, I confirmed the issue was related to VPMASKMOVD/Q instructions - it doesn't verify if ed equals x3.