### PR TITLE
[Box32] Check allocation end address

### DIFF
--- a/src/custommem.c
+++ b/src/custommem.c
@@ -659,9 +659,9 @@ void* map128_customMalloc(size_t size, int is32bits)
     uint8_t* map = p_blocks[i].first;
     for(int idx=(allocsize-mapsize)>>7;  idx<(allocsize>>7); ++idx)
         map[idx>>3] |= (1<<(idx&7));
-    // 32bits check
-    if(is32bits && p>(void*)0xffffffffLL) {
-        printf_log(LOG_INFO, "Warning: failed to allocate 0x%x (0x%x) bytes in 32bits address space (block %d)\n", size, allocsize, i);
+    // 32bits check - ensure entire allocation fits in 32-bit space
+    if(is32bits && ((uintptr_t)p + allocsize > 0x100000000ULL)) {
+        printf_log(LOG_INFO, "Warning: failed to allocate 0x%x (0x%x) bytes in 32bits address space (block %d, addr %p)\n", size, allocsize, i, p);
         // failed to allocate memory
         if(BOX64ENV(showbt) || BOX64ENV(showsegv)) {
             // mask size from this block
@@ -931,8 +931,9 @@ void* internal_customMalloc(size_t size, int is32bits)
     blockmark_t* n = NEXT_BLOCK(m);
     n->next.x32 = 0;
     n->prev.x32 = m->next.x32;
-    if(is32bits && p>(void*)0xffffffffLL) {
-        printf_log(LOG_INFO, "Warning: failed to allocate 0x%x (0x%x) bytes in 32bits address space (block %d)\n", size, allocsize, i);
+    // 32bits check - ensure entire allocation fits in 32-bit space
+    if(is32bits && ((uintptr_t)p + allocsize > 0x100000000ULL)) {
+        printf_log(LOG_INFO, "Warning: failed to allocate 0x%x (0x%x) bytes in 32bits address space (block %d, addr %p)\n", size, allocsize, i, p);
         // failed to allocate memory
         if(BOX64ENV(showbt) || BOX64ENV(showsegv)) {
             // mask size from this block
@@ -1222,8 +1223,9 @@ void* internal_customMemAligned(size_t align, size_t size, int is32bits)
     p_blocks[i].block = p;
     p_blocks[i].first = p;
     p_blocks[i].size = allocsize;
-    if(is32bits && p>(void*)0xffffffffLL) {
-        printf_log(LOG_INFO, "Warning: failed to allocate aligned 0x%x (0x%x) bytes in 32bits address space (block %d)\n", size, allocsize, i);
+    // 32bits check - ensure entire allocation fits in 32-bit space
+    if(is32bits && ((uintptr_t)p + allocsize > 0x100000000ULL)) {
+        printf_log(LOG_INFO, "Warning: failed to allocate aligned 0x%x (0x%x) bytes in 32bits address space (block %d, addr %p)\n", size, allocsize, i, p);
         // failed to allocate memory
         if(BOX64ENV(showbt) || BOX64ENV(showsegv)) {
             // mask size from this block


### PR DESCRIPTION
The box32_malloc/calloc/realloc/memalign functions were only checking if the returned pointer was below 4GB (ptr < 0x100000000), but not whether the entire allocation fits within 32-bit address space.

This caused a segfault when malloc returned an address like 0xFFFEA010 for a 0x20010 byte allocation - the start address passes the check, but ptr + size = 0x1000A020 exceeds 4GB. When 32-bit code accesses elements near the end of the array, the address calculation wraps around due to 32-bit arithmetic truncation, resulting in NULL pointer access.

Example crash scenario:
    - malloc(0x20010) returns 0xFFFEA010
    - Old check: 0xFFFEA010 < 0x100000000 ✓ (accepted)
    - Access bitmap[0x57FA]: 0xFFFEA018 + 0x15FE8 = 0x100000000
    - 32-bit truncation: 0x100000000 → 0x00000000
    - SEGFAULT at NULL

Fix:
    - mallochook.c: Add FITS_IN_32BIT(ptr, size) macro that checks (ptr + size) <= 0x100000000, apply to all box32_* functions
    - custommem.c: Fix three occurrences of the same bug in internal_customMalloc and customMemAligned32 functions

This bug was exposed when running 32-bit x86 NBench compiled with -m32 -mno-sse flags under box32 on RV64, where memory layout caused large allocations to land near the top of 32-bit address space.

close #2710