### PR TITLE
[LA64_DYNAREC] Fix BTR , ANDW opcode.

### DIFF
--- a/src/dynarec/la64/dynarec_la64_0f.c
+++ b/src/dynarec/la64/dynarec_la64_0f.c
@@ -1672,7 +1672,11 @@ uintptr_t dynarec64_0F(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
             }
             ANDI(x2, gd, rex.w ? 0x3f : 0x1f);
             SRL_D(x4, ed, x2);
-            BSTRINS_D(xFlags, x4, 0, 0);
+            if(cpuext.lbt) {
+                X64_SET_EFLAGS(x4, X_CF);
+            } else {
+                BSTRINS_D(xFlags, x4, 0, 0);
+            }
             ADDI_D(x4, xZR, 1);
             ANDI(x2, gd, rex.w ? 0x3f : 0x1f);
             SLL_D(x4, x4, x2);

--- a/src/dynarec/la64/dynarec_la64_emit_logic.c
+++ b/src/dynarec/la64/dynarec_la64_emit_logic.c
@@ -347,7 +347,7 @@ void emit_and16(dynarec_la64_t* dyn, int ninst, int s1, int s2, int s3, int s4)
     }
 
     IFXA (X_ALL, cpuext.lbt) {
-        X64_AND_W(s1, s2);
+        X64_AND_H(s1, s2);
     }
 
     AND(s1, s1, s2); // res = s1 & s2


### PR DESCRIPTION
Fix B3 BTR eflags when cpuext.lbt == 1. 
Fix 16bits AND when cpuext.lbt ==1.