### PR TITLE
[LA64_DYNAREC] Fix IDIV Ew dividend construction

### DIFF
--- a/src/dynarec/la64/dynarec_la64_66.c
+++ b/src/dynarec/la64/dynarec_la64_66.c
@@ -1384,8 +1384,7 @@ uintptr_t dynarec64_66(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
                         MARK3;
                     }
                     BSTRPICK_D(x2, xRAX, 15, 0);
-                    SLLI_D(x3, xRDX, 16);
-                    OR(x2, x2, x3);
+                    BSTRINS_D(x2, xRDX, 31, 16);
                     DIV_W(x3, x2, ed);
                     MOD_W(x4, x2, ed);
                     BSTRINSz(xRAX, x3, 15, 0);


### PR DESCRIPTION
**Problem**

The IDIV Ew instruction in the LA64 dynarec implementation produces incorrect results due to improper dividend construction.

Running the following minimal test case (using inline asm to force IDIV Ew) returns 0 instead of the expected -10922.

Expected behavior: tf_h(-32766) should return -10922 (0xd556). Actual behavior: tf_h(-32766) returns 0 (0x0000).

**Repro Code**
```c
#include <stdio.h>

// inline asm to force IDIV Ew
__attribute__((noinline)) short tf_h(short c) {
    short q;
    __asm__ volatile (
        "movw  %[c], %%ax\n\t"
        "cwd\n\t"                // DX:AX = sign_extend(AX)
        "movw  $3, %%cx\n\t"
        "idivw %%cx\n\t"         // AX = DX:AX / CX
        "movw  %%ax, %[q]\n\t"
        : [q] "=r"(q)
        : [c] "r"(c)
        : "ax", "dx", "cx"
    );
    return q;
}

int main(void) {
    short v = (short)0x8002; // -32766
    short r = tf_h(v);
    printf("tf_h(%d) = %d (0x%04x)\n", v, r, (unsigned short)r);
    return 0;
}
```

**Repro Log (Before Fix)**
```
[BOX64] Transfert to main(1, ...)
2869102|0x40118f: Calling printf(0x402004, 0xFFFF8002, 0x0, ...) 
=> tf_h(-32766) = 0 (0x0000)
```

**Now**
```
 return 0x0[function: 0x30010020]
2870319|0x40118f: Calling printf(0x402004, 0xFFFF8002, 0xFFFFD556, ...) =>tf_h(-32766) = -10922 (0xd556)
 return 0x1F
 return 0x0
[BOX64] Emulation finished, EAX=0
[BOX64] Calling atexit registered functions (exiting box64)
[BOX64] Calling atexit registered functions
[BOX64] Calling fini for all loaded elfs and unload native libs
[BOX64] Calling atexit registered functions for elf: 0x382b2940//home/yzw/python-trans/box64-up/test/t1
[BOX64] Calling Fini[0] for /home/yzw/python-trans/box64-up/test/t1 @0x4010f0
[BOX64] Calling Fini for /home/yzw/python-trans/box64-up/test/t1 @0x401198
[BOX64] Unloaded main elf: Will Dec RefCount of 1 libs
[BOX64] 2870319|Free a X86_64 Emu (0x382b0930)
(reverse-i-search)`com': git commit -sm "[LA64_DYNAREC] Fix IDIV Ew dividend construction"
```