### PR TITLE
Fix undefined behavior in EXTRQ/INSERTQ

### DIFF
--- a/src/emu/x64run660f.c
+++ b/src/emu/x64run660f.c
@@ -1713,7 +1713,7 @@ uintptr_t Run660F(x64emu_t *emu, rex_t rex, uintptr_t addr)
             tmp8s = F8&0x3f;
             tmp8u = F8&0x3f;
             EX->q[0]>>=tmp8u;
-            EX->q[0]&=((1<<(tmp8s+1))-1);
+            EX->q[0]&=(tmp8s==63)?~0ULL:((1ULL<<(tmp8s+1))-1);
         }
         break;
     case 0x79:  /* EXTRQ Ex, Gx */
@@ -1730,7 +1730,7 @@ uintptr_t Run660F(x64emu_t *emu, rex_t rex, uintptr_t addr)
             tmp8s = EX->ub[0]&0x3f;
             tmp8u = EX->ub[1]&0x3f;
             GX->q[0]>>=tmp8u;
-            GX->q[0]&=((1<<(tmp8s+1))-1);
+            GX->q[0]&=(tmp8s==63)?~0ULL:((1ULL<<(tmp8s+1))-1);
         }
         break;
 

--- a/src/emu/x64runf20f.c
+++ b/src/emu/x64runf20f.c
@@ -309,7 +309,7 @@ uintptr_t RunF20F(x64emu_t *emu, rex_t rex, uintptr_t addr, int *step)
             GETEX(2);
             tmp8s = F8&0x3f;
             tmp8u = F8&0x3f;
-            tmp64u = (1<<(tmp8s+1))-1;
+            tmp64u = (tmp8s==63)?~0ULL:((1ULL<<(tmp8s+1))-1);
             GX->q[0] &=~(tmp64u<<tmp8u);
             GX->q[0] |= (EX->q[0]&tmp64u)<<tmp8u;
         }
@@ -327,7 +327,7 @@ uintptr_t RunF20F(x64emu_t *emu, rex_t rex, uintptr_t addr, int *step)
             GETEX(2);
             tmp8u = EX->ub[8]&0x3f;
             tmp8s = EX->ub[9]&0x3f;
-            tmp64u = (1<<(tmp8s+1))-1;
+            tmp64u = (tmp8s==63)?~0ULL:((1ULL<<(tmp8s+1))-1);
             GX->q[0] &=~(tmp64u<<tmp8u);
             GX->q[0] |= (EX->q[0]&tmp64u)<<tmp8u;
         }


### PR DESCRIPTION
Use 1LL instead of 1 in left shift for EXTRQ (0x78, 0x79) and INSERTQ (0x78, 0x79) mask generation. The shift amount (tmp8s+1) ranges 1-64 since tmp8s is masked with 0x3f (0-63), causing undefined behavior when shifting the 32-bit int literal 1 by more than 31.