### PR TITLE
[WRAPPER] Add wrapper for rintl

### DIFF
--- a/src/wrapped/wrappedlibm_private.h
+++ b/src/wrapped/wrappedlibm_private.h
@@ -315,7 +315,7 @@ GOW(remquof, fFffp)
 // remquol  // Weak
 GOWM(rint, dFEd)
 GOWM(rintf, fFEf)
-// rintl    // Weak
+GOWD(rintl, DFD, rint)
 GOW(round, dFd)
 GOW(roundf, fFf)
 GO(roundeven, dFd)  //since C23


### PR DESCRIPTION
Hi,

Testcase for x64 [python-build-standalone 3.11.14+20251014](https://github.com/astral-sh/python-build-standalone/releases/download/20251014/cpython-3.11.14+20251014-x86_64-unknown-linux-gnu-install_only.tar.gz):

```
box64 /your/path/x64/python/bin/pip3 install numpy==2.3.4
box64 /your/path/x64/python/bin/python3 -c "import numpy"
```

Reproduced `rintl` issue:
```
[BOX64] Error: Global Symbol rintl not found, cannot apply R_X86_64_GLOB_DAT @0x7fff009a6c58 ((nil)) in /home/zhaixiang/python/lib/python3.11/site-packages/numpy/_core/_multiarray_umath.cpython-311-x86_64-linux-gnu.so
```

Reduced testcase and make test passed.

```
#include <stdio.h>
#include <math.h>

int main(int argc, char* argv) {
    long double x = 3.7L;
    long double y = -2.3L;

    printf("rintl(%.1Lf) = %.1Lf\n", x, rintl(x));
    printf("rintl(%.1Lf) = %.1Lf\n", y, rintl(y));

    return 0;
}
```

Same output from x64 host and box64 for LA64:

```
$ ./x64-test-rintl
rintl(3.7) = 4.0
rintl(-2.3) = -2.0

[BOX64] Box64 loongarch64 v0.3.9 e6c4bbcd with Dynarec built on Oct 28 2025 19:35:42
[BOX64] Dynarec for LoongArch with extension LSX LASX LBT_X86
[BOX64] Running on Loongson-3A5000-HV with 4 cores, pagesize: 16384
[BOX64] Will use hardware counter measured at 2.5 GHz
[BOX64] Didn't detect 48bits of address space, considering it's 39bits
[BOX64] Counted 64 Env var
[BOX64] Library search path: 
[BOX64] Binary search path: ./:bin/:/usr/local/bin/:/usr/bin/:/bin/:/usr/local/games/:/usr/games/
[BOX64] Looking for /home/zhaixiang/x64-test-rintl
[BOX64] Rename process to "x64-test-rintl"
[BOX64] Using native(wrapped) libm.so.6
[BOX64] Using native(wrapped) libc.so.6
[BOX64] Using native(wrapped) ld-linux-x86-64.so.2
[BOX64] Using native(wrapped) libpthread.so.0
[BOX64] Using native(wrapped) libdl.so.2
[BOX64] Using native(wrapped) libutil.so.1
[BOX64] Using native(wrapped) librt.so.1
[BOX64] Using native(wrapped) libbsd.so.0
rintl(3.7) = 4.0
rintl(-2.3) = -2.0
```

Please review my patch.

Thanks,
Leslie Zhai