### PR TITLE
[EMU] Fix ABI issue in my_cpuid leaf detection

### DIFF
--- a/src/dynarec/arm64/dynarec_arm64_0f.c
+++ b/src/dynarec/arm64/dynarec_arm64_0f.c
@@ -1794,8 +1794,7 @@ uintptr_t dynarec64_0F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int nin
             NOTEST(x1);
             GETIP(ip);  // sync RIP for easier debugging
             STRx_U12(xRIP, xEmu, offsetof(x64emu_t, ip));
-            MOVx_REG(x1, xRAX);
-            CALL_(const_cpuid, -1, 0);
+            CALL(const_cpuid, -1);
             break;
         case 0xA3:
             INST_NAME("BT Ed, Gd");

--- a/src/dynarec/la64/dynarec_la64_0f.c
+++ b/src/dynarec/la64/dynarec_la64_0f.c
@@ -1425,7 +1425,7 @@ uintptr_t dynarec64_0F(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
         case 0xA2:
             INST_NAME("CPUID");
             NOTEST(x1);
-            CALL_(const_cpuid, -1, 0, xRAX, 0);
+            CALL(const_cpuid, -1, 0, 0);
             // BX and DX are not synchronized durring the call, so need to force the update
             LD_D(xRDX, xEmu, offsetof(x64emu_t, regs[_DX]));
             LD_D(xRBX, xEmu, offsetof(x64emu_t, regs[_BX]));

--- a/src/dynarec/rv64/dynarec_rv64_0f.c
+++ b/src/dynarec/rv64/dynarec_rv64_0f.c
@@ -1851,7 +1851,7 @@ uintptr_t dynarec64_0F(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
         case 0xA2:
             INST_NAME("CPUID");
             NOTEST(x1);
-            CALL_(const_cpuid, -1, 0, xRAX, 0);
+            CALL(const_cpuid, -1, 0, 0);
             // BX and DX are not synchronized during the call, so need to force the update
             LD(xRDX, xEmu, offsetof(x64emu_t, regs[_DX]));
             LD(xRBX, xEmu, offsetof(x64emu_t, regs[_BX]));

--- a/src/emu/x64run0f.c
+++ b/src/emu/x64run0f.c
@@ -1182,8 +1182,7 @@ uintptr_t Run0F(x64emu_t *emu, rex_t rex, uintptr_t addr, int *step)
                 GetSegmentBaseEmu(emu, _FS);  // refresh segs_offs
             break;
         case 0xA2:                      /* CPUID */
-            tmp32u = R_EAX;
-            my_cpuid(emu, tmp32u);
+            my_cpuid(emu);
             break;
         case 0xA3:                      /* BT Ed,Gd */
             CHECK_FLAGS(emu);

--- a/src/include/my_cpuid.h
+++ b/src/include/my_cpuid.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 typedef struct x64emu_s x64emu_t;
 
-void my_cpuid(x64emu_t* emu, uint32_t tmp32u);
+void my_cpuid(x64emu_t* emu);
 uint32_t helper_getcpu(x64emu_t* emu);  // get the numa/cpu id actually running
 uint32_t get_random32();
 uint64_t get_random64();

--- a/src/os/my_cpuid_common.c
+++ b/src/os/my_cpuid_common.c
@@ -7,7 +7,7 @@
 #include "debug.h"
 #include "freq.h"
 
-void my_cpuid(x64emu_t* emu, uint32_t tmp32u)
+void my_cpuid(x64emu_t* emu)
 {
     emu->regs[_AX].dword[1] = emu->regs[_DX].dword[1] = emu->regs[_CX].dword[1] = emu->regs[_BX].dword[1] = 0;
     int ncpu = getNCpu();
@@ -39,9 +39,10 @@ void my_cpuid(x64emu_t* emu, uint32_t tmp32u)
             branding[0] = ' ';
         }
     }
+    uint32_t leaf = (uint32_t)R_EAX;
     uint32_t subleaf = R_ECX;
-    //printf_log(LOG_INFO, "%04d|%p: cpuid leaf=0x%x (subleaf=0x%x)", GetTID(), (void*)R_RIP, tmp32u, subleaf);
-    switch(tmp32u) {
+    //printf_log(LOG_INFO, "%04d|%p: cpuid leaf=0x%x (subleaf=0x%x)", GetTID(), (void*)R_RIP, leaf, subleaf);
+    switch(leaf) {
         case 0x0:
             // emulate a P4. TODO: Emulate a Core2?
             R_RAX = BOX64ENV(cputype)?0x0000000f:0x00000016;
@@ -558,7 +559,7 @@ void my_cpuid(x64emu_t* emu, uint32_t tmp32u)
             break;
         default:
             if(warned) {
-                printf_log(LOG_INFO, "Warning, CPUID command %X unsupported (ECX=%08x)\n", tmp32u, R_RCX);
+                printf_log(LOG_INFO, "Warning, CPUID command %X unsupported (ECX=%08x)\n", leaf, R_RCX);
                 --warned;
                 if(!warned)
                     printf_log(LOG_INFO, "Stopped logging CPUID issues\n");


### PR DESCRIPTION
Issue: https://github.com/ptitSeb/box64/issues/3369

This PR fixes the issue where numpy failed to load on LoongArch due to missing X86_V2 baseline features (specifically LAHF from leaf 0x80000001).

Even though tmp32u is uint32_t, on LoongArch it is passed in a 64-bit register with dirty high bits. The switch statement was compiling into a 64-bit comparison, causing the check for 0x80000001 to fail.

The tmp32u function interface is retained.
Current, NumPy imports successfully without error.(slowly)
