### PR TITLE
[DYNAREC] Fixed uninitlized lock flag for 16-bit opcodes

### DIFF
--- a/src/dynarec/arm64/dynarec_arm64_helper.c
+++ b/src/dynarec/arm64/dynarec_arm64_helper.c
@@ -31,15 +31,14 @@ uintptr_t geted(dynarec_arm_t* dyn, uintptr_t addr, int ninst, uint8_t nextop, u
     if (l == LOCK_LOCK) {
         dyn->insts[ninst].lock = 1;
     }
+    int lock = l?((l==LOCK_LOCK)?1:2):0;
+    if(lock==2) *l = 0;
 
     if(rex.is32bits && rex.is67)
         return geted16(dyn, addr, ninst, nextop, ed, hint, fixaddress, unscaled, absmax, mask, rex, s);
 
-    int lock = l?((l==LOCK_LOCK)?1:2):0;
     if(unscaled)
         *unscaled = 0;
-    if(lock==2)
-        *l = 0;
     uint8_t ret = x2;
     uint8_t scratch = x2;
     *fixaddress = 0;

--- a/src/dynarec/la64/dynarec_la64_helper.c
+++ b/src/dynarec/la64/dynarec_la64_helper.c
@@ -38,12 +38,12 @@ uintptr_t geted(dynarec_la64_t* dyn, uintptr_t addr, int ninst, uint8_t nextop, 
         dyn->insts[ninst].lock = 1;
     }
 
+    int lock = l ? ((l == LOCK_LOCK) ? 1 : 2) : 0;
+    if (lock == 2) *l = 0;
+
     if (rex.is32bits && rex.is67)
         return geted16(dyn, addr, ninst, nextop, ed, hint, scratch, fixaddress, rex, i12);
 
-    int lock = l ? ((l == LOCK_LOCK) ? 1 : 2) : 0;
-    if (lock == 2)
-        *l = 0;
     uint8_t ret = x2;
     *fixaddress = 0;
     if (hint > 0) ret = hint;


### PR DESCRIPTION
This is a regresion introduced by the prefix refactor, so RV64 DynaRec should be good.