### PR TITLE
[WRAPPER] Refactor findGDestroyNotifyFct

### DIFF
--- a/src/include/gtkclass.h
+++ b/src/include/gtkclass.h
@@ -2236,6 +2236,7 @@ my_GTypeValueTable_t* findFreeGTypeValueTable(my_GTypeValueTable_t* fcts);
 my_GTypeInfo_t* findFreeGTypeInfo(my_GTypeInfo_t* fcts, size_t parent);
 my_GtkTypeInfo_t* findFreeGtkTypeInfo(my_GtkTypeInfo_t* fcts, size_t parent);
 void* find_class_init_Fct(void* fct, size_t parent);
+void* findGDestroyNotifyFct(void* fct);
 
 void InitGTKClass(bridge_t *bridge);
 void FiniGTKClass(void);

--- a/src/tools/gtkclass.c
+++ b/src/tools/gtkclass.c
@@ -5589,6 +5589,29 @@ my_GtkTypeInfo_t* findFreeGtkTypeInfo(my_GtkTypeInfo_t* fcts, size_t parent)
     return NULL;
 }
 
+// GDestroyNotify ...
+#define GO(A)   \
+static uintptr_t my_GDestroyNotify_fct_##A = 0;                    \
+static void my_GDestroyNotify_##A(void* a)                         \
+{                                                                  \
+    RunFunctionFmt(my_GDestroyNotify_fct_##A, "p", a); \
+}
+SUPER()
+#undef GO
+void* findGDestroyNotifyFct(void* fct)
+{
+    if(!fct) return fct;
+    if(GetNativeFnc((uintptr_t)fct))  return GetNativeFnc((uintptr_t)fct);
+    #define GO(A) if(my_GDestroyNotify_fct_##A == (uintptr_t)fct) return my_GDestroyNotify_##A;
+    SUPER()
+    #undef GO
+    #define GO(A) if(my_GDestroyNotify_fct_##A == 0) {my_GDestroyNotify_fct_##A = (uintptr_t)fct; return my_GDestroyNotify_##A; }
+    SUPER()
+    #undef GO
+    printf_log(LOG_NONE, "Warning, no more slot for glib2 GDestroyNotify callback\n");
+    return NULL;
+}
+
 #undef SUPER
 
 void InitGTKClass(bridge_t *bridge)

--- a/src/wrapped/wrappedgdk3.c
+++ b/src/wrapped/wrappedgdk3.c
@@ -79,28 +79,6 @@ static void* findGSourceFunc(void* fct)
     printf_log(LOG_NONE, "Warning, no more slot for gdk-3 GSourceFunc callback\n");
     return NULL;
 }
-// GDestroyNotify
-#define GO(A)   \
-static uintptr_t my_GDestroyNotify_fct_##A = 0;                         \
-static void my_GDestroyNotify_##A(void* data)                           \
-{                                                                       \
-    RunFunctionFmt(my_GDestroyNotify_fct_##A, "p", data);         \
-}
-SUPER()
-#undef GO
-static void* findGDestroyNotifyFct(void* fct)
-{
-    if(!fct) return fct;
-    if(GetNativeFnc((uintptr_t)fct))  return GetNativeFnc((uintptr_t)fct);
-    #define GO(A) if(my_GDestroyNotify_fct_##A == (uintptr_t)fct) return my_GDestroyNotify_##A;
-    SUPER()
-    #undef GO
-    #define GO(A) if(my_GDestroyNotify_fct_##A == 0) {my_GDestroyNotify_fct_##A = (uintptr_t)fct; return my_GDestroyNotify_##A; }
-    SUPER()
-    #undef GO
-    printf_log(LOG_NONE, "Warning, no more slot for gdk-3 GDestroyNotify callback\n");
-    return NULL;
-}
 // GCallback  (generic function with 6 arguments, hopefully it's enough)
 #define GO(A)   \
 static uintptr_t my_GCallback_fct_##A = 0;                                                      \

--- a/src/wrapped/wrappedgdkx112.c
+++ b/src/wrapped/wrappedgdkx112.c
@@ -81,28 +81,6 @@ static void* findGSourceFunc(void* fct)
     printf_log(LOG_NONE, "Warning, no more slot for gdk2 GSourceFunc callback\n");
     return NULL;
 }
-// GDestroyNotify
-#define GO(A)   \
-static uintptr_t my_GDestroyNotify_fct_##A = 0;                         \
-static void my_GDestroyNotify_##A(void* data)                           \
-{                                                                       \
-    RunFunctionFmt(my_GDestroyNotify_fct_##A, "p", data);         \
-}
-SUPER()
-#undef GO
-static void* findGDestroyNotifyFct(void* fct)
-{
-    if(!fct) return fct;
-    if(GetNativeFnc((uintptr_t)fct))  return GetNativeFnc((uintptr_t)fct);
-    #define GO(A) if(my_GDestroyNotify_fct_##A == (uintptr_t)fct) return my_GDestroyNotify_##A;
-    SUPER()
-    #undef GO
-    #define GO(A) if(my_GDestroyNotify_fct_##A == 0) {my_GDestroyNotify_fct_##A = (uintptr_t)fct; return my_GDestroyNotify_##A; }
-    SUPER()
-    #undef GO
-    printf_log(LOG_NONE, "Warning, no more slot for gdk2 GDestroyNotify callback\n");
-    return NULL;
-}
 // EventHandler
 #define GO(A)   \
 static uintptr_t my_EventHandler_fct_##A = 0;               \

--- a/src/wrapped/wrappedgio2.c
+++ b/src/wrapped/wrappedgio2.c
@@ -64,29 +64,6 @@ static void* findGAsyncReadyCallbackFct(void* fct)
     return NULL;
 }
 
-// GDestroyNotify
-#define GO(A)   \
-static uintptr_t my_GDestroyNotify_fct_##A = 0;                       \
-static void my_GDestroyNotify_##A(void* data)                         \
-{                                                                     \
-    RunFunctionFmt(my_GDestroyNotify_fct_##A, "p", data); \
-}
-SUPER()
-#undef GO
-static void* findGDestroyNotifyFct(void* fct)
-{
-    if(!fct) return fct;
-    if(GetNativeFnc((uintptr_t)fct))  return GetNativeFnc((uintptr_t)fct);
-    #define GO(A) if(my_GDestroyNotify_fct_##A == (uintptr_t)fct) return my_GDestroyNotify_##A;
-    SUPER()
-    #undef GO
-    #define GO(A) if(my_GDestroyNotify_fct_##A == 0) {my_GDestroyNotify_fct_##A = (uintptr_t)fct; return my_GDestroyNotify_##A; }
-    SUPER()
-    #undef GO
-    printf_log(LOG_NONE, "Warning, no more slot for gio2 GDestroyNotify callback\n");
-    return NULL;
-}
-
 // GDBusProxyTypeFunc
 #define GO(A)   \
 static uintptr_t my_GDBusProxyTypeFunc_fct_##A = 0;                                                           \

--- a/src/wrapped/wrappedglib2.c
+++ b/src/wrapped/wrappedglib2.c
@@ -445,28 +445,6 @@ static void* findGIOFuncFct(void* fct)
     printf_log(LOG_NONE, "Warning, no more slot for glib2 GIOFunc callback\n");
     return NULL;
 }
-// GDestroyNotify ...
-#define GO(A)   \
-static uintptr_t my_GDestroyNotify_fct_##A = 0;                    \
-static void my_GDestroyNotify_##A(void* a)                         \
-{                                                                  \
-    RunFunctionFmt(my_GDestroyNotify_fct_##A, "p", a); \
-}
-SUPER()
-#undef GO
-static void* findGDestroyNotifyFct(void* fct)
-{
-    if(!fct) return fct;
-    if(GetNativeFnc((uintptr_t)fct))  return GetNativeFnc((uintptr_t)fct);
-    #define GO(A) if(my_GDestroyNotify_fct_##A == (uintptr_t)fct) return my_GDestroyNotify_##A;
-    SUPER()
-    #undef GO
-    #define GO(A) if(my_GDestroyNotify_fct_##A == 0) {my_GDestroyNotify_fct_##A = (uintptr_t)fct; return my_GDestroyNotify_##A; }
-    SUPER()
-    #undef GO
-    printf_log(LOG_NONE, "Warning, no more slot for glib2 GDestroyNotify callback\n");
-    return NULL;
-}
 // GFunc ...
 #define GO(A)   \
 static uintptr_t my_GFunc_fct_##A = 0;                        \

--- a/src/wrapped/wrappedgtk3.c
+++ b/src/wrapped/wrappedgtk3.c
@@ -350,29 +350,6 @@ static void* findGtkTreeCellDataFuncFct(void* fct)
     return NULL;
 }
 
-// GDestroyNotify
-#define GO(A)   \
-static uintptr_t my_GDestroyNotify_fct_##A = 0;                         \
-static void my_GDestroyNotify_##A(void* data)                           \
-{                                                                       \
-    RunFunctionFmt(my_GDestroyNotify_fct_##A, "p", data);         \
-}
-SUPER()
-#undef GO
-static void* findGDestroyNotifyFct(void* fct)
-{
-    if(!fct) return fct;
-    if(GetNativeFnc((uintptr_t)fct))  return GetNativeFnc((uintptr_t)fct);
-    #define GO(A) if(my_GDestroyNotify_fct_##A == (uintptr_t)fct) return my_GDestroyNotify_##A;
-    SUPER()
-    #undef GO
-    #define GO(A) if(my_GDestroyNotify_fct_##A == 0) {my_GDestroyNotify_fct_##A = (uintptr_t)fct; return my_GDestroyNotify_##A; }
-    SUPER()
-    #undef GO
-    printf_log(LOG_NONE, "Warning, no more slot for gtk-3 GDestroyNotify callback\n");
-    return NULL;
-}
-
 // GtkTreeIterCompareFunc
 #define GO(A)   \
 static uintptr_t my_GtkTreeIterCompareFunc_fct_##A = 0;                                                 \

--- a/src/wrapped/wrappedgtkx112.c
+++ b/src/wrapped/wrappedgtkx112.c
@@ -389,30 +389,6 @@ static void* findGtkTreeCellDataFuncFct(void* fct)
     return NULL;
 }
 
-
-// GDestroyNotify
-#define GO(A)   \
-static uintptr_t my_GDestroyNotify_fct_##A = 0;                         \
-static void my_GDestroyNotify_##A(void* data)                           \
-{                                                                       \
-    RunFunctionFmt(my_GDestroyNotify_fct_##A, "p", data);         \
-}
-SUPER()
-#undef GO
-static void* findGDestroyNotifyFct(void* fct)
-{
-    if(!fct) return fct;
-    if(GetNativeFnc((uintptr_t)fct))  return GetNativeFnc((uintptr_t)fct);
-    #define GO(A) if(my_GDestroyNotify_fct_##A == (uintptr_t)fct) return my_GDestroyNotify_##A;
-    SUPER()
-    #undef GO
-    #define GO(A) if(my_GDestroyNotify_fct_##A == 0) {my_GDestroyNotify_fct_##A = (uintptr_t)fct; return my_GDestroyNotify_##A; }
-    SUPER()
-    #undef GO
-    printf_log(LOG_NONE, "Warning, no more slot for gtk-2 GDestroyNotify callback\n");
-    return NULL;
-}
-
 // GtkTreeModelForeachFunc
 #define GO(A)   \
 static uintptr_t my_GtkTreeModelForeachFunc_fct_##A = 0;                                                            \


### PR DESCRIPTION
Hi,

There are duplicated `findGDestroyNotifyFct`, so just put it into `src/tools/gtkclass.c`.

Testcase: [gtk+-3.24.5/tests/testpixbuf-save](https://github.com/GNOME/gtk/blob/3.24.5/tests/testpixbuf-save.c) which used `GDestroyNotify` Passed.
`make test` Passed.

Please review my patch.

Thanks,
Leslie Zhai