### PR TITLE
[ELF] Fix ABS_ADDR for LA64 ABI 1.0

### DIFF
--- a/src/elfs/elfhacks.c
+++ b/src/elfs/elfhacks.c
@@ -29,7 +29,7 @@
  *  \{
  */
 
-#if defined(__GLIBC__) && !(defined(__riscv) || defined(__mips__))
+#if defined(__GLIBC__) && !(defined(__riscv) || defined(__mips__) || defined(LA64_ABI_1))
 # define ABS_ADDR(obj, ptr) (ptr)
 #else
 # define ABS_ADDR(obj, ptr) ((obj->addr) + (ptr))


### PR DESCRIPTION
Hi,

Fixed https://github.com/ptitSeb/box64/issues/3459 .

Thanks,
Leslie Zhai