### PR TITLE
Fix missing braces in x64run0f.c opcode 0x00 handler

### DIFF
--- a/src/emu/x64run0f.c
+++ b/src/emu/x64run0f.c
@@ -86,19 +86,20 @@ uintptr_t Run0F(x64emu_t *emu, rex_t rex, uintptr_t addr, int *step)
                     default:
                         return 0;
                 }
-            } else
+            } else {
                 nextop = F8;
                 switch((nextop>>3)&7) {
                     case 0:                 /* SLDT Ew */
                         GETEW(0);
                         if(MODREG)
                             ED->q[0] = 0;
-                        else                            
+                        else
                             EW->word[0] = 0;
                         break;
                     default:
                         return 0;
                 }
+            }
             break;
         case 0x01:                      /* XGETBV, SGDT, etc... */
             nextop = F8;


### PR DESCRIPTION
The else branch at line 89 was missing braces, causing the second switch statement to always execute regardless of rex.is32bits.



