### PR TITLE
[WRAPPER] Fix no more slot for glib2 GSourceFunc callback

### DIFF
--- a/src/wrapped/wrappedglib2.c
+++ b/src/wrapped/wrappedglib2.c
@@ -70,6 +70,11 @@ GO(6)   \
 GO(7)   \
 GO(8)   \
 GO(9)   \
+GO(10)  \
+GO(11)  \
+GO(12)  \
+GO(13)  \
+GO(14)  \
 
 // GCopyFct
 #define GO(A)   \


### PR DESCRIPTION
Hi,

[gtkperf](http://prdownloads.sourceforge.net/gtkperf/gtkperf_0.40.tar.gz?download) reproduced the issue:
```
GtkDrawingArea - Text - [BOX64] Warning, no more slot for glib2 GSourceFunc callback
```

Please review my patch.

Thanks,
Leslie Zhai