### PR TITLE
[LA64_DYNAREC] Fix IDIV Ew with sign-extended DX:AX

### DIFF
--- a/src/dynarec/la64/dynarec_la64_66.c
+++ b/src/dynarec/la64/dynarec_la64_66.c
@@ -1392,8 +1392,7 @@ uintptr_t dynarec64_66(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
                         MARK3;
                     }
                     BSTRPICK_D(x2, xRAX, 15, 0);
-                    BSTRINS_D(x2, xRDX, 31, 16);
-                    ADDI_W(x2, x2, 0);
+                    BSTRINS_W(x2, xRDX, 31, 16);
                     DIV_W(x3, x2, ed);
                     MOD_W(x4, x2, ed);
                     BSTRINSz(xRAX, x3, 15, 0);


### PR DESCRIPTION
**Problem**
After the previous [fix,](https://github.com/ptitSeb/box64/pull/3346) IDIV Ew still returns 0 in the minimal inline-asm test for negative inputs.

Root Cause: The DX:AX construction logic lost sign-extension. The combined dividend was interpreted as 0x00000000ffff8002 (positive large number) instead of 0xffffffffffff8002 (negative short), producing an incorrect quotient.

**Repro Case**
```c
#include <stdio.h>

// Inline asm to force IDIV Ew
__attribute__((noinline)) short tf_h(short c) {
    short q;
    __asm__ volatile (
        "movw  %[c], %%ax\n\t"
        "cwd\n\t"                // DX:AX = sign_extend(AX)
        "movw  $3, %%cx\n\t"
        "idivw %%cx\n\t"         // AX = DX:AX / CX
        "movw  %%ax, %[q]\n\t"
        : [q] "=r"(q)
        : [c] "r"(c)
        : "ax", "dx", "cx"
    );
    return q;
}

int main(void) {
    short v = (short)0x8002;
    short r = tf_h(v);
    printf("tf_h(%d) = %d (0x%04x)\n", v, r, (unsigned short)r);
    return 0;
}
```

**Fix Implementation**
Used BSTRPICK_D + BSTRINS_D to manually construct the DX:AX value.

Applied ADDI_W (add immediate word) to properly sign-extend the resulting 32-bit dividend into the 64-bit register before executing DIV_W.(need 0x00000000ffff8002 not 0xffffffffffff8002)

Validation
GDB check at div.w instruction confirms correct inputs:
```c
r15 (dividend) = 0xffffffffffff8002  <-- Correctly sign-extended
r14 (divisor)  = 0x3
r16 (quotient) = 0xffffffffffffd556  (-10922)
```