### PR TITLE
[DYNAREC_PURGE] Tick-Based Cache Purge System

### DIFF
--- a/src/dynarec/arm64/dynarec_arm64_helper.c
+++ b/src/dynarec/arm64/dynarec_arm64_helper.c
@@ -2782,16 +2782,10 @@ void doEnterBlock(dynarec_arm_t* dyn, int ninst, int s1, int s2, int s3)
         STLXRw(s3, s2, s1);
         CBNZw(s3, -3*4);
     }
-    // now increment hot
-    ADDx_U12(s1, s1, offsetof(dynablock_t, hot)-offsetof(dynablock_t, in_used));
-    if(cpuext.atomics) {
-        STADDLw(s3, s1);
-    } else {
-        LDAXRw(s2, s1);
-        ADDw_U12(s2, s2, 1);
-        STLXRw(s3, s2, s1);
-        CBNZw(s3, -3*4);
-    }
+    // set tick
+    LDRx_U12(s2, xEmu, offsetof(x64emu_t, context));
+    LDRw_U12(s2, s2, offsetof(box64context_t, tick));
+    STRw_U12(s2, s1, offsetof(dynablock_t, tick)-offsetof(dynablock_t, in_used));
     MESSAGE(LOG_INFO, "-------- doEnter\n");
 }
 void doLeaveBlock(dynarec_arm_t* dyn, int ninst, int s1, int s2, int s3)

--- a/src/dynarec/dynablock.c
+++ b/src/dynarec/dynablock.c
@@ -224,7 +224,7 @@ void cancelFillBlock()
 void dynablock_leave_runtime(dynablock_t* db)
 {
     if(!db) return;
-    if(!db->hot) return;
+    if(!db->tick) return;
     __atomic_fetch_sub(&db->in_used, 1, __ATOMIC_ACQ_REL);
 }
 

--- a/src/dynarec/dynablock_private.h
+++ b/src/dynarec/dynablock_private.h
@@ -16,7 +16,7 @@ typedef struct dynablock_s {
     void*           actual_block;   // the actual start of the block (so block-sizeof(void*))
     struct dynablock_s*    previous;   // a previous block that might need to be freed
     uint32_t        in_used;// will be 0 if not in_used, >0 if used be some code
-    uint32_t        hot;    // simple counter on how many time the block is run
+    uint32_t        tick;    // last "tick" when dynablock was run
     void*           x64_addr;
     uintptr_t       x64_size;
     size_t          native_size;

--- a/src/include/box64context.h
+++ b/src/include/box64context.h
@@ -93,6 +93,7 @@ typedef struct base_segment_s {
 } base_segment_t;
 
 typedef struct box64context_s {
+    uint32_t            tick;           // for dynarec age
     path_collection_t   box64_path;     // PATH env. variable
     path_collection_t   box64_ld_lib;   // LD_LIBRARY_PATH env. variable
 

--- a/src/include/env.h
+++ b/src/include/env.h
@@ -76,6 +76,7 @@ extern char* ftrace_name;
     INTEGER(BOX64_DYNAREC_X87DOUBLE, dynarec_x87double, 0, 0, 2, 1)           \
     BOOLEAN(BOX64_DYNAREC_INTERP_SIGNAL, dynarec_interp_signal, 0, 0)         \
     BOOLEAN(BOX64_DYNAREC_PURGE, dynarec_purge, 0, 0)                         \
+    INTEGER(BOX64_DYNAREC_PURGE_AGE, dynarec_purge_age, 1024, 10, 0x10000, 0)  \
     BOOLEAN(BOX64_NODYNAREC_DELAY, nodynarec_delay, 0, 1)                     \
     STRING(BOX64_EMULATED_LIBS, emulated_libs, 0)                             \
     INTEGER(BOX64_DYNAREC_NOARCH, dynarec_noarch, 0, 0, 2, 1)                 \


### PR DESCRIPTION
Replace the hot-counter (LFU) purge heuristic with a timestamp-based (LRU) mechanism.

The previous logic incremented a hot counter on each execution and implicitly pinned blocks after a small number of hits, preventing reclamation even when blocks were no longer used.

The new logic tracks the last execution time using a global tick counter. A dynarec block becomes purgeable when its age exceeds `BOX64_DYNAREC_PURGE_AGE`.

#### What is "tick" ?

A global counter that increments every time `AllocDynarecMap()` is called. When a block is executed, it copies the current global tick to its own tick field. This records "when" the block was last used.

#### What is "age" ?

`age = my_context->tick - dynablock->tick`

The difference between the current global tick and the block's tick. It represents how many allocations have happened since the block was last executed. A higher age means the block hasn't been used for a longer time. This shifts eviction from frequency-based to recency-based behavior.

Configuration:

 -  `BOX64_DYNAREC_PURGE=1`       Enable purging (default: 0)
 -  `BOX64_DYNAREC_PURGE_AGE=N`   Ticks before purgeable (default: 1024)


TODO : Implement auto-adjusting threshold algorithm. Currently users must manually tune `BOX64_DYNAREC_PURGE_AGE` based on their workload. An adaptive algorithm that adjusts based on memory pressure and cache hit rate would be better.



