### PR TITLE
[ENV] Fixed race condition of init/uninit of rolling logs

### DIFF
--- a/src/box64context.c
+++ b/src/box64context.c
@@ -135,20 +135,25 @@ static void atfork_child_box64context(void)
     init_mutexes(my_context);
 }
 
+int box64_cycle_log_initialized = 0;
+
 void freeCycleLog(box64context_t* ctx)
 {
-    if(BOX64ENV(rolling_log)) {
+    if (BOX64ENV(rolling_log) && box64_cycle_log_initialized) {
         box_free(ctx->log_call);
         box_free(ctx->log_ret);
         ctx->log_call = NULL;
         ctx->log_ret = NULL;
+        box64_cycle_log_initialized = 0;
     }
 }
+
 void initCycleLog(box64context_t* context)
 {
     if(context && BOX64ENV(rolling_log)) {
         context->log_call = (char*)box_calloc(BOX64ENV(rolling_log), 256*sizeof(char));
         context->log_ret = (char*)box_calloc(BOX64ENV(rolling_log), 128*sizeof(char));
+        box64_cycle_log_initialized = 1;
     }
 }
 

--- a/src/tools/env.c
+++ b/src/tools/env.c
@@ -144,6 +144,8 @@ static void parseRange(const char* s, uintptr_t* start, uintptr_t* end)
 void AddNewLibs(const char* list);
 int canNCpuBeChanged();
 
+extern int box64_cycle_log_initialized;
+
 static void applyCustomRules()
 {
     if (BOX64ENV(log) == LOG_NEVER) {
@@ -152,8 +154,7 @@ static void applyCustomRules()
     }
 
 #ifndef _WIN32
-    if(box64env.is_cycle_log_overridden) {
-        freeCycleLog(my_context);
+    if (box64env.is_cycle_log_overridden) {
         box64env.rolling_log = BOX64ENV(cycle_log);
 
         if (BOX64ENV(rolling_log) == 1) {
@@ -162,7 +163,7 @@ static void applyCustomRules()
         if (BOX64ENV(rolling_log) && BOX64ENV(log) > LOG_INFO) {
             box64env.rolling_log = 0;
         }
-        initCycleLog(my_context);
+        if (!box64_cycle_log_initialized) initCycleLog(my_context);
     }
 
     if (box64env.is_dynarec_gdbjit_str_overridden) {


### PR DESCRIPTION
I had issues using this feature to trace wps office