### PR TITLE
[WRAPPER] Add some wrappers for libm

### DIFF
--- a/src/wrapped/wrappedlibm_private.h
+++ b/src/wrapped/wrappedlibm_private.h
@@ -40,8 +40,8 @@ GOW(cacos, XFX)
 GOW(cacosf, xFx)
 GOW(cacosh, XFX)
 GOW(cacoshf, xFx)
-// cacoshl  // Weak
-// cacosl   // Weak
+GOWD(cacoshl, YFY, cacosh)
+GOWD(cacosl, YFY, cacos)
 GOW(carg, XFX)
 GOW(cargf, xFx)
 // cargl    // Weak
@@ -49,14 +49,14 @@ GOW(casin, XFX)
 GOW(casinf, xFx)
 GOW(casinh, XFX)
 GOW(casinhf, xFx)
-// casinhl  // Weak
-// casinl   // Weak
+GOWD(casinhl, YFY, casinh)
+GOWD(casinl, YFY, casin)
 GOW(catan, XFX)
 GOW(catanf, xFx)
 GOW(catanh, XFX)
 GOW(catanhf, xFx)
-// catanhl  // Weak
-// catanl   // Weak
+GOWD(catanhl, YFY, catanh)
+GOWD(catanl, YFY, catan)
 GOW(cbrt, dFd)
 GOW(cbrtf, fFf)
 GOWD(cbrtl, DFD, cbrt)
@@ -152,7 +152,7 @@ GOW(expm1f, fFf)
 GOWD(expm1l, DFD, expm1)
 GOW(fabs, dFd)
 GOW(fabsf, fFf)
-// fabsl    // Weak
+GOWD(fabsl, DFD, fabs)
 GOW(fdim, dFdd)
 GOW(fdimf, fFff)
 // fdiml    // Weak
@@ -184,10 +184,10 @@ GOW(fmaf, fFfff)
 GOWD(fmal, DFDDD, fma)
 GOW(fmax, dFdd)
 GOW(fmaxf, fFff)
-// fmaxl    // Weak
+GOWD(fmaxl, DFDD, fmax)
 GOW(fmin, dFdd)
 GOW(fminf, fFff)
-// fminl    // Weak
+GOWD(fminl, DFDD, fmin)
 GOW(fmod, dFdd)
 GOW(fmodf, fFff)
 GOM(__fmodf_finite, fFff)
@@ -366,7 +366,7 @@ GOW(tgammaf, fFf)
 GOWD(tgammal, DFD, tgamma)
 GOW(trunc, dFd)
 GOW(truncf, fFf)
-// truncl   // Weak
+GOWD(truncl, DFD, trunc)
 GO(y0, dFd)
 GO(y0f, fFf)
 // __y0f_finite


### PR DESCRIPTION
Hi,

Testcase for x64 [python-build-standalone 3.11.14+20251014](https://github.com/astral-sh/python-build-standalone/releases/download/20251014/cpython-3.11.14+20251014-x86_64-unknown-linux-gnu-install_only.tar.gz):

```
box64 /your/path/x64/python/bin/pip3 install numpy==2.3.4
box64 /your/path/x64/python/bin/python3 -c "import numpy"
```

Reproduced:

```
[BOX64] Error: Global Symbol truncl not found, cannot apply R_X86_64_GLOB_DAT @0x7fff009a6890 ((nil)) in /home/zhaixiang/python/lib/python3.11/site-packages/numpy/_core/_multiarray_umath.cpython-311-x86_64-linux-gnu.so
...
[BOX64] Error: Global Symbol fabsl not found, cannot apply R_X86_64_GLOB_DAT @0x7fff009a6d98 ((nil)) in /home/zhaixiang/python/lib/python3.11/site-packages/numpy/_core/_multiarray_umath.cpython-311-x86_64-linux-gnu.so
[BOX64] Error: Symbol casinhl not found, cannot apply R_X86_64_JUMP_SLOT @0x7fff009a70e8 (0x2b206) in /home/zhaixiang/python/lib/python3.11/site-packages/numpy/_core/_multiarray_umath.cpython-311-x86_64-linux-gnu.so
[BOX64] Error: Symbol catanl not found, cannot apply R_X86_64_JUMP_SLOT @0x7fff009a7368 (0x2b706) in /home/zhaixiang/python/lib/python3.11/site-packages/numpy/_core/_multiarray_umath.cpython-311-x86_64-linux-gnu.so
[BOX64] Error: Symbol fminl not found, cannot apply R_X86_64_JUMP_SLOT @0x7fff009a7660 (0x2bcf6) in /home/zhaixiang/python/lib/python3.11/site-packages/numpy/_core/_multiarray_umath.cpython-311-x86_64-linux-gnu.so
[BOX64] Error: Symbol fmaxl not found, cannot apply R_X86_64_JUMP_SLOT @0x7fff009a7688 (0x2bd46) in /home/zhaixiang/python/lib/python3.11/site-packages/numpy/_core/_multiarray_umath.cpython-311-x86_64-linux-gnu.so
[BOX64] Error: Symbol cacosl not found, cannot apply R_X86_64_JUMP_SLOT @0x7fff009a78f8 (0x2c226) in /home/zhaixiang/python/lib/python3.11/site-packages/numpy/_core/_multiarray_umath.cpython-311-x86_64-linux-gnu.so
[BOX64] Error: Symbol cacoshl not found, cannot apply R_X86_64_JUMP_SLOT @0x7fff009a79e8 (0x2c406) in /home/zhaixiang/python/lib/python3.11/site-packages/numpy/_core/_multiarray_umath.cpython-311-x86_64-linux-gnu.so
[BOX64] Error: Symbol catanhl not found, cannot apply R_X86_64_JUMP_SLOT @0x7fff009a7ec8 (0x2cdc6) in /home/zhaixiang/python/lib/python3.11/site-packages/numpy/_core/_multiarray_umath.cpython-311-x86_64-linux-gnu.so
[BOX64] Error: Symbol casinl not found, cannot apply R_X86_64_JUMP_SLOT @0x7fff009a80d8 (0x2d1e6) in /home/zhaixiang/python/lib/python3.11/site-packages/numpy/_core/_multiarray_umath.cpython-311-x86_64-linux-gnu.so
[BOX64] Error: relocating Plt symbols in elf _multiarray_umath.cpython-311-x86_64-linux-gnu.so
```

Reduced[1] testcase passed and make test passed.

Please review my patch.

[1]
```
#include <complex.h>
#include <math.h>
#include <stdio.h>

int main(int argc, char* argv[]) {
    long double complex z = 1.0L + 2.0L * I;
    long double complex result = casinhl(z);
    
    printf("casinhl(%.1Lf + %.1Lfi) = %.6Lf + %.6Lfi\n", 
           creall(z), cimagl(z), creall(result), cimagl(result));

    z = 2.0L + 1.0L * I;
    result = cacoshl(z);
    
    printf("cacoshl(%.1Lf + %.1Lfi) = %.6Lf + %.6Lfi\n", 
           creall(z), cimagl(z), creall(result), cimagl(result));

    z = 0.5L + 0.5L * I;
    result = cacosl(z);
    
    printf("cacosl(%.1Lf + %.1Lfi) = %.6Lf + %.6Lfi\n", 
           creall(z), cimagl(z), creall(result), cimagl(result));

    z = 0.5L + 0.5L * I;
    result = casinl(z);
    
    printf("casinl(%.1Lf + %.1Lfi) = %.6Lf + %.6Lfi\n", 
           creall(z), cimagl(z), creall(result), cimagl(result));

    z = 0.5L + 0.5L * I;
    result = catanhl(z);
    
    printf("catanhl(%.1Lf + %.1Lfi) = %.6Lf + %.6Lfi\n", 
           creall(z), cimagl(z), creall(result), cimagl(result));

    z = 0.5L + 0.5L * I;
    result = catanl(z);
    
    printf("catanl(%.1Lf + %.1Lfi) = %.6Lf + %.6Lfi\n", 
           creall(z), cimagl(z), creall(result), cimagl(result));

    return 0;
}
```

Thanks,
Leslie Zhai