### PR TITLE
[WRAPPER] torch running miss symbol

### DIFF
--- a/src/emu/x64printer.c
+++ b/src/emu/x64printer.c
@@ -4439,6 +4439,8 @@ void x64Print(x64emu_t* emu, char* buff, size_t buffsz, const char* func, int ti
         snprintf(buff, buffsz, "%04d|%p: Calling %s(%" PRIf ", %" PRIi32 ", %" PRIp ", %" PRIp ", %" PRIp ", %" PRIu64 ")", tid, *(void**)(R_RSP), func, emu->xmm[0].d[0], (int32_t)R_RDI, (void*)R_RSI, (void*)R_RDX, (void*)R_RCX, (uintptr_t)R_R8);
     } else if (w == iFDipppL) {
         snprintf(buff, buffsz, "%04d|%p: Calling %s(%" PRILf ", %" PRIi32 ", %" PRIp ", %" PRIp ", %" PRIp ", %" PRIu64 ")", tid, *(void**)(R_RSP), func, LD2localLD((void*)(R_RSP + 8)), (int32_t)R_RDI, (void*)R_RSI, (void*)R_RDX, (void*)R_RCX, (uintptr_t)R_R8);
+    } else if (w == iFllllpp) {
+        snprintf(buff, buffsz, "%04d|%p: Calling %s(%" PRIi64 ", %" PRIi64 ", %" PRIi64 ", %" PRIi64 ", %" PRIp ", %" PRIp ")", tid, *(void**)(R_RSP), func, (intptr_t)R_RDI, (intptr_t)R_RSI, (intptr_t)R_RDX, (intptr_t)R_RCX, (void*)R_R8, (void*)R_R9);
     } else if (w == iFlpippp) {
         snprintf(buff, buffsz, "%04d|%p: Calling %s(%" PRIi64 ", %" PRIp ", %" PRIi32 ", %" PRIp ", %" PRIp ", %" PRIp ")", tid, *(void**)(R_RSP), func, (intptr_t)R_RDI, (void*)R_RSI, (int32_t)R_RDX, (void*)R_RCX, (void*)R_R8, (void*)R_R9);
     } else if (w == iFLpppii) {

--- a/src/wrapped/generated/functions_list.txt
+++ b/src/wrapped/generated/functions_list.txt
@@ -2428,6 +2428,7 @@
 #() iFupLpLp
 #() iFdipppL
 #() iFDipppL
+#() iFllllpp
 #() iFlpippp
 #() iFLpppii
 #() iFpiiiii

--- a/src/wrapped/generated/wrapper.c
+++ b/src/wrapped/generated/wrapper.c
@@ -2455,6 +2455,7 @@ typedef int32_t (*iFupupLp_t)(uint32_t, void*, uint32_t, void*, uintptr_t, void*
 typedef int32_t (*iFupuppp_t)(uint32_t, void*, uint32_t, void*, void*, void*);
 typedef int32_t (*iFupLpLp_t)(uint32_t, void*, uintptr_t, void*, uintptr_t, void*);
 typedef int32_t (*iFdipppL_t)(double, int32_t, void*, void*, void*, uintptr_t);
+typedef int32_t (*iFllllpp_t)(intptr_t, intptr_t, intptr_t, intptr_t, void*, void*);
 typedef int32_t (*iFlpippp_t)(intptr_t, void*, int32_t, void*, void*, void*);
 typedef int32_t (*iFLpppii_t)(uintptr_t, void*, void*, void*, int32_t, int32_t);
 typedef int32_t (*iFpiiiii_t)(void*, int32_t, int32_t, int32_t, int32_t, int32_t);
@@ -6379,6 +6380,7 @@ void iFupupLp(x64emu_t *emu, uintptr_t fcn) { iFupupLp_t fn = (iFupupLp_t)fcn; R
 void iFupuppp(x64emu_t *emu, uintptr_t fcn) { iFupuppp_t fn = (iFupuppp_t)fcn; R_RAX=(uint32_t)fn((uint32_t)R_RDI, (void*)R_RSI, (uint32_t)R_RDX, (void*)R_RCX, (void*)R_R8, (void*)R_R9); }
 void iFupLpLp(x64emu_t *emu, uintptr_t fcn) { iFupLpLp_t fn = (iFupLpLp_t)fcn; R_RAX=(uint32_t)fn((uint32_t)R_RDI, (void*)R_RSI, (uintptr_t)R_RDX, (void*)R_RCX, (uintptr_t)R_R8, (void*)R_R9); }
 void iFdipppL(x64emu_t *emu, uintptr_t fcn) { iFdipppL_t fn = (iFdipppL_t)fcn; R_RAX=(uint32_t)fn(emu->xmm[0].d[0], (int32_t)R_RDI, (void*)R_RSI, (void*)R_RDX, (void*)R_RCX, (uintptr_t)R_R8); }
+void iFllllpp(x64emu_t *emu, uintptr_t fcn) { iFllllpp_t fn = (iFllllpp_t)fcn; R_RAX=(uint32_t)fn((intptr_t)R_RDI, (intptr_t)R_RSI, (intptr_t)R_RDX, (intptr_t)R_RCX, (void*)R_R8, (void*)R_R9); }
 void iFlpippp(x64emu_t *emu, uintptr_t fcn) { iFlpippp_t fn = (iFlpippp_t)fcn; R_RAX=(uint32_t)fn((intptr_t)R_RDI, (void*)R_RSI, (int32_t)R_RDX, (void*)R_RCX, (void*)R_R8, (void*)R_R9); }
 void iFLpppii(x64emu_t *emu, uintptr_t fcn) { iFLpppii_t fn = (iFLpppii_t)fcn; R_RAX=(uint32_t)fn((uintptr_t)R_RDI, (void*)R_RSI, (void*)R_RDX, (void*)R_RCX, (int32_t)R_R8, (int32_t)R_R9); }
 void iFpiiiii(x64emu_t *emu, uintptr_t fcn) { iFpiiiii_t fn = (iFpiiiii_t)fcn; R_RAX=(uint32_t)fn((void*)R_RDI, (int32_t)R_RSI, (int32_t)R_RDX, (int32_t)R_RCX, (int32_t)R_R8, (int32_t)R_R9); }
@@ -9866,6 +9868,7 @@ int isSimpleWrapper(wrapper_t fun) {
 	if (fun == &iFupuppp) return 1;
 	if (fun == &iFupLpLp) return 1;
 	if (fun == &iFdipppL) return 2;
+	if (fun == &iFllllpp) return 1;
 	if (fun == &iFlpippp) return 1;
 	if (fun == &iFLpppii) return 1;
 	if (fun == &iFpiiiii) return 1;
@@ -12111,6 +12114,7 @@ int isSimpleWrapper(wrapper_t fun) {
 	if (fun == &iFupuppp) return 81;
 	if (fun == &iFupLpLp) return 17;
 	if (fun == &iFdipppL) return 18;
+	if (fun == &iFllllpp) return 1;
 	if (fun == &iFlpippp) return 65;
 	if (fun == &iFLpppii) return 769;
 	if (fun == &iFpiiiii) return 993;
@@ -14356,6 +14360,7 @@ int isSimpleWrapper(wrapper_t fun) {
 	if (fun == &iFupuppp) return 81;
 	if (fun == &iFupLpLp) return 17;
 	if (fun == &iFdipppL) return 18;
+	if (fun == &iFllllpp) return 1;
 	if (fun == &iFlpippp) return 65;
 	if (fun == &iFLpppii) return 769;
 	if (fun == &iFpiiiii) return 993;

--- a/src/wrapped/generated/wrapper.h
+++ b/src/wrapped/generated/wrapper.h
@@ -2465,6 +2465,7 @@ void iFupuppp(x64emu_t *emu, uintptr_t fnc);
 void iFupLpLp(x64emu_t *emu, uintptr_t fnc);
 void iFdipppL(x64emu_t *emu, uintptr_t fnc);
 void iFDipppL(x64emu_t *emu, uintptr_t fnc);
+void iFllllpp(x64emu_t *emu, uintptr_t fnc);
 void iFlpippp(x64emu_t *emu, uintptr_t fnc);
 void iFLpppii(x64emu_t *emu, uintptr_t fnc);
 void iFpiiiii(x64emu_t *emu, uintptr_t fnc);

--- a/src/wrapped/wrappedgomp_private.h
+++ b/src/wrapped/wrappedgomp_private.h
@@ -133,16 +133,16 @@
 //GO(acc_wait_h_, 
 
 //GO(GOMP_alloc, 
-//GO(GOMP_atomic_end, 
-//GO(GOMP_atomic_start, 
-//GO(GOMP_barrier, 
+GO(GOMP_atomic_end, vFv)
+GO(GOMP_atomic_start, vFv)
+GO(GOMP_barrier, vFv)
 //GO(GOMP_barrier_cancel, 
 //GO(GOMP_cancel, 
 //GO(GOMP_cancellation_point, 
-//GO(GOMP_critical_end, 
-//GO(GOMP_critical_name_end, 
-//GO(GOMP_critical_name_start, 
-//GO(GOMP_critical_start, 
+GO(GOMP_critical_end, vFv)
+GO(GOMP_critical_name_end, vFp)
+GO(GOMP_critical_name_start, vFp)
+GO(GOMP_critical_start, vFv)
 //GO(GOMP_doacross_post, 
 //GO(GOMP_doacross_ull_post, 
 //GO(GOMP_doacross_ull_wait, 
@@ -154,11 +154,11 @@
 //GO(GOMP_loop_doacross_runtime_start, 
 //GO(GOMP_loop_doacross_start, 
 //GO(GOMP_loop_doacross_static_start, 
-//GO(GOMP_loop_dynamic_next, 
-//GO(GOMP_loop_dynamic_start, 
-//GO(GOMP_loop_end, 
+GO(GOMP_loop_dynamic_next, iFpp)
+GO(GOMP_loop_dynamic_start, iFllllpp)
+GO(GOMP_loop_end, vFv)
 //GO(GOMP_loop_end_cancel, 
-//GO(GOMP_loop_end_nowait, 
+GO(GOMP_loop_end_nowait, vFv)
 //GO(GOMP_loop_guided_next, 
 //GO(GOMP_loop_guided_start, 
 //GO(GOMP_loop_maybe_nonmonotonic_runtime_next, 
@@ -169,13 +169,13 @@
 //GO(GOMP_loop_nonmonotonic_guided_start, 
 //GO(GOMP_loop_nonmonotonic_runtime_next, 
 //GO(GOMP_loop_nonmonotonic_runtime_start, 
-//GO(GOMP_loop_ordered_dynamic_next, 
-//GO(GOMP_loop_ordered_dynamic_start, 
+GO(GOMP_loop_ordered_dynamic_next, iFpp)
+GO(GOMP_loop_ordered_dynamic_start, iFllllpp)
 //GO(GOMP_loop_ordered_guided_next, 
 //GO(GOMP_loop_ordered_guided_start, 
 //GO(GOMP_loop_ordered_runtime_next, 
 //GO(GOMP_loop_ordered_runtime_start, 
-//GO(GOMP_loop_ordered_start, 
+//GO(GOMP_loop_ordered_start,
 //GO(GOMP_loop_ordered_static_next, 
 //GO(GOMP_loop_ordered_static_start, 
 //GO(GOMP_loop_runtime_next, 
@@ -218,8 +218,8 @@
 //GO(GOMP_offload_register_ver, 
 //GO(GOMP_offload_unregister, 
 //GO(GOMP_offload_unregister_ver, 
-//GO(GOMP_ordered_end, 
-//GO(GOMP_ordered_start, 
+GO(GOMP_ordered_end, vFv)
+GO(GOMP_ordered_start, vFv)
 GOM(GOMP_parallel, vFEppuu)
 //GO(GOMP_parallel_end, 
 //GO(GOMP_parallel_loop_dynamic, 
@@ -255,12 +255,12 @@ GOM(GOMP_parallel, vFEppuu)
 //GO(GOMP_sections2_start, 
 //GO(GOMP_sections_end, 
 //GO(GOMP_sections_end_cancel, 
-//GO(GOMP_sections_end_nowait, 
-//GO(GOMP_sections_next, 
-//GO(GOMP_sections_start, 
+GO(GOMP_sections_end_nowait, vFv)
+GO(GOMP_sections_next, uFv)
+GO(GOMP_sections_start, uFu)
 //GO(GOMP_single_copy_end, 
 //GO(GOMP_single_copy_start, 
-//GO(GOMP_single_start, 
+GO(GOMP_single_start, iFv)
 //GO(GOMP_target, 
 //GO(GOMP_target_data, 
 //GO(GOMP_target_data_ext, 
@@ -347,7 +347,7 @@ GO(omp_get_max_threads, iFv)
 //GO(omp_get_num_devices_, 
 //GO(omp_get_num_places, 
 //GO(omp_get_num_places_, 
-//GO(omp_get_num_procs, 
+GO(omp_get_num_procs, iFv)
 //GO(omp_get_num_procs_, 
 //GO(omp_get_num_teams, 
 //GO(omp_get_num_teams_, 
@@ -403,7 +403,7 @@ GO(omp_get_thread_num, iFv)
 //GO(omp_init_nest_lock@OMP_1.0
 //GO(omp_init_nest_lock_, 
 //GO(omp_init_nest_lock_@OMP_1.0
-//GO(omp_in_parallel, 
+GO(omp_in_parallel, iFv)
 //GO(omp_in_parallel_, 
 //GO(omp_is_initial_device, 
 //GO(omp_is_initial_device_, 
@@ -439,7 +439,7 @@ GO(omp_get_thread_num, iFv)
 //GO(omp_set_num_teams, 
 //GO(omp_set_num_teams_, 
 //GO(omp_set_num_teams_8_, 
-//GO(omp_set_num_threads, 
+GO(omp_set_num_threads, vFi)
 //GO(omp_set_num_threads_, 
 //GO(omp_set_num_threads_8_, 
 //GO(omp_set_schedule, 


### PR DESCRIPTION
The torch CPU version is missing symbols related to the gomp libs.

```
[BOX64] Error: Symbol omp_set_num_threads not found, cannot apply R_X86_64_JUMP_SLOT @0x7fff1ae68470 (0x1086c56) in /home/yzw/python-trans/python-standalone/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so (optver=36 / OMP_1.0)
[BOX64] Error: Symbol omp_in_parallel not found, cannot apply R_X86_64_JUMP_SLOT @0x7fff1ae68490 (0x1086c96) in /home/yzw/python-trans/python-standalone/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so (optver=36 / OMP_1.0)
[BOX64] Error: Symbol GOMP_barrier not found, cannot apply R_X86_64_JUMP_SLOT @0x7fff1ae92d68 (0x10dbe46) in /home/yzw/python-trans/python-standalone/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so (optver=38 / GOMP_1.0)
[BOX64] Error: Symbol omp_get_num_procs not found, cannot apply R_X86_64_JUMP_SLOT @0x7fff1ae969d8 (0x10e3726) in /home/yzw/python-trans/python-standalone/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so (optver=36 / OMP_1.0)
[BOX64] Error: Symbol GOMP_loop_dynamic_start not found, cannot apply R_X86_64_JUMP_SLOT @0x7fff1ae96a70 (0x10e3856) in /home/yzw/python-trans/python-standalone/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so (optver=38 / GOMP_1.0)
[BOX64] Error: Symbol GOMP_loop_dynamic_next not found, cannot apply R_X86_64_JUMP_SLOT @0x7fff1ae96a78 (0x10e3866) in /home/yzw/python-trans/python-standalone/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so (optver=38 / GOMP_1.0)
[BOX64] Error: Symbol GOMP_loop_end not found, cannot apply R_X86_64_JUMP_SLOT @0x7fff1ae96a80 (0x10e3876) in /home/yzw/python-trans/python-standalone/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so (optver=38 / GOMP_1.0)
[BOX64] Error: Symbol GOMP_critical_start not found, cannot apply R_X86_64_JUMP_SLOT @0x7fff1ae96dc8 (0x10e3f06) in /home/yzw/python-trans/python-standalone/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so (optver=38 / GOMP_1.0)
[BOX64] Error: Symbol GOMP_critical_end not found, cannot apply R_X86_64_JUMP_SLOT @0x7fff1ae96dd0 (0x10e3f16) in /home/yzw/python-trans/python-standalone/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so (optver=38 / GOMP_1.0)
```
