### PR TITLE
[WRAPPER] Provide weak arc4random in libc

### DIFF
--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -4000,12 +4000,13 @@ EXPORT char* secure_getenv(const char* name)
     return getenv(name);
 }
 
-#ifdef STATICBUILD
 uint32_t get_random32();
-__attribute__((weak)) uint32_t arc4random()
+__attribute__((weak)) uint32_t arc4random(void)
 {
     return get_random32();
 }
+
+#ifdef STATICBUILD
 #include "libtools/static_libc.h"
 #endif
 

--- a/src/wrapped/wrappedlibc_private.h
+++ b/src/wrapped/wrappedlibc_private.h
@@ -2690,10 +2690,10 @@ GO(android_set_abort_message, vFp)
 #ifdef STATICBUILD
 GO(dummy_pFLp, pFLp)
 GO(dummy_pFpLLp, pFpLLp)
-GO(arc4random, uFv)
 #else
 // not needed in no-static build
 //GO(dummy_pFLp, pFLp)
 //GO(dummy_pFpLLp, pFpLLp)
-//GO(arc4random, uFv)
 #endif
+
+GO(arc4random, uFv)


### PR DESCRIPTION
Add a weak arc4random fallback in wrappedlibc so symbol resolution succeeds on hosts without arc4random in libc/libbsd. This avoids PLT relocation failures when loading libstdc++/numpy. #3370 