### PR TITLE
Fix a lot of GCC warnings

### DIFF
--- a/src/elfs/elfload_dump32.c
+++ b/src/elfs/elfload_dump32.c
@@ -251,9 +251,9 @@ void DumpSymTab32(elfheader_t *h)
 {
     if (BOX64ENV(dump) && h->SymTab._32) {
         const char* name = ElfName(h);
-        printf_dump(LOG_NEVER, "ELF Dump SymTab(%d)=\n", h->numSymTab);
-        for (int i=0; i<h->numSymTab; ++i)
-            printf_dump(LOG_NEVER, "  %s:SymTab[%d] = \"%s\", value=%p, size=%d, info/other=%d/%d index=%d\n", name, 
+        printf_dump(LOG_NEVER, "ELF Dump SymTab(%zu)=\n", h->numSymTab);
+        for (size_t i=0; i<h->numSymTab; ++i)
+            printf_dump(LOG_NEVER, "  %s:SymTab[%zu] = \"%s\", value=%p, size=%d, info/other=%d/%d index=%d\n", name, 
                 i, h->StrTab+h->SymTab._32[i].st_name, from_ptrv(h->SymTab._32[i].st_value), h->SymTab._32[i].st_size,
                 h->SymTab._32[i].st_info, h->SymTab._32[i].st_other, h->SymTab._32[i].st_shndx);
         printf_dump(LOG_NEVER, "ELF Dump SymTab=====\n");
@@ -264,7 +264,7 @@ void DumpDynamicSections32(elfheader_t *h)
 {
     if (BOX64ENV(dump) && h->Dynamic._32) {
         printf_dump(LOG_NEVER, "ELF Dump Dynamic(%d)=\n", h->numDynamic);
-        for (int i=0; i<h->numDynamic; ++i)
+        for (size_t i=0; i<h->numDynamic; ++i)
             printf_dump(LOG_NEVER, "  Dynamic %04d : %s\n", i, DumpDynamic(h->Dynamic._32+i));
         printf_dump(LOG_NEVER, "ELF Dump Dynamic=====\n");
     }
@@ -274,10 +274,10 @@ void DumpDynSym32(elfheader_t *h)
 {
     if (BOX64ENV(dump) && h->DynSym._32) {
         const char* name = ElfName(h);
-        printf_dump(LOG_NEVER, "ELF Dump DynSym(%d)=\n", h->numDynSym);
-        for (int i=0; i<h->numDynSym; ++i) {
+        printf_dump(LOG_NEVER, "ELF Dump DynSym(%zu)=\n", h->numDynSym);
+        for (size_t i=0; i<h->numDynSym; ++i) {
             int version = h->VerSym?((Elf32_Half*)((uintptr_t)h->VerSym+h->delta))[i]:-1;
-            printf_dump(LOG_NEVER, "  %s:DynSym[%d] = %s\n", name, i, DumpSym(h, h->DynSym._32+i, version));
+            printf_dump(LOG_NEVER, "  %s:DynSym[%zu] = %s\n", name, i, DumpSym(h, h->DynSym._32+i, version));
         }
         printf_dump(LOG_NEVER, "ELF Dump DynSym=====\n");
     }
@@ -287,7 +287,7 @@ void DumpDynamicNeeded32(elfheader_t *h)
 {
     if (BOX64ENV(dump) && h->DynStrTab) {
         printf_dump(LOG_NEVER, "ELF Dump DT_NEEDED=====\n");
-        for (int i=0; i<h->numDynamic; ++i)
+        for (size_t i=0; i<h->numDynamic; ++i)
             if(h->Dynamic._32[i].d_tag==DT_NEEDED) {
                 printf_dump(LOG_NEVER, "  Needed : %s\n", h->DynStrTab+h->Dynamic._32[i].d_un.d_val + h->delta);
             }
@@ -299,7 +299,7 @@ void DumpDynamicRPath32(elfheader_t *h)
 {
     if (BOX64ENV(dump) && h->DynStrTab) {
         printf_dump(LOG_NEVER, "ELF Dump DT_RPATH/DT_RUNPATH=====\n");
-        for (int i=0; i<h->numDynamic; ++i) {
+        for (size_t i=0; i<h->numDynamic; ++i) {
             if(h->Dynamic._32[i].d_tag==DT_RPATH) {
                 printf_dump(LOG_NEVER, "   RPATH : %s\n", h->DynStrTab+h->Dynamic._32[i].d_un.d_val + h->delta);
             }
@@ -349,4 +349,3 @@ void DumpRelRTable32(elfheader_t *h, int cnt, Elf32_Relr *relr, const char* name
         printf_dump(LOG_NEVER, "ELF Dump %s Table=====\n", name);
     }
 }
-

--- a/src/elfs/elfparser32.c
+++ b/src/elfs/elfparser32.c
@@ -189,7 +189,7 @@ elfheader_t* ParseElfHeader32(FILE* f, const char* name, int exec)
         // grab DT_REL & DT_RELA stuffs
         // also grab the DT_STRTAB string table
         {
-            for (int i=0; i<h->numDynamic; ++i) {
+            for (size_t i=0; i<h->numDynamic; ++i) {
                 Elf32_Dyn d = h->Dynamic._32[i];
                 Elf32_Word val = d.d_un.d_val;
                 Elf32_Addr ptr = d.d_un.d_ptr;

--- a/src/emu/x64int3.c
+++ b/src/emu/x64int3.c
@@ -108,7 +108,7 @@ static void concatString(char* buff, int len, void* s, const char* trail)
 {
     char tmp[len];
     if(!s) snprintf(tmp, len-1, "%p%s", s, trail);
-    else snprintf(tmp, len-1, "%p\"%s\"%s", s, s, trail);
+    else snprintf(tmp, len-1, "%p\"%s\"%s", s, (char*)s, trail);
     strncat(buff, tmp, len);
 }
 
@@ -416,6 +416,7 @@ void x64Int3(x64emu_t* emu, uintptr_t* addr)
                         uint8_t type = *(uint8_t*)(R_RAX);
                         snprintf(buff2, 64, "[type=%d]", type);
                     }
+                    break;
                     case 100: 
                         snprintf(buff2, 64, "[function: %p]", (void*)R_RIP);
                         break;

--- a/src/emu/x64run.c
+++ b/src/emu/x64run.c
@@ -1999,7 +1999,7 @@ x64emurun:
         case 0xE7:                      /* OUT XX, EAX */
             // this is a privilege opcode...
             #ifndef TEST_INTERPRETER
-            F8;
+            (void)F8;
             if(rex.is32bits && BOX64ENV(ignoreint3))
             {} else
             EmitSignal(emu, X64_SIGSEGV, (void*)R_RIP, 0xbad0);
@@ -2055,17 +2055,16 @@ x64emurun:
                         R_RSI = R_ESI;
                         R_RDI = R_EDI;
                     }
-                    #ifndef TEST_INTERPRETER
                     if(is32bits)
                         running32bits = 1;
-                    #endif
                 }
                 #endif
             } else {
                 unimp = 2;
                 goto fini;
             }
-            STEP;
+            STEP
+            break;
         case 0xEB:                      /* JMP Ib */
             tmp32s = F8S; // jump is relative
             addr += tmp32s;

--- a/src/emu/x64run0f.c
+++ b/src/emu/x64run0f.c
@@ -320,7 +320,7 @@ uintptr_t Run0F(x64emu_t *emu, rex_t rex, uintptr_t addr, int *step)
             nextop = F8;
             #ifndef TEST_INTERPRETER
             tmp8u = (rex.r*8)+(nextop>>3&7);
-            if((((opcode==20) || (opcode==22)) && ((tmp8u==1) || (tmp8u==5) || (tmp8u==6) || (tmp8u==7) || (tmp8u>8))) || (((opcode==0x21) || (opcode==0x23) && rex.r))) {
+            if((((opcode==20) || (opcode==22)) && ((tmp8u==1) || (tmp8u==5) || (tmp8u==6) || (tmp8u==7) || (tmp8u>8))) || (((opcode==0x21) || (opcode==0x23)) && rex.r)) {
                 EmitSignal(emu, X64_SIGILL, (void*)R_RIP, 0);
             } else
                 EmitSignal(emu, X64_SIGSEGV, (void*)R_RIP, 0);

--- a/src/emu/x64syscall.c
+++ b/src/emu/x64syscall.c
@@ -512,7 +512,7 @@ void EXPORT x64Syscall_linux(x64emu_t *emu)
                 break;
             case 4: S_RAX = syscall(sc, R_RDI, R_RSI, R_RDX, R_R10); break;
             case 5: 
-                if(s==165) {if(log) snprintf(buff2, 127, " [sys_mount(%s, %s, %s, 0x%x, %s]", (char*)R_RDI, (char*)R_RSI, (char*)R_RDX, R_R10, R_R8?(char*)R_R8:"(nil)");}; 
+                if(s==165) {if(log) snprintf(buff2, 127, " [sys_mount(%s, %s, %s, 0x%lx, %s]", (char*)R_RDI, (char*)R_RSI, (char*)R_RDX, R_R10, R_R8?(char*)R_R8:"(nil)");}; 
                 S_RAX = syscall(sc, R_RDI, R_RSI, R_RDX, R_R10, R_R8); 
                 break;
             case 6: S_RAX = syscall(sc, R_RDI, R_RSI, R_RDX, R_R10, R_R8, R_R9); break;

--- a/src/emu/x86int3.c
+++ b/src/emu/x86int3.c
@@ -150,8 +150,8 @@ void x86Int3(x64emu_t* emu, uintptr_t* addr)
                     char tmp[50];
                     char tmp2[50] = {0};
                     uint32_t n = from_ptri(uint32_t, R_ESP+8);
-                    for(int ii=0; ii<n; ++ii) {
-                        snprintf(tmp, 49, "%s%d/0x%hx", ii?" ,":"", ((int*)pu32)[ii*2], ((uint16_t*)pu32)[ii*4+2]);
+                    for(uint32_t ii=0; ii<n; ++ii) {
+                        snprintf(tmp, 49, "%s%d/0x%hx", ii?", ":"", ((int*)pu32)[ii*2], ((uint16_t*)pu32)[ii*4+2]);
                         strncat(tmp2, tmp, 49);
                     }
                     snprintf(buff, 255, "%04d|%p: Calling %s(%p[%s], %u, %d)", tid, from_ptriv(R_ESP), (char *)s, from_ptrv(R_ESP+4), tmp2, from_ptri(uint32_t, R_ESP+8), from_ptri(int, R_ESP+12));
@@ -197,7 +197,7 @@ void x86Int3(x64emu_t* emu, uintptr_t* addr)
                     perr = 1;
                 } else  if(strstr(s, "sem_timedwait")==s) {
                     pu32 = (uint32_t*)from_ptr(*(ptr_t*)from_ptr(R_ESP+8));
-                    snprintf(buff, 255, "%04d|%p: Calling %s(%p, %p[%d sec %d ns])", tid, from_ptriv(R_ESP), (char *)s, (char *)from_ptriv(R_ESP+4), (char *)from_ptriv(R_ESP+8), pu32?pu32[0]:-1, pu32?pu32[1]:-1);
+                    snprintf(buff, 255, "%04d|%p: Calling %s(%p, %p[%d sec %d ns])", tid, from_ptriv(R_ESP), (char *)s, (char *)from_ptriv(R_ESP+4), (char *)from_ptriv(R_ESP+8), pu32?pu32[0]:-1u, pu32?pu32[1]:-1u);
                     perr = 1;
                 } else  if(strstr(s, "waitpid")==s) {
                     snprintf(buff, 255, "%04d|%p: Calling %s(%d, %p, 0x%x)", tid, from_ptriv(R_ESP), (char *)s, from_ptri(int32_t, R_ESP+4), from_ptriv(R_ESP+8), from_ptri(uint32_t, R_ESP+12));
@@ -267,11 +267,11 @@ void x86Int3(x64emu_t* emu, uintptr_t* addr)
                     pu32 = (uint32_t*)from_ptr(*(ptr_t*)from_ptr(R_ESP+4));
                     post = 3;
                 } else  if(strstr(s, "__snprintf_chk")==s) {
-                    snprintf(buff, 255, "%04d|%p: Calling %s(%p, %zu, %d, %d, \"%s\", %p)", tid, from_ptriv(R_ESP), (char *)s, from_ptriv(R_ESP+4), from_ptri(long_t, R_ESP+8), *(int*)from_ptr(R_ESP+12), *(int*)from_ptr(R_ESP+16), (char*)from_ptriv(R_ESP+20), *(void**)from_ptr(R_ESP+24));
+                    snprintf(buff, 255, "%04d|%p: Calling %s(%p, %zu, %d, %d, \"%s\", %p)", tid, from_ptriv(R_ESP), (char *)s, from_ptriv(R_ESP+4), (size_t)from_ptri(long_t, R_ESP+8), *(int*)from_ptr(R_ESP+12), *(int*)from_ptr(R_ESP+16), (char*)from_ptriv(R_ESP+20), *(void**)from_ptr(R_ESP+24));
                     pu32 = (uint32_t*)from_ptr(*(ptr_t*)from_ptr(R_ESP+4));
                     post = 3;
                 } else  if(strstr(s, "snprintf")==s) {
-                    snprintf(buff, 255, "%04d|%p: Calling %s(%p, %zu, \"%s\", ...)", tid, from_ptriv(R_ESP), (char *)s, from_ptriv(R_ESP+4), from_ptri(long_t, R_ESP+8), (char*)from_ptriv(R_ESP+12));
+                    snprintf(buff, 255, "%04d|%p: Calling %s(%p, %zu, \"%s\", ...)", tid, from_ptriv(R_ESP), (char *)s, from_ptriv(R_ESP+4), (size_t)from_ptri(long_t, R_ESP+8), (char*)from_ptriv(R_ESP+12));
                     pu32 = (uint32_t*)from_ptr(*(ptr_t*)from_ptr(R_ESP+4));
                     post = 3;
                 } else  if(strstr(s, "sprintf")==s) {
@@ -405,7 +405,7 @@ void x86Int3(x64emu_t* emu, uintptr_t* addr)
                     perr = 4;
                 } else if (!strcmp(s, "nanosleep")) {
                     pu32 = (uint32_t*)from_ptrv(*(uint32_t*)from_ptrv(R_ESP+4));
-                    snprintf(buff, 256, "%04d|%p: Calling %s(%p[%d, %d], %p)", tid, from_ptriv(R_ESP), (char *)s, (void*)from_ptriv(R_ESP+4), pu32?pu32[0]:0, pu32?pu32[1]:0, (void*)from_ptriv(R_ESP+8));
+                    snprintf(buff, 256, "%04d|%p: Calling %s(%p[%d, %d], %p)", tid, from_ptriv(R_ESP), (char *)s, (void*)from_ptriv(R_ESP+4), pu32?pu32[0]:0u, pu32?pu32[1]:0u, (void*)from_ptriv(R_ESP+8));
                 } else {
                     snprintf(buff, 255, "%04d|%p: Calling %s (%08X, %08X, %08X...)", tid, from_ptriv(R_ESP), (char *)s, from_ptri(uint32_t, R_ESP+4), from_ptri(uint32_t, R_ESP+8), from_ptri(uint32_t, R_ESP+12));
                 }
@@ -417,7 +417,7 @@ void x86Int3(x64emu_t* emu, uintptr_t* addr)
                 w(emu, a);   // some function never come back, so unlock the mutex first!
                 if(post)
                     switch(post) {
-                    case 1: snprintf(buff2, 63, " [%d sec %d nsec]", pu32?pu32[0]:-1, pu32?pu32[1]:-1);
+                    case 1: snprintf(buff2, 63, " [%d sec %d nsec]", pu32?pu32[0]:-1u, pu32?pu32[1]:-1u);
                             break;
                     case 2: snprintf(buff2, 63, "(%s)", R_EAX?((char*)from_ptr(R_EAX)):"nil");
                             break;
@@ -447,19 +447,20 @@ void x86Int3(x64emu_t* emu, uintptr_t* addr)
                                 default:
                                     snprintf(buff2, 63, " [type=%hhd]", *pu8); 
                             }
-                            break;
+                    break;
                     case 11: snprintf(buff2, 63, " [%d / %d / %d /%d]", pu32[0], pu32[1], pu32[2], pu32[3]);
                             break;
                     case 12: if(R_EAX>0) {
                         char tmp[50];
                         char tmp2[50] = {0};
                         uint32_t n = from_ptri(uint32_t, R_ESP+8);
-                        for(int ii=0; ii<n; ++ii) {
-                            snprintf(tmp, 49, "%s%d/0x%hx", ii?" ,":"", pu32[ii*2], pu32[ii*2+1]>>16);
+                        for(uint32_t ii=0; ii<n; ++ii) {
+                            snprintf(tmp, 49, "%s%d/0x%hx", ii?", ":"", pu32[ii*2], pu32[ii*2+1]>>16);
                             strncat(tmp2, tmp, 49);
                         }
                         snprintf(buff2, 63, "[%s]", tmp2);
                     }
+                    break;
                     case 13: if(R_EAX==0x25E)
                                 snprintf(buff2, 63, "%s", "here");
                             break;

--- a/src/emu/x86syscall_32.c
+++ b/src/emu/x86syscall_32.c
@@ -269,7 +269,7 @@ typedef struct native_linux_dirent {
 } native_linux_dirent_t;
 
 int32_t my_open(x64emu_t* emu, void* pathname, int32_t flags, uint32_t mode);
-int32_t my32_execve(x64emu_t* emu, const char* path, char* const argv[], char* const envp[]);
+int32_t my32_execve(x64emu_t* emu, const char* path, ptr_t argv[], ptr_t envp[]);
 ssize_t my32_read(int fd, void* buf, size_t count);
 void* my32_mmap64(x64emu_t* emu, void *addr, size_t length, int prot, int flags, int fd, int64_t offset);
 int my32_munmap(x64emu_t* emu, void* addr, unsigned long length);

--- a/src/include/myalign32.h
+++ b/src/include/myalign32.h
@@ -79,7 +79,6 @@ typedef struct  va_list {
 void myStackAlign32(const char* fmt, uint32_t* st, uint64_t* mystack);
 size_t myStackAlignScanf32(const char* fmt, uint32_t* st, uint64_t* mystack, size_t nb_elem); // return the number of long/ptr_t conversion pending
 void myStackAlignScanf32_final(const char* fmt, uint32_t* st, uint64_t* mystack, size_t nb_elem, int n); // convert the long/ptr_t scanf results
-void myStackAlignGVariantNew32(const char* fmt, uint32_t* st, uint64_t* mystack);
 size_t myStackAlignScanfW32(const char* fmt, uint32_t* st, uint64_t* mystack, size_t nb_elem);
 void myStackAlignScanfW32_final(const char* fmt, uint32_t* st, uint64_t* mystack, size_t nb_elem, int n);
 void myStackAlignW32(const char* fmt, uint32_t* st, uint64_t* mystack);

--- a/src/librarian/globalsymbols32.c
+++ b/src/librarian/globalsymbols32.c
@@ -49,7 +49,7 @@ extern void* UP;
 extern void* BC;
 extern uint8_t PC;
 extern uint16_t ospeed;
-extern void* ttytype;
+extern void* ttytype[32];
 
 void my32_checkGlobalTInfo()
 {

--- a/src/libtools/decopcode.c
+++ b/src/libtools/decopcode.c
@@ -88,6 +88,7 @@ int decode_0f(uint8_t* addr, int idx, rex_t rex)
         case 0xC0:
         case 0xC1:
         case 0xC7:
+            nextop = addr[idx++];
             return (MODREG)?0:(OPCODE_READ|OPCODE_WRITE);
         case 0xA0:
         case 0xA8:

--- a/src/libtools/libc_net32.c
+++ b/src/libtools/libc_net32.c
@@ -411,6 +411,7 @@ EXPORT int my32_getifaddrs(x64emu_t* emu, void** res)
             p = next;
         }
     }
+    return ret;
 }
 
 EXPORT void* my32___h_errno_location(x64emu_t* emu)

--- a/src/libtools/my_x11_xevent.c
+++ b/src/libtools/my_x11_xevent.c
@@ -263,9 +263,9 @@ void convertXEvent(my_XEvent_32_t* dst, my_XEvent_t* src)
         default: {
             register_events_t* head = register_events_head;
             while(head) {
-                if(type>=head->start_event && type<=head->end_event) {
-                    for(int i=0; i<head->n; ++i)
-                        if(type==head->events[i].event) {
+                if((uint32_t)type>=head->start_event && (uint32_t)type<=head->end_event) {
+                    for(size_t i=0; i<head->n; ++i)
+                        if((uint32_t)type==head->events[i].event) {
                             head->events[i].to32(dst, src);
                             return;
                         }
@@ -500,9 +500,9 @@ void unconvertXEvent(my_XEvent_t* dst, my_XEvent_32_t* src)
         default: {
             register_events_t* head = register_events_head;
             while(head) {
-                if(type>=head->start_event && type<=head->end_event) {
-                    for(int i=0; i<head->n; ++i)
-                        if(type==head->events[i].event) {
+                if((uint32_t)type>=head->start_event && (uint32_t)type<=head->end_event) {
+                    for(size_t i=0; i<head->n; ++i)
+                        if((uint32_t)type==head->events[i].event) {
                             head->events[i].to64(dst, src);
                             return;
                         }

--- a/src/libtools/myalignxcb32.c
+++ b/src/libtools/myalignxcb32.c
@@ -188,13 +188,13 @@ void* add_xcb_connection32(void* src)
             unalign_xcb_connection32(src, &i386_xcb_connects[i]);
             return &i386_xcb_connects[i];
         }
-        // find a free slot
-        for(int i=0; i<NXCB; ++i)
-            if(!my_xcb_connects[i]) {
-                my_xcb_connects[i] = src;
-                unalign_xcb_connection32(src, &i386_xcb_connects[i]);
-                return &i386_xcb_connects[i];
-            }
+    // find a free slot
+    for(int i=0; i<NXCB; ++i)
+        if(!my_xcb_connects[i]) {
+            my_xcb_connects[i] = src;
+            unalign_xcb_connection32(src, &i386_xcb_connects[i]);
+            return &i386_xcb_connects[i];
+        }
     printf_log(LOG_NONE, "Error, no more free xcb_connect 32bits slot for %p\n", src);
     return src;
 }

--- a/src/libtools/sdl1align32.c
+++ b/src/libtools/sdl1align32.c
@@ -161,12 +161,13 @@ void convert_SDL_Event_to_32(void* dst_, const void* src_)
             dst->user.code = src->user.code;
             dst->user.data1 = to_ptrv(src->user.data1);
             dst->user.data2 = to_ptrv(src->user.data2);
+            break;
         case SDL_SYSWMEVENT:
             printf_log(LOG_NONE, "TODO: Convert SDL_SYSWMEVENT\n");
             abort();
             break;
         default:
-            printf_log(LOG_INFO, "Warning, unsuported SDL1.2 event %d\n", src->type);
+            printf_log(LOG_INFO, "Warning, unsupported SDL1.2 event %d\n", src->type);
             memcpy(dst, src, sizeof(my_SDL_Event_32_t));
     }
 }
@@ -239,12 +240,13 @@ void convert_SDL_Event_to_64(void* dst_, const void* src_)
             dst->user.code = src->user.code;
             dst->user.data1 = from_ptrv(src->user.data1);
             dst->user.data2 = from_ptrv(src->user.data2);
+            break;
         case SDL_SYSWMEVENT:
             printf_log(LOG_NONE, "TODO: Convert SDL_SYSWMEVENT\n");
             abort();
             break;
         default:
-            printf_log(LOG_INFO, "Warning, unsuported SDL1.2 (un)event %d\n", src->type);
+            printf_log(LOG_INFO, "Warning, unsupported SDL1.2 (un)event %d\n", src->type);
             memcpy(dst, src, sizeof(my_SDL_Event_32_t));
     }
 }

--- a/src/libtools/signals.c
+++ b/src/libtools/signals.c
@@ -1490,7 +1490,7 @@ void my_box64signalhandler(int32_t sig, siginfo_t* info, void * ucntx)
     int db_searched = 0;
     uintptr_t x64pc = (uintptr_t)-1;
     x64pc = R_RIP;
-    if(((sig==X64_SIGBUS) && ((addr!=pc) || ((sig==X64_SIGSEGV)) && emu->segs[_CS]==0x23 && ((uintptr_t)addr>>32)==0xffffffff))
+    if(((sig==X64_SIGBUS) && ((addr!=pc) || ((sig==X64_SIGSEGV) && emu->segs[_CS]==0x23 && ((uintptr_t)addr>>32)==0xffffffff)))
 #ifdef RV64
     || ((sig==X64_SIGSEGV) && (addr==pc) && (info->si_code==2) && (!checkMutex(is_memprot_locked) && getProtection_fast((uintptr_t)addr)==(PROT_READ|PROT_WRITE|PROT_EXEC)))
 #endif
@@ -1967,7 +1967,7 @@ dynarec_log(/*LOG_DEBUG*/LOG_INFO, "%04d|Repeated SIGSEGV with Access error on %
                     printf_log_prefix(0, log_minimum, "(%s)\n", DecodeX64Trace(dec, x64pc, 1));
                 else
                     printf_log_prefix(0, log_minimum, "(%02X %02X %02X %02X %02X)\n", ((uint8_t*)x64pc)[0], ((uint8_t*)x64pc)[1], ((uint8_t*)x64pc)[2], ((uint8_t*)x64pc)[3], ((uint8_t*)x64pc)[4]);
-            } else if(sig==X64_SIGBUS || (sig==X64_SIGSEGV && (x64pc!=(uintptr_t)addr) && (pc!=addr)) && (getProtection_fast(x64pc)&PROT_READ) && (getProtection_fast((uintptr_t)pc)&PROT_READ)) {
+            } else if(sig==X64_SIGBUS || (sig==X64_SIGSEGV && (x64pc!=(uintptr_t)addr) && (pc!=addr) && (getProtection_fast(x64pc)&PROT_READ) && (getProtection_fast((uintptr_t)pc)&PROT_READ))) {
                 if (dec)
                     printf_log_prefix(0, log_minimum, " %sopcode=%s; native opcode=%08x\n", (emu->segs[_CS] == 0x23) ? "x86" : "x64", DecodeX64Trace(dec, x64pc, 1), *(uint32_t*)pc);
                 else

--- a/src/libtools/threads.c
+++ b/src/libtools/threads.c
@@ -597,9 +597,9 @@ EXPORT int my_pthread_create(x64emu_t *emu, void* t, void* attr, void* start_rou
 		stacksize = attr_stacksize;
 		own = 0;
 	} else {
-        stack = InternalMmap(NULL, stacksize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_GROWSDOWN, -1, 0);
-        if(stack!=MAP_FAILED)
-	        setProtection_stack((uintptr_t)stack, stacksize, PROT_READ|PROT_WRITE);
+		stack = InternalMmap(NULL, stacksize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_GROWSDOWN, -1, 0);
+		if(stack!=MAP_FAILED)
+			setProtection_stack((uintptr_t)stack, stacksize, PROT_READ|PROT_WRITE);
 		own = 1;
 	}
 

--- a/src/libtools/threads32.c
+++ b/src/libtools/threads32.c
@@ -160,7 +160,7 @@ EXPORT int my32_pthread_attr_setstack(x64emu_t* emu, void* attr, void* stackaddr
 
 EXPORT int my32_pthread_create(x64emu_t *emu, void* t, void* attr, void* start_routine, void* arg)
 {
-	int stacksize = 2*1024*1024;	//default stack size is 2Mo
+	size_t stacksize = 2*1024*1024;	//default stack size is 2Mo
 	void* attr_stack;
 	size_t attr_stacksize;
 	int own;
@@ -471,7 +471,7 @@ kh_mapcond_t *mapcond = NULL;
 
 static pthread_cond_t* add_cond(void* cond)
 {
-	if(((uintptr_t)cond)&7==0)
+	if((((uintptr_t)cond)&7)==0)
 		return cond;
 	mutex_lock(&my_context->mutex_thread);
 	khint_t k;
@@ -488,7 +488,7 @@ static pthread_cond_t* add_cond(void* cond)
 }
 static pthread_cond_t* get_cond(void* cond)
 {
-	if(((uintptr_t)cond)&7==0)
+	if((((uintptr_t)cond)&7)==0)
 		return cond;
 	pthread_cond_t* ret;
 	int r;
@@ -513,7 +513,7 @@ static pthread_cond_t* get_cond(void* cond)
 }
 static void del_cond(void* cond)
 {
-	if(((uintptr_t)cond)&7==0)
+	if((((uintptr_t)cond)&7)==0)
 		return;
 	if(!mapcond)
 		return;
@@ -790,7 +790,7 @@ EXPORT int my32_pthread_attr_setstacksize(x64emu_t* emu, void* attr, size_t p)
 	GetStackSize((uintptr_t)attr, &pp, &size);
 	AddStackSize((uintptr_t)attr, pp, p);
 	// PTHREAD_STACK_MIN on x86 might be lower than the current platform...
-	if(p>=0xc000 && p<PTHREAD_STACK_MIN && !(p&4095))
+	if(p>=0xc000 && p<(size_t)PTHREAD_STACK_MIN && !(p&4095))
 		p = PTHREAD_STACK_MIN;
 	return pthread_attr_setstacksize(get_attr(attr), p);
 }
@@ -920,7 +920,7 @@ pthread_mutex_t* createNewMutex()
 	return ret;
 }
 // init = 0: just get the mutex
-// init = 1: get the mutex and init it with optione attr (attr will disallow native mutex)
+// init = 1: get the mutex and init it with optional attr (attr will disallow native mutex)
 pthread_mutex_t* getAlignedMutex(pthread_mutex_t* m)
 {
 	fake_phtread_mutex_t* fake = (fake_phtread_mutex_t*)m;
@@ -951,7 +951,7 @@ pthread_mutex_t* getAlignedMutex(pthread_mutex_t* m)
 	pthread_mutexattr_settype(&attr, fake->i386__kind);
 	pthread_mutex_init(from_ptrv(fake->real_mutex), &attr);
 	pthread_mutexattr_destroy(&attr);
-	fake->__kind==KIND_SIGN;
+	fake->__kind = KIND_SIGN;
 	printf_log(LOG_DEBUG, " (fb: m=%p) ", from_ptrv(fake->real_mutex));
 	return from_ptrv(fake->real_mutex);
 }

--- a/src/steam.c
+++ b/src/steam.c
@@ -43,7 +43,7 @@ static void create_libs_symlink(const char* folder)
     snprintf(tmp, sizeof(tmp), "%s/lib*.so.*.*.*", folder);
     if(!glob(tmp, 0, NULL, &g)) {
         printf_log(LOG_DEBUG, "Creating symlinks for %s\n", folder);
-        for(int i=0; i<g.gl_pathc; ++i) {
+        for(ulong_t i=0; i<g.gl_pathc; ++i) {
             if(FileIsX64X86ELF(g.gl_pathv[i])) {
                 create_lib_symlink(g.gl_pathv[i]);
             }
@@ -53,7 +53,7 @@ static void create_libs_symlink(const char* folder)
     // then do lib*.so.X.X
     snprintf(tmp, sizeof(tmp), "%s/lib*.so.*.*", folder);
     if(!glob(tmp, 0, NULL, &g)) {
-        for(int i=0; i<g.gl_pathc; ++i) {
+        for(ulong_t i=0; i<g.gl_pathc; ++i) {
             if(FileIsX64X86ELF(g.gl_pathv[i])) {
                 create_lib_symlink(g.gl_pathv[i]);
             }
@@ -141,7 +141,7 @@ void pressure_vessel(int argc, const char** argv, int nextarg, const char* prog)
                 snprintf(tmp, sizeof(tmp), "%svar/*/usr/bin/python3", sniper);
                 if(!glob(tmp, 0, NULL, &g)) {
                     int found = 0;
-                    for(int i=0; i<g.gl_pathc && !found; ++i) {
+                    for(ulong_t i=0; i<g.gl_pathc && !found; ++i) {
                         if(FileIsX64ELF(g.gl_pathv[i])) {
                             found = 1;
                             setenv("BOX64_PYTHON3", g.gl_pathv[i], 1);
@@ -169,7 +169,7 @@ void pressure_vessel(int argc, const char** argv, int nextarg, const char* prog)
             snprintf(tmp, sizeof(tmp), "%s/bin/python3*", sniper);
             if(!glob(tmp, 0, NULL, &g)) {
                 int found = 0;
-                for(int i=0; i<g.gl_pathc && !found; ++i) {
+                for(ulong_t i=0; i<g.gl_pathc && !found; ++i) {
                     if(FileIsX64ELF(g.gl_pathv[i])) {
                         found = 1;
                         setenv("BOX64_PYTHON3", g.gl_pathv[i], 1);

--- a/src/tools/env.c
+++ b/src/tools/env.c
@@ -328,6 +328,8 @@ static void freeEnv(box64env_t* env)
 #define ENV_ARCH "rv64"
 #elif defined(LA64)
 #define ENV_ARCH "la64"
+#elif defined(X86_64)
+#define ENV_ARCH "x86_64"
 #else
 #warning "Unknown architecture for ENV_ARCH"
 #define ENV_ARCH "unknown"

--- a/src/tools/pe_tools.c
+++ b/src/tools/pe_tools.c
@@ -251,7 +251,7 @@ void ParseVolatileMetadata(char* filename, void* addr)
         return;
     }
 
-    if (fread(buffer, 1, size, file) != size) {
+    if ((long)fread(buffer, 1, size, file) != size) {
         free(buffer);
         fclose(file);
         return;

--- a/src/wrapped32/wrappeddbus.c
+++ b/src/wrapped32/wrappeddbus.c
@@ -421,6 +421,7 @@ static void* inplace_shrink_arraystring(void* a)
     while(src[n]) ++n;
     for(int i=0; i<=n; ++i) // convert last NULL value
         dst[i] = to_ptrv(src[i]);
+    return a;
 }
 
 static void* inplace_expand_arraystring(void* a)

--- a/src/wrapped32/wrappedfontconfig.c
+++ b/src/wrapped32/wrappedfontconfig.c
@@ -215,6 +215,7 @@ EXPORT int my32_FcPatternAdd(void* p, void* object, int type, fcvalue_32_t t, in
             break;
         case 2:
             val.u.d = t.d;
+            break;
         case 1:
         case 4: // just in case
             val.u.i = t.i;
@@ -299,7 +300,7 @@ EXPORT int my32_FcFontSetAdd(x64emu_t* emu, void* set, void* pattern)
 
 EXPORT void* my32_FcConfigGetFonts(x64emu_t* emu, void* config, uint32_t name)
 {
-    inplace_FcFontSet_shrink(my->FcConfigGetFonts(config, name));   // that's probably a bad idea, as the font is own by the config
+    return inplace_FcFontSet_shrink(my->FcConfigGetFonts(config, name));   // that's probably a bad idea, as the font is own by the config
 }
 
 EXPORT void* my32_FcFontSetSort(x64emu_t* emu, void* config, ptr_t* sets, int nsets, void* pattern, int trim, ptr_t* csp, void* result)

--- a/src/wrapped32/wrappedfreetype.c
+++ b/src/wrapped32/wrappedfreetype.c
@@ -2532,7 +2532,7 @@ EXPORT int my32_FT_Get_MM_Var(x64emu_t* emu, void* face, FT_MM_Var_32_t* amaster
         amaster->axis = to_ptrv(p);
         FT_Var_Axis_32_t* axis = p;
         p += amaster_l->num_axis*sizeof(FT_Var_Axis_32_t);
-        for(int i=0; i<amaster_l->num_axis; ++i) {
+        for(uint32_t i=0; i<amaster_l->num_axis; ++i) {
             axis[i].name = to_cstring(amaster_l->axis[i].name);
             axis[i].minimum = to_long(amaster_l->axis[i].minimum);
             axis[i].def = to_long(amaster_l->axis[i].def);
@@ -2546,11 +2546,11 @@ EXPORT int my32_FT_Get_MM_Var(x64emu_t* emu, void* face, FT_MM_Var_32_t* amaster
         amaster->axis = to_ptrv(p);
         FT_Var_Named_Style_32_t* axis = p;
         p += amaster_l->num_axis*sizeof(FT_Var_Named_Style_32_t);
-        for(int i=0; i<amaster_l->num_namedstyles; ++i) {
+        for(uint32_t i=0; i<amaster_l->num_namedstyles; ++i) {
             axis[i].coords = to_ptrv(p);
             long_t* coords = p;
             p += sizeof(long_t)*amaster_l->num_axis;
-            for(int j=0; j<amaster_l->num_axis; ++j)
+            for(uint32_t j=0; j<amaster_l->num_axis; ++j)
                 coords[j] = to_long(amaster_l->namedstyle[i].coords[j]);
         }
     } else
@@ -2571,7 +2571,7 @@ EXPORT int my32_FT_Done_MM_Var(x64emu_t* emu, void* face, FT_MM_Var_32_t* amaste
 EXPORT int my32_FT_Set_Var_Design_Coordinates(x64emu_t* emu, void* face, uint32_t num_coords, long_t* coords)
 {
     long coords_l[num_coords];
-    for(int i=0; i<num_coords; ++i)
+    for(uint32_t i=0; i<num_coords; ++i)
         coords_l[i] = from_long(coords[i]);
     inplace_FT_FaceRec_enlarge(face);
     int ret = my->FT_Set_Var_Design_Coordinates(face, num_coords, coords_l);
@@ -2582,7 +2582,7 @@ EXPORT int my32_FT_Set_Var_Design_Coordinates(x64emu_t* emu, void* face, uint32_
 EXPORT int my32_FT_Set_Var_Blend_Coordinates(x64emu_t* emu, void* face, uint32_t num_coords, long_t* coords)
 {
     long coords_l[num_coords];
-    for(int i=0; i<num_coords; ++i)
+    for(uint32_t i=0; i<num_coords; ++i)
         coords_l[i] = from_long(coords[i]);
     inplace_FT_FaceRec_enlarge(face);
     int ret = my->FT_Set_Var_Blend_Coordinates(face, num_coords, coords_l);
@@ -2597,7 +2597,7 @@ EXPORT int my32_FT_Get_Var_Blend_Coordinates(x64emu_t* emu, void* face, uint32_t
     inplace_FT_FaceRec_enlarge(face);
     int ret = my->FT_Get_Var_Blend_Coordinates(face, num_coords, coords_l);
     inplace_FT_FaceRec_shrink(face);
-    for(int i=0; i<num_coords; ++i)
+    for(uint32_t i=0; i<num_coords; ++i)
         coords[i] = to_long(coords_l[i]);
     return ret;
 }
@@ -2633,7 +2633,7 @@ EXPORT int my32_FT_Get_Advances(x64emu_t* emu, void* face, uint32_t start, uint3
     inplace_FT_FaceRec_enlarge(face);
     int ret = my->FT_Get_Advances(face, start, count, flags, advances_l);
     inplace_FT_FaceRec_shrink(face);
-    for(int i=0; i<count; ++i)
+    for(uint32_t i=0; i<count; ++i)
         padvances[i] = to_long(advances_l[i]);
     return ret;
 }

--- a/src/wrapped32/wrappedlibasound.c
+++ b/src/wrapped32/wrappedlibasound.c
@@ -319,7 +319,7 @@ EXPORT int my32_snd_pcm_mmap_begin(x64emu_t* emu, void* pcm, ptr_t* areas, ulong
         last_nch = nch;
     }
     if(nch>15) {printf_log(LOG_INFO, "Warning, too many channels in pcm of 32bits alsa: %d\n", nch); nch=15; }
-    for(int i=0; i<nch; ++i) {
+    for(unsigned int i=0; i<nch; ++i) {
         my_areas[i].addr = to_ptrv(l_areas[i].addr);
         my_areas[i].first = l_areas[i].first;
         my_areas[i].step = l_areas[i].step;

--- a/src/wrapped32/wrappedlibx11.c
+++ b/src/wrapped32/wrappedlibx11.c
@@ -95,6 +95,7 @@ static int my32_rev_wire_to_event_##A(void* dpy, void* re, void* event)         
     static my_XEvent_t re_l = {0};                                                                  \
     int ret = my32_rev_wire_to_event_fct_##A (getDisplay(dpy), &re_l, event);                       \
     convertXEvent(re, &re_l);                                                                       \
+    return ret;                                                                                     \
 }
 SUPER()
 #undef GO
@@ -1945,7 +1946,7 @@ EXPORT void* my32_XGetWMHints(x64emu_t* emu, void* dpy, XID window)
     return ret;
 }
 
-EXPORT int my32_XSetWMNormalHints(x64emu_t* emu, void* dpy, XID window, void* hints)
+EXPORT void my32_XSetWMNormalHints(x64emu_t* emu, void* dpy, XID window, void* hints)
 {
     inplace_enlarge_wmsizehints(hints);
     my->XSetWMNormalHints(dpy, window, hints);
@@ -2072,6 +2073,7 @@ EXPORT int my32_XChangeProperty(x64emu_t* emu, void* dpy, XID window, XID prop, 
     int ret = my->XChangeProperty(dpy, window, prop, type, fmt, mode, data, n);
     if(tmp)
         box_free(tmp);
+    return ret;
 }
 
 EXPORT void my32_XSetWMProperties(x64emu_t* emu, void* dpy, XID window, void* window_name, void* icon_name, ptr_t* argv, int argc, void* normal_hints, my_XWMHints_32_t* wm_hints, ptr_t* class_hints)
@@ -2192,7 +2194,7 @@ EXPORT int my32_XQueryTree(x64emu_t* emu, void* dpy, XID window, XID_32* root, X
     *parent = to_ulong(parent_l);
     *children = to_ptrv(children_l);
     if(children_l)
-        for(int i=0; i<*n; ++i)
+        for(uint32_t i=0; i<*n; ++i)
             ((XID_32*)children_l)[i] = to_ulong(children_l[i]);
     return ret;
 }
@@ -2422,6 +2424,7 @@ EXPORT int my32_XFontsOfFontSet(x64emu_t* emu, my_XFontSet_32_t* set, ptr_t* fon
             set->fonts[j][i] = to_ptrv(((void**)fonts_ret_l)[i]);
         *fonts_ret = to_ptrv(set->fonts[j]);
     }
+    return ret;
 }
 
 EXPORT void* my32_XExtentsOfFontSet(x64emu_t* emu, my_XFontSet_32_t* set)
@@ -2591,7 +2594,7 @@ EXPORT int my32_XGetWindowProperty(x64emu_t* emu, void* dpy, XID window, XID pro
         // inplace shrink
         unsigned long *src = prop_l;
         ulong_t* dst = prop_l;
-        for(int i=0; i<*nitems_return; ++i)
+        for(ulong_t i=0; i<*nitems_return; ++i)
             dst[i] = to_ulong_silent(src[i]);
     }
     return ret;

--- a/src/wrapped32/wrappedlibxcursor.c
+++ b/src/wrapped32/wrappedlibxcursor.c
@@ -156,6 +156,7 @@ EXPORT unsigned long my32_XcursorImageLoadCursor(x64emu_t* emu, void* dpy, void*
 	inplace_XcursorImage_enlarge(image);
 	unsigned long ret = my->XcursorImageLoadCursor(dpy, image);
 	inplace_XcursorImage_shrink(image);
+    return ret;
 }
 
 EXPORT void* my32_XcursorImagesCreate(x64emu_t* emu, int n)
@@ -203,4 +204,3 @@ EXPORT void* my32_XcursorShapeLoadImages(x64emu_t* emu, uint32_t shape, void* th
 }
 
 #include "wrappedlib_init32.h"
-

--- a/src/wrapped32/wrappedlibxext.c
+++ b/src/wrapped32/wrappedlibxext.c
@@ -258,6 +258,7 @@ static int my32_rev_wire_to_event_##A(void* dpy, void* re, void* event)         
     static my_XEvent_t re_l = {0};                                                                  \
     int ret = my32_rev_wire_to_event_fct_##A (getDisplay(dpy), &re_l, event);                       \
     convertXEvent(re, &re_l);                                                                       \
+    return ret;                                                                                     \
 }
 SUPER()
 #undef GO

--- a/src/wrapped32/wrappedlibxi.c
+++ b/src/wrapped32/wrappedlibxi.c
@@ -139,6 +139,7 @@ EXPORT void* my32_XGetDeviceMotionEvents(x64emu_t* emu, void* dpy, void* d, unsi
             dst[*n].time = 0; dst[*n].data = 0; // mark the end
         }
     }
+    return ret;
 }
 
 EXPORT void my32_XFreeDeviceMotionEvents(x64emu_t* emu, void* l)
@@ -152,7 +153,7 @@ EXPORT void my32_XFreeDeviceMotionEvents(x64emu_t* emu, void* l)
         dst[i].data = from_ptrv(src[i].data);
         dst[i].time = from_ulong(src[i].time);
     }
-    my->XFreeDeviceMotionEvents(l);
+    return my->XFreeDeviceMotionEvents(l);
 }
 
 EXPORT int my32_XGrabDevice(x64emu_t* emu, void* dpy, void* d, XID w, int owner, int count, void* evt, int this_mode, int other_modes, unsigned long time)

--- a/src/wrapped32/wrappedmount.c
+++ b/src/wrapped32/wrappedmount.c
@@ -95,12 +95,12 @@ static my_libmnt_optmap_32_t optmap_32[N] = {0};
 my_libmnt_optmap_32_t* shrink_libmnt_optmap(void* a)
 {
     if(!a) return NULL;
-    for(int i; i<N; ++i) {
+    for(int i=0; i<N; ++i) {
         if(optmap_64[i]==a)
             return &optmap_32[i];
     }
     // look for free slot
-    for(int i; i<N; ++i)
+    for(int i=0; i<N; ++i)
         if(!optmap_64[i]) {
             optmap_64[i] = a;
             convert_libmnt_optmap_32(&optmap_32[i], a);
@@ -119,7 +119,7 @@ my_libmnt_optmap_32_t* shrink_libmnt_optmap(void* a)
 my_libmnt_optmap_t* enlarge_libmnt_optmap(void* a)
 {
     if(!a) return NULL;
-    for(int i; i<N; ++i) {
+    for(int i=0; i<N; ++i) {
         if(&optmap_32[i]==a)
             return optmap_64[i];
     }
@@ -149,4 +149,3 @@ EXPORT int my32_mnt_table_uniq_fs(void* tb, int flags, void* f)
 }
 
 #include "wrappedlib_init32.h"
-


### PR DESCRIPTION
This PR fixes a lot of warnings emitted by an x86-64 GCC build of box64. Most of those are minor ones or only on debug paths, but some are quite important (mostly for box32).