### PR TITLE
[WRAPPER] Add arc4random to libc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -818,7 +818,7 @@ if(NOT CI)
         OUTPUT "${BOX64_ROOT}/src/wrapped/generated/functions_list.txt"
         COMMAND "${PYTHON_EXECUTABLE}" "${BOX64_ROOT}/rebuild_wrappers.py"
         "${BOX64_ROOT}"
-        "PANDORA" "HAVE_LD80BITS" "NOALIGN" "HAVE_TRACE" "ANDROID" "TERMUX" "STATICBUILD" "LA64" "--"
+        "PANDORA" "HAVE_LD80BITS" "NOALIGN" "HAVE_TRACE" "ANDROID" "TERMUX" "STATICBUILD" "LA64" "LA64_ABI_1" "--"
         ${WRAPPEDS_HEAD}
         MAIN_DEPENDENCY "${BOX64_ROOT}/rebuild_wrappers.py"
         DEPENDS ${WRAPPEDS} ${WRAPPEDS_HEAD}

--- a/src/wrapped/generated/functions_list.txt
+++ b/src/wrapped/generated/functions_list.txt
@@ -5032,6 +5032,8 @@ wrappedlibc:
   - uname
 - CFp:
   - _ITM_RU1
+- uFv:
+  - arc4random
 - uFp:
   - _ITM_RU4
 - UFp:

--- a/src/wrapped/generated/wrappedlibctypes.h
+++ b/src/wrapped/generated/wrappedlibctypes.h
@@ -18,6 +18,7 @@ typedef int32_t (*iFv_t)(void);
 typedef int32_t (*iFi_t)(int32_t);
 typedef int32_t (*iFp_t)(void*);
 typedef uint8_t (*CFp_t)(void*);
+typedef uint32_t (*uFv_t)(void);
 typedef uint32_t (*uFp_t)(void*);
 typedef uint64_t (*UFp_t)(void*);
 typedef intptr_t (*lFv_t)(void);
@@ -137,6 +138,7 @@ typedef int32_t (*iFppipppp_t)(void*, void*, int32_t, void*, void*, void*, void*
 	GO(stime, iFp_t) \
 	GO(uname, iFp_t) \
 	GO(_ITM_RU1, CFp_t) \
+	GO(arc4random, uFv_t) \
 	GO(_ITM_RU4, uFp_t) \
 	GO(_ITM_RU8, UFp_t) \
 	GO(syscall, lFv_t) \

--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -4000,6 +4000,13 @@ EXPORT char* secure_getenv(const char* name)
     return getenv(name);
 }
 
+uint32_t get_random32();
+
+EXPORT uint32_t my_arc4random(void)
+{
+    return get_random32();
+}
+
 #ifdef STATICBUILD
 uint32_t get_random32();
 __attribute__((weak)) uint32_t arc4random()

--- a/src/wrapped/wrappedlibc_private.h
+++ b/src/wrapped/wrappedlibc_private.h
@@ -2690,10 +2690,14 @@ GO(android_set_abort_message, vFp)
 #ifdef STATICBUILD
 GO(dummy_pFLp, pFLp)
 GO(dummy_pFpLLp, pFpLLp)
-GO(arc4random, uFv)
 #else
 // not needed in no-static build
 //GO(dummy_pFLp, pFLp)
 //GO(dummy_pFpLLp, pFpLLp)
-//GO(arc4random, uFv)
+#endif
+
+#ifdef LA64_ABI_1
+GOM(arc4random, uFv)
+#else
+GO(arc4random, uFv)
 #endif


### PR DESCRIPTION
Add arc4random to libc to allow x86_64 NumPy wheels to load.