### PR TITLE
box64-bundle-x86-libs.csv: fix libffi library

### DIFF
--- a/box64-bundle-x86-libs.csv
+++ b/box64-bundle-x86-libs.csv
@@ -16,8 +16,8 @@ https://archive.debian.org/debian/pool/main/c/curl/libcurl3-gnutls_7.74.0-1.3+de
 https://archive.debian.org/debian/pool/main/c/curl/libcurl3-gnutls_7.74.0-1.3+deb11u7~bpo11+1_i386.deb,625e5189304d4d3bfb27cb821e257816c5ce761b1696b5da5ca4fa1035c48463
 https://vault.almalinux.org/9.5/AppStream/x86_64/os/Packages/libepoxy-1.5.5-4.el9.i686.rpm,fe35e8de9b68c8d7e7b6b525580fc36cf9c86412cdb2b022dc01f95801771981
 https://vault.almalinux.org/9.5/AppStream/x86_64/os/Packages/libepoxy-1.5.5-4.el9.x86_64.rpm,b6d1e7f1c832882ceb05187cbc2d8fe1f459bcd88c7160487ee6f734e1a5d017
-https://vault.almalinux.org/9.5/AppStream/x86_64/os/Packages/libffi-devel-3.4.2-8.el9.i686.rpm,0c6f2ecc324680c6424bee4b1dbbdad2863f0f7f3130b196fc6e2b2823f07bc4
-https://vault.almalinux.org/9.5/AppStream/x86_64/os/Packages/libffi-devel-3.4.2-8.el9.x86_64.rpm,483e4c58cb8af94143a0ff4b3e49b62cb7d6896766c8c0d9fe3659e68945b50e
+https://vault.almalinux.org/9.5/BaseOS/x86_64/os/Packages/libffi-3.4.2-8.el9.i686.rpm,70daa216ed2a6540e41c455efc95d2b5671db164137f854bceae07e348f58645
+https://vault.almalinux.org/9.5/BaseOS/x86_64/os/Packages/libffi-3.4.2-8.el9.x86_64.rpm,1cf2d122e5c423681394c1bc599ee2281d2eafff5a3749842bc93c37db4bed5e
 https://vault.almalinux.org/9.5/BaseOS/x86_64/os/Packages/libgomp-11.5.0-2.el9.alma.1.i686.rpm,686ac26afe2073a3607f26fd1592a8ccd9b78f6eec6e872528634b43c4e04dd7
 https://vault.almalinux.org/9.5/BaseOS/x86_64/os/Packages/libgomp-11.5.0-2.el9.alma.1.x86_64.rpm,9a2bdc6807b22ffb6294b30dcc13e20198abe5facaeefcf1bfacec3e1013e3c2
 https://vault.almalinux.org/9.5/BaseOS/x86_64/os/Packages/libgpg-error-1.42-5.el9.i686.rpm,23f828674bc30752687452dacf4a25ca8c25ef0d25e3e6953d0714b5b33cef08


### PR DESCRIPTION
libffi-devel package is empty and contains only a symlink. Use the correct package to bundle the library binary.