### PR TITLE
[WRAPPER] Fixed atfork handler

### DIFF
--- a/src/emu/x64int3.c
+++ b/src/emu/x64int3.c
@@ -59,7 +59,7 @@ x64emu_t* x64emu_fork(x64emu_t* emu, int forktype)
         // error...
     } else if(v!=0) {  
         // execute atforks parent functions
-        for (int i=0; i<my_context->atfork_sz; --i)
+        for (int i=0; i<my_context->atfork_sz; ++i)
             if(my_context->atforks[i].parent)
                 EmuCall(emu, my_context->atforks[i].parent);
         if(forktype==3) {
@@ -68,7 +68,7 @@ x64emu_t* x64emu_fork(x64emu_t* emu, int forktype)
         }
     } else if(v==0) {
         // execute atforks child functions
-        for (int i=0; i<my_context->atfork_sz; --i)
+        for (int i=0; i<my_context->atfork_sz; ++i)
             if(my_context->atforks[i].child)
                 EmuCall(emu, my_context->atforks[i].child);
     }

--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -598,13 +598,13 @@ pid_t EXPORT my_fork(x64emu_t* emu)
         // error...
     } else if(v>0) {
         // execute atforks parent functions
-        for (int i=0; i<my_context->atfork_sz; --i)
+        for (int i=0; i<my_context->atfork_sz; ++i)
             if(my_context->atforks[i].parent)
                 RunFunctionWithEmu(emu, 0, my_context->atforks[i].parent, 0);
 
     } else /*if(v==0)*/ {
         // execute atforks child functions
-        for (int i=0; i<my_context->atfork_sz; --i)
+        for (int i=0; i<my_context->atfork_sz; ++i)
             if(my_context->atforks[i].child)
                 RunFunctionWithEmu(emu, 0, my_context->atforks[i].child, 0);
     }
@@ -2819,10 +2819,11 @@ EXPORT int32_t my___register_atfork(x64emu_t *emu, void* prepare, void* parent, 
         my_context->atfork_cap += 4;
         my_context->atforks = (atfork_fnc_t*)box_realloc(my_context->atforks, my_context->atfork_cap*sizeof(atfork_fnc_t));
     }
-    my_context->atforks[my_context->atfork_sz].prepare = (uintptr_t)prepare;
-    my_context->atforks[my_context->atfork_sz].parent = (uintptr_t)parent;
-    my_context->atforks[my_context->atfork_sz].child = (uintptr_t)child;
-    my_context->atforks[my_context->atfork_sz].handle = handle;
+    int i = my_context->atfork_sz++;
+    my_context->atforks[i].prepare = (uintptr_t)prepare;
+    my_context->atforks[i].parent = (uintptr_t)parent;
+    my_context->atforks[i].child = (uintptr_t)child;
+    my_context->atforks[i].handle = handle;
     return 0;
 }
 

--- a/src/wrapped32/wrappedlibc.c
+++ b/src/wrapped32/wrappedlibc.c
@@ -719,13 +719,13 @@ pid_t EXPORT my32_fork(x64emu_t* emu)
         // error...
     } else if(v>0) {
         // execute atforks parent functions
-        for (int i=0; i<my_context->atfork_sz; --i)
+        for (int i=0; i<my_context->atfork_sz; ++i)
             if(my_context->atforks[i].parent)
                 RunFunctionWithEmu(emu, 0, my_context->atforks[i].parent, 0);
 
     } else /*if(v==0)*/ {
         // execute atforks child functions
-        for (int i=0; i<my_context->atfork_sz; --i)
+        for (int i=0; i<my_context->atfork_sz; ++i)
             if(my_context->atforks[i].child)
                 RunFunctionWithEmu(emu, 0, my_context->atforks[i].child, 0);
     }
@@ -2609,10 +2609,11 @@ EXPORT int32_t my32___register_atfork(x64emu_t *emu, void* prepare, void* parent
         my_context->atfork_cap += 4;
         my_context->atforks = (atfork_fnc_t*)realloc(my_context->atforks, my_context->atfork_cap*sizeof(atfork_fnc_t));
     }
-    my_context->atforks[my_context->atfork_sz].prepare = (uintptr_t)prepare;
-    my_context->atforks[my_context->atfork_sz].parent = (uintptr_t)parent;
-    my_context->atforks[my_context->atfork_sz].child = (uintptr_t)child;
-    my_context->atforks[my_context->atfork_sz].handle = handle;
+    int i = my_context->atfork_sz++;
+    my_context->atforks[i].prepare = (uintptr_t)prepare;
+    my_context->atforks[i].parent = (uintptr_t)parent;
+    my_context->atforks[i].child = (uintptr_t)child;
+    my_context->atforks[i].handle = handle;
     return 0;
 }
 


### PR DESCRIPTION
Increment atfork_sz after registering an entry in my___register_atfork and my32___register_atfork, matching the working pattern in wrappedlibpthread.c. Without the increment, each registration overwrites slot 0 and all prior handlers are lost.

The two bugs mask each other. Since atfork_sz is never incremented by __register_atfork, it stays 0, so the broken loops are never reached with a nonzero count. Programs that register atfork handlers via pthread_atfork (which calls wrappedlibpthread.c and does increment correctly) would hit Bug 2 though — their parent/child handlers silently never run.



Fixes #3455