### PR TITLE
[Docs] Add glibc capability warning and fix typo

### DIFF
--- a/docs/COMPILE.md
+++ b/docs/COMPILE.md
@@ -346,6 +346,9 @@ In particular, you must specify the cross-compiler. For example:
 -DCMAKE_C_COMPILER=riscv64-unknown-linux-gnu-gcc  # Or whichever cross-compiler you use
 ```
 
+Be aware of potential glibc capability errors when choosing a cross-compiler.
+To avoid this, run `ldd --version` on your target machine to check its glibc version.
+
 ### Running tests with QEMU (optional)
 To do a quick check, run:
 ```

--- a/docs/COMPILE.md
+++ b/docs/COMPILE.md
@@ -370,7 +370,7 @@ $ mv box64-x86_64-linux-gnu /usr/lib
 ```
 For `i386`:
 ```shell
-$ mv x64lib box64-i386-linux-gnu
+$ mv x86lib box64-i386-linux-gnu
 $ mv box64-i386-linux-gnu /usr/lib
 ```
 


### PR DESCRIPTION
The previous one mixed up `x64` and `x86`.