### PR TITLE
[LA64_DYNAREC] Fix some la64 avx/sse ops.

### DIFF
--- a/src/dynarec/la64/dynarec_la64_660f.c
+++ b/src/dynarec/la64/dynarec_la64_660f.c
@@ -2519,7 +2519,7 @@ uintptr_t dynarec64_660F(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int 
             v1 = fpu_get_scratch(dyn);
             VREPLVEI_D(v0, q1, 0);
             VLDI(v1, (0b011 << 10) | 0x3f);
-            VSLEI_DU(v1, v0, v1);
+            VSLE_DU(v1, v0, v1);
             VSLL_D(q0, q0, v0);
             VAND_V(q0, q0, v1);
             break;

--- a/src/dynarec/la64/dynarec_la64_avx_66_0f.c
+++ b/src/dynarec/la64/dynarec_la64_avx_66_0f.c
@@ -827,7 +827,7 @@ uintptr_t dynarec64_AVX_66_0F(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip,
                 if (rex.w) {
                     VPICKVE2GR_D(ed, v0, 0);
                 } else {
-                    VPICKVE2GR_W(ed, v0, 0);
+                    VPICKVE2GR_WU(ed, v0, 0);
                 }
             } else {
                 addr = geted(dyn, addr, ninst, nextop, &ed, x2, x1, &fixedaddress, rex, NULL, 1, 0);

--- a/src/dynarec/la64/dynarec_la64_avx_66_0f38.c
+++ b/src/dynarec/la64/dynarec_la64_avx_66_0f38.c
@@ -187,7 +187,6 @@ uintptr_t dynarec64_AVX_66_0F38(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t i
             INST_NAME("VPERMILPS Gx, Vx, Ex");
             nextop = F8;
             GETGY_empty_VYEY_xy(v0, v1, v2, 0);
-            u8 = F8;
             d0 = fpu_get_scratch(dyn);
             VANDIxy(d0, v2, 0b11);
             VSHUFxy(W, d0, v1, v1);
@@ -457,17 +456,17 @@ uintptr_t dynarec64_AVX_66_0F38(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t i
             q0 = fpu_get_scratch(dyn);
             q1 = fpu_get_scratch(dyn);
             d0 = fpu_get_scratch(dyn);
-            VLDIxy(q0, 0b0010011111111); // broadcast 0xff as 16-bit elements to all lanes
+            VLDIxy(d0, (0b10111 <<8) | 0x00);  // Broadcast 0x0000FFFF as 32bits to all lane
             if (v1 == v2) {
-                VMAXIxy(W, v0, v1, 0);
-                VMINxy(W, v0, v1, q0);
-                VPICKEVxy(H, v0, v0, v0);
+                VMAXIxy(W, q0, v1, 0);
+                VMINxy(W, q0, q0, d0);
+                VPICKEVxy(H, v0, q0, q0);
             } else {
                 VMAXIxy(W, q1, v2, 0);
-                VMAXIxy(W, v0, v1, 0);
-                VMINxy(W, q1, q1, q0);
-                VMINxy(W, v0, v0, q0);
-                VPICKEVxy(H, v0, q1, v0);
+                VMAXIxy(W, q0, v1, 0);
+                VMINxy(W, q1, q1, d0);
+                VMINxy(W, q0, q0, d0);
+                VPICKEVxy(H, v0, q1, q0);
             }
             break;
         case 0x2C:
@@ -980,7 +979,6 @@ uintptr_t dynarec64_AVX_66_0F38(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t i
                 }
                 VXOR_V(v2, v2, v2);
             }
-            XVPERMI_Q(v0, v2, XVPERMI_IMM_4_0(1, 2));
             break;
         case 0x96:
             INST_NAME("VFMADDSUB132PS/D Gx, Vx, Ex");

--- a/src/dynarec/la64/la64_emitter.h
+++ b/src/dynarec/la64/la64_emitter.h
@@ -3288,18 +3288,18 @@ LSX instruction starts with V, LASX instruction starts with XV.
         }                               \
     } while (0)
 
-#define VREPLVEIxy(width, vd, vj, imm)        \
-    do {                                      \
-        if (vex.l) {                          \
-            if (imm > 0) {                    \
-                ADDI_D(x5, xZR, imm);         \
-                XVREPLVE_##width(vd, vj, x5); \
-            } else {                          \
-                XVREPLVE0_##width(vd, vj);    \
-            }                                 \
-        } else {                              \
-            VREPLVEI_##width(vd, vj, imm);    \
-        }                                     \
+#define VREPLVEIxy(width, vd, vj, imm)         \
+    do {                                       \
+        if (vex.l) {                           \
+            if (imm > 0) {                     \
+                ADDI_D(x5, xZR, imm);          \
+                XVREPLVE_##width(vd, vj, x5);  \
+            } else {                           \
+                XVREPLVE_##width(vd, vj, xZR); \
+            }                                  \
+        } else {                               \
+            VREPLVEI_##width(vd, vj, imm);     \
+        }                                      \
     } while (0)
 
 #define VSEQxy(width, vd, vj, vk)      \

--- a/src/dynarec/la64/la64_printer.c
+++ b/src/dynarec/la64/la64_printer.c
@@ -7672,6 +7672,50 @@ const char* la64_print(uint32_t opcode, uintptr_t addr)
         snprintf(buff, sizeof(buff), "%-15s %s, %s, 0x%lx", "VBITCLRI.D", Vt[Rd], Vt[Rj], imm);
         return buff;
     }
+    if (isMask(opcode, "01110010100110100iiiiijjjjjddddd", &a)) {
+        snprintf(buff, sizeof(buff), "%-15s %s, %s, 0x%lx", "VFRSTPI.B", Vt[Rd], Vt[Rj], imm);
+        return buff;
+    }
+    if (isMask(opcode, "01110010100110101iiiiijjjjjddddd", &a)) {
+        snprintf(buff, sizeof(buff), "%-15s %s, %s, 0x%lx", "VFRSTPI.H", Vt[Rd], Vt[Rj], imm);
+        return buff;
+    }
+    if (isMask(opcode, "01110010100100000iiiiijjjjjddddd", &a)) {
+        snprintf(buff, sizeof(buff), "%-15s %s, %s, 0x%lx", "VMAXI.B", Vt[Rd], Vt[Rj], imm);
+        return buff;
+    }
+    if (isMask(opcode, "01110010100100001iiiiijjjjjddddd", &a)) {
+        snprintf(buff, sizeof(buff), "%-15s %s, %s, 0x%lx", "VMAXI.H", Vt[Rd], Vt[Rj], imm);
+        return buff;
+    }
+    if (isMask(opcode, "01110010100100010iiiiijjjjjddddd", &a)) {
+        snprintf(buff, sizeof(buff), "%-15s %s, %s, 0x%lx", "VMAXI.W", Vt[Rd], Vt[Rj], imm);
+        return buff;
+    }
+    if (isMask(opcode, "01110010100100011iiiiijjjjjddddd", &a)) {
+        snprintf(buff, sizeof(buff), "%-15s %s, %s, 0x%lx", "VMAXI.D", Vt[Rd], Vt[Rj], imm);
+        return buff;
+    }
+    if (isMask(opcode, "01110010100101000iiiiijjjjjddddd", &a)) {
+        snprintf(buff, sizeof(buff), "%-15s %s, %s, 0x%lx", "VMAXI.BU", Vt[Rd], Vt[Rj], imm);
+        return buff;
+    }
+    if (isMask(opcode, "01110010100101001iiiiijjjjjddddd", &a)) {
+        snprintf(buff, sizeof(buff), "%-15s %s, %s, 0x%lx", "VMAXI.HU", Vt[Rd], Vt[Rj], imm);
+        return buff;
+    }
+    if (isMask(opcode, "01110010100101010iiiiijjjjjddddd", &a)) {
+        snprintf(buff, sizeof(buff), "%-15s %s, %s, 0x%lx", "VMAXI.WU", Vt[Rd], Vt[Rj], imm);
+        return buff;
+    }
+    if (isMask(opcode, "01110010100101011iiiiijjjjjddddd", &a)) {
+        snprintf(buff, sizeof(buff), "%-15s %s, %s, 0x%lx", "VMAXI.DU", Vt[Rd], Vt[Rj], imm);
+        return buff;
+    }
+    if (isMask(opcode, "01110011111000iiiiiiiiiiiiiddddd", &a)) {
+        snprintf(buff, sizeof(buff), "%-15s %s, 0x%lx", "VLDI", Vt[Rd], imm);
+        return buff;
+    }
     snprintf(buff, sizeof(buff), "%08X ???", __builtin_bswap32(opcode));
     return buff;
 }


### PR DESCRIPTION
Fix 66.0F.F3 PSLLQ
Fix VEX.66.0F.7E VMOVD not zero-extend
Fix Vex.66.0F.3A.06 VPERM2F128/VPERM2I128
Fix Vex.66.0F.3A.0D VBLENDPD
Fix VEX.66.0F.3A.18/38 VINSERTF128/VINSERTI128  when q0 == q1 or q0 == q2 
Fix VEX.66.0F.3A.21 VINSERTPS fix u8 get pos
Fix VEX.66.0F.3A.40 VDPPS Fix VREPLVEIxy emit when vex.l 
Fix VEX.66.0F.38.0C VPERMILPS
Fix VEX.66.0F.38.2B VPACKUSDW
Fix VEX.66.0F.38.93 VGATHERQPD