### PR TITLE
[WRAPPER] Add bridge for Display's resource_alloc when directly call XOpenIM but not XOpenDisplay

### DIFF
--- a/src/wrapped/generated/functions_list.txt
+++ b/src/wrapped/generated/functions_list.txt
@@ -5480,6 +5480,8 @@ wrappedlibx11:
   - XCheckIfEvent
   - XIfEvent
   - XPeekIfEvent
+- pFpppp:
+  - XOpenIM
 - iFppppp:
   - XQueryExtension
 - iFpppppp:

--- a/src/wrapped/generated/wrappedlibx11types.h
+++ b/src/wrapped/generated/wrappedlibx11types.h
@@ -24,6 +24,7 @@ typedef int32_t (*iFppp_t)(void*, void*, void*);
 typedef void* (*pFpip_t)(void*, int32_t, void*);
 typedef void* (*pFpCL_t)(void*, uint8_t, uintptr_t);
 typedef int32_t (*iFpppp_t)(void*, void*, void*, void*);
+typedef void* (*pFpppp_t)(void*, void*, void*, void*);
 typedef int32_t (*iFppppp_t)(void*, void*, void*, void*, void*);
 typedef int32_t (*iFpppppp_t)(void*, void*, void*, void*, void*, void*);
 typedef void* (*pFpLiiuuLi_t)(void*, uintptr_t, int32_t, int32_t, uint32_t, uint32_t, uintptr_t, int32_t);
@@ -57,6 +58,7 @@ typedef uintptr_t (*LFpLiiuuuiupLp_t)(void*, uintptr_t, int32_t, int32_t, uint32
 	GO(XCheckIfEvent, iFpppp_t) \
 	GO(XIfEvent, iFpppp_t) \
 	GO(XPeekIfEvent, iFpppp_t) \
+	GO(XOpenIM, pFpppp_t) \
 	GO(XQueryExtension, iFppppp_t) \
 	GO(XRegisterIMInstantiateCallback, iFpppppp_t) \
 	GO(XUnregisterIMInstantiateCallback, iFpppppp_t) \

--- a/src/wrapped/wrappedlibx11.c
+++ b/src/wrapped/wrappedlibx11.c
@@ -1646,6 +1646,22 @@ EXPORT uintptr_t my_XCreateWindow(x64emu_t* emu, my_XDisplay_t* dpy, uintptr_t v
     return ret;
 }
 
+EXPORT void* my_XOpenIM(x64emu_t* emu, my_XDisplay_t* dpy, void* v2, void* v3, void* v4)
+{
+    void* ret = my->XOpenIM(dpy, v2, v3, v4);
+    bridge_t* system = emu->context->system;
+
+    #define GO(A, W)\
+    if(dpy->A)      \
+        if(!CheckBridged(system, dpy->A)) \
+            AddAutomaticBridge(system, W, dpy->A, 0, #A); \
+
+    GO(resource_alloc, LFp)
+    #undef GO
+
+    return ret;
+}
+
 #define CUSTOM_INIT                 \
     AddAutomaticBridge(lib->w.bridge, vFp, *(void**)dlsym(lib->w.lib, "_XLockMutex_fn"), 0, "_XLockMutex_fn"); \
     AddAutomaticBridge(lib->w.bridge, vFp, *(void**)dlsym(lib->w.lib, "_XUnlockMutex_fn"), 0, "_XUnlockMutex_fn"); \

--- a/src/wrapped/wrappedlibx11_private.h
+++ b/src/wrapped/wrappedlibx11_private.h
@@ -933,7 +933,7 @@ GO(XOffsetRegion, iFpii)
 //GO(_XomInitConverter, 
 GO(XOMOfOC, pFp)
 GOM(XOpenDisplay, pFEp)
-GO(XOpenIM, pFpppp)
+GOM(XOpenIM, pFEpppp)
 //GO(_XOpenLC, 
 GO(XOpenOM, pFpppp)
 //GO(_XParseBaseFontNameList, 


### PR DESCRIPTION
Hi,

for https://github.com/ptitSeb/box64/issues/2794
testcase: [Scilab 6.0.1](https://www.scilab.org/download/6.0.1/scilab-6.0.1.bin.linux-x86_64.tar.gz) moved forward:
![2025-07-04_10-05](https://github.com/user-attachments/assets/cf5cc15a-e028-4a3c-955d-2b41af3f15ee)

Please review my patch.

Thanks,
Leslie Zhai
