### PR TITLE
[DYNAREC_PURGE] Decrement in_used before longjmp

### DIFF
--- a/src/dynarec/dynablock.c
+++ b/src/dynarec/dynablock.c
@@ -221,6 +221,13 @@ void cancelFillBlock()
     LongJmp(GET_JUMPBUFF(dynarec_jmpbuf), 1);
 }
 
+void dynablock_leave_runtime(dynablock_t* db)
+{
+    if(!db) return;
+    if(!db->hot) return;
+    __atomic_fetch_sub(&db->in_used, 1, __ATOMIC_ACQ_REL);
+}
+
 /* 
     return NULL if block is not found / cannot be created. 
     Don't create if create==0

--- a/src/include/dynablock.h
+++ b/src/include/dynablock.h
@@ -20,6 +20,7 @@ dynablock_t* DBAlternateBlock(x64emu_t* emu, uintptr_t addr, uintptr_t filladdr,
 
 // for use in signal handler
 void cancelFillBlock(void);
+void dynablock_leave_runtime(dynablock_t* db);
 
 // clear instruction cache on a range
 void ClearCache(void* start, size_t len);

--- a/src/libtools/signal32.c
+++ b/src/libtools/signal32.c
@@ -747,6 +747,9 @@ void my_sigactionhandler_oldcode_32(x64emu_t* emu, int32_t sig, int simple, sigi
             #ifdef RV64
             emu->xSPSave = emu->old_savedsp;
             #endif
+            #ifdef DYNAREC
+            dynablock_leave_runtime((dynablock_t*)cur_db);
+            #endif
             #ifdef ANDROID
             siglongjmp(*emu->jmpbuf, skip);
             #else

--- a/src/libtools/signals.c
+++ b/src/libtools/signals.c
@@ -1264,6 +1264,9 @@ void my_sigactionhandler_oldcode_64(x64emu_t* emu, int32_t sig, int simple, sigi
             #ifdef RV64
             emu->xSPSave = emu->old_savedsp;
             #endif
+            #ifdef DYNAREC
+            dynablock_leave_runtime((dynablock_t*)cur_db);
+            #endif
             #ifdef ANDROID
             siglongjmp(*emu->jmpbuf, skip);
             #else
@@ -1566,6 +1569,7 @@ void my_box64signalhandler(int32_t sig, siginfo_t* info, void * ucntx)
                         dynarec_log(LOG_INFO, "Dynablock (%p, x64addr=%p) %s, getting out at %s %p (%p)!\n", db, db->x64_addr, is_hotpage?"in HotPage":"dirty", getAddrFunctionName(R_RIP), (void*)R_RIP, type_callret?"self-loop":"ret from callret", (void*)addr);
                         emu->test.clean = 0;
                         // use "3" to regen a dynablock at current pc (else it will first do an interp run)
+                        dynablock_leave_runtime(db);
                         #ifdef ANDROID
                         siglongjmp(*(JUMPBUFF*)emu->jmpbuf, 3);
                         #else
@@ -1637,6 +1641,7 @@ void my_box64signalhandler(int32_t sig, siginfo_t* info, void * ucntx)
                     CancelBlock64(1);
                 emu->test.clean = 0;
                 // will restore unblocked Signal flags too
+                dynablock_leave_runtime(db);
                 #ifdef ANDROID
                 siglongjmp(*(JUMPBUFF*)emu->jmpbuf, 2);
                 #else


### PR DESCRIPTION
Signal handlers that use siglongjmp() to escape from dynarec blocks were abandoning blocks without decrementing their in_used reference count, causing blocks to remain permanently marked as in-use and preventing them from being freed even when they're no longer needed.