### PR TITLE
[LA64_DYNAREC] Add more 32/64 bits arith lock opcodes.

### DIFF
--- a/src/dynarec/la64/dynarec_la64_helper.h
+++ b/src/dynarec/la64/dynarec_la64_helper.h
@@ -1849,11 +1849,11 @@ uintptr_t dynarec64_DF(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
     x7 = imm if inst use imm op
 */
 #define LOCK_32_IN_8BYTE(op, x1, wback, x3, x4, x5, x6, x7) \
+    if (wback != x2) {                                      \
+        MV(x2, wback);                                      \
+        wback = x2;                                         \
+    }                                                       \
     BSTRINS_D(wback, xZR, 2, 0);                            \
-    if(wback != x2) {                                            \
-        MV(x2, wback);                                           \
-        wback = x2;                                              \
-    }                                                            \
     SLLI_W(x3, x3, 3);                                      \
     if (cpuext.lamcas) {                                    \
         LD_D(x5, wback, 0);                                 \


### PR DESCRIPTION
  *  Fix LOCK_32_IN_8BYTE
  *  F0 0F C1 /0 LOCK XADD Ed, Gd
  *  F0 11 LOCK ADC Ed, Gd
  *  F0 19 LOCK SBB Ed, Gd
  *  F0 29 LOCK SUB Ed, Gd
  *  F0 81/83 /2 LOCK ADC Ed, Id/Ib
  *  F0 81/83 /3 LOCK SBB Ed, Id/Ib
  *  F0 81/83 /5 LOCK SUB Ed, Id/Ib
  *  F0 F7 /3 LOCK NEG Ed
  *  F0 FF /0 LOCK INC Ed
  *  F0 FF /1 LOCK DEC Ed