### PR TITLE
Fix undefined type ‘struct mallinfo2’ for LA64 ABI 1.0

### DIFF
--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -3203,6 +3203,7 @@ EXPORT void* my_mallinfo(x64emu_t* emu, void* p)
     return p;
 }
 
+#ifndef LA64_ABI_1
 typedef struct mallinfo2 (*mallinfo2_fnc)(void);
 EXPORT void* my_mallinfo2(x64emu_t* emu, void* p)
 {
@@ -3218,6 +3219,7 @@ EXPORT void* my_mallinfo2(x64emu_t* emu, void* p)
         memset(p, 0, sizeof(struct mallinfo2));
     return p;
 }
+#endif // LA64_ABI_1
 
 #ifdef STATICBUILD
 void my_updateGlobalOpt() {}


### PR DESCRIPTION
Hi,

glibc >= 2.33 [Add mallinfo2 function that support sizes >= 4GB](https://sourceware.org/pipermail/glibc-cvs/2020q3/070629.html), but LA64 ABI 1.0 glibc is 2.28, so `mallinfo2` is not available.

Please review my patch.

Thanks,
Leslie Zhai