### PR TITLE
[ARM64_DYNAREC] Refined CLFLUSH family opcodes

### DIFF
--- a/src/dynarec/arm64/arm64_emitter.h
+++ b/src/dynarec/arm64/arm64_emitter.h
@@ -401,6 +401,9 @@ int convert_bitmask(uint64_t bitmask);
 #define DSB_ST()                        EMIT(DSB_gen(0b1110))
 #define DSB_SY()                        EMIT(DSB_gen(0b1111))
 
+#define DC_gen(op1, CRm, op2, Xt)       (0b1101010100001<<19 | (op1)<<16 | 0b0111<<12 | (CRm)<<8 | (op2)<<5 | Xt)
+#define DC_CIVAC(Xt)                    EMIT(DC_gen(0b011, 0b1110, 0b001, Xt))
+
 // Break
 #define BRK_gen(imm16)                  (0b11010100<<24 | 0b001<<21 | (((imm16)&0xffff)<<5))
 #define BRK(imm16)                      EMIT(BRK_gen(imm16))

--- a/src/dynarec/arm64/dynarec_arm64_0f.c
+++ b/src/dynarec/arm64/dynarec_arm64_0f.c
@@ -2060,12 +2060,9 @@ uintptr_t dynarec64_0F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int nin
                         break;
                     case 7:
                         INST_NAME("CLFLUSH Ed");
-                        MESSAGE(LOG_DUMP, "Need Optimization (CLFLUSH)?\n");
                         addr = geted(dyn, addr, ninst, nextop, &ed, x1, &fixedaddress, NULL, 0, 0, rex, NULL, 0, 0);
-                        if(ed!=x1) {
-                            MOVx_REG(x1, ed);
-                        }
-                        CALL_(const_native_clflush, -1, 0);
+                        DC_CIVAC(ed);
+                        SMDMB();
                         break;
                     default:
                         DEFAULT;

--- a/src/dynarec/arm64/dynarec_arm64_660f.c
+++ b/src/dynarec/arm64/dynarec_arm64_660f.c
@@ -2512,21 +2512,13 @@ uintptr_t dynarec64_660F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
                 switch((nextop>>3)&7) {
                     case 6:
                         INST_NAME("CLWB Ed");
-                        MESSAGE(LOG_DUMP, "Need Optimization (CLWB)?\n");
                         addr = geted(dyn, addr, ninst, nextop, &ed, x1, &fixedaddress, NULL, 0, 0, rex, NULL, 0, 0);
-                        if(ed!=x1) {
-                            MOVx_REG(x1, ed);
-                        }
-                        CALL_(const_native_clflush, -1, 0);
+                        DC_CIVAC(ed);
                         break;
                     case 7:
                         INST_NAME("CLFLUSHOPT Ed");
-                        MESSAGE(LOG_DUMP, "Need Optimization (CLFLUSHOPT)?\n");
                         addr = geted(dyn, addr, ninst, nextop, &ed, x1, &fixedaddress, NULL, 0, 0, rex, NULL, 0, 0);
-                        if(ed!=x1) {
-                            MOVx_REG(x1, ed);
-                        }
-                        CALL_(const_native_clflush, -1, 0);
+                        DC_CIVAC(ed);
                         break;
                     default:
                         DEFAULT;

--- a/src/dynarec/arm64/dynarec_arm64_consts.c
+++ b/src/dynarec/arm64/dynarec_arm64_consts.c
@@ -53,7 +53,6 @@ uintptr_t getConst(arm64_consts_t which)
         case const_native_int3: return (uintptr_t)native_int3;
         case const_native_int: return (uintptr_t)native_int;
         case const_native_div0: return (uintptr_t)native_div0;
-        case const_native_clflush: return (uintptr_t)native_clflush;
         case const_native_frstor16: return (uintptr_t)native_frstor16;
         case const_native_fsave16: return (uintptr_t)native_fsave16;
         case const_native_fsave: return (uintptr_t)native_fsave;

--- a/src/dynarec/arm64/dynarec_arm64_consts.h
+++ b/src/dynarec/arm64/dynarec_arm64_consts.h
@@ -17,7 +17,6 @@ typedef enum arm64_consts_s {
     const_native_int3,
     const_native_int,
     const_native_div0,
-    const_native_clflush,
     const_native_frstor16,
     const_native_fsave16,
     const_native_fsave,

--- a/src/tools/env.c
+++ b/src/tools/env.c
@@ -835,7 +835,7 @@ done:
 #define HEADER_SIGN "DynaCache"
 #define SET_VERSION(MAJ, MIN, REV) (((MAJ)<<24)|((MIN)<<16)|(REV))
 #ifdef ARM64
-#define ARCH_VERSION SET_VERSION(0, 0, 9)
+#define ARCH_VERSION SET_VERSION(0, 0, 10)
 #elif defined(RV64)
 #define ARCH_VERSION SET_VERSION(0, 0, 3)
 #elif defined(LA64)


### PR DESCRIPTION
CLFLUSH/CLFLUSHOPT/CLWB are not used to clear icache, so we don't need to clear corresponding dynablocks, but we do need to flush dcache.