### PR TITLE
[LA64_DYNAREC] Fix la64 avx->sse same reg migration.

### DIFF
--- a/src/dynarec/la64/dynarec_la64_helper.c
+++ b/src/dynarec/la64/dynarec_la64_helper.c
@@ -881,15 +881,17 @@ int sse_get_reg(dynarec_la64_t* dyn, int ninst, int s1, int a, int forwrite)
         }
         return dyn->lsx.ssecache[a].reg;
     }
+    int need_vld = 1;
     // migrate from avx to sse
     if (dyn->lsx.avxcache[a].v != -1) {
         avx_reflect_reg_upper128(dyn, ninst, a, forwrite);
         dyn->lsx.avxcache[a].v = -1;
+        need_vld = 0;
     }
     dyn->lsx.ssecache[a].reg = fpu_get_reg_xmm(dyn, forwrite ? LSX_CACHE_XMMW : LSX_CACHE_XMMR, a);
     int ret = dyn->lsx.ssecache[a].reg;
     dyn->lsx.ssecache[a].write = forwrite;
-    VLD(ret, xEmu, offsetof(x64emu_t, xmm[a]));
+    if(need_vld) VLD(ret, xEmu, offsetof(x64emu_t, xmm[a])); //skip VLD if migrate from avx
     return ret;
 }
 


### PR DESCRIPTION
In current code, if an avx reg  writed reg is used by following sse inst.
A VLD would emitted by sse_get_reg,  causing prev avx inst writed content lose. 
Skip sse_get_reg's VLD  emit, when reg content is already loaded/changed in prev avx inst.