### PR TITLE
Update elfloader.c for setting BOX64_MALLOC_HACK=2

### DIFF
--- a/src/elfs/elfloader.c
+++ b/src/elfs/elfloader.c
@@ -1149,8 +1149,11 @@ void RefreshElfTLS(elfheader_t* h)
 }
 void MarkElfInitDone(elfheader_t* h)
 {
-    if(h)
+    if(h) {
         h->init_done = 1;
+    	if(h->malloc_hook_2)
+            startMallocHook();
+    }
 }
 #ifndef STATICBUILD
 void startMallocHook();


### PR DESCRIPTION
When setting BOX64_MALLOC_HACK=2,  new added code helps  activate the malloc-hook mechanism for the X86_64 ELF file . relate: Issue 3011