### PR TITLE
[LA64_DYNAREC] preserve xRDI when call_c clobbers A0

### DIFF
--- a/src/dynarec/la64/dynarec_la64_helper.c
+++ b/src/dynarec/la64/dynarec_la64_helper.c
@@ -507,6 +507,17 @@ void call_c(dynarec_la64_t* dyn, int ninst, la64_consts_t fnc, int reg, int ret,
     CHECK_DFNONE(1);
     if (savereg == 0)
         savereg = x87pc;
+    // If any arg lives in xRDI (A0), preserve it before overwriting A0 with xEmu.
+    int a1 = arg1, a2 = arg2, a3 = arg3, a4 = arg4, a5 = arg5, a6 = arg6;
+    if (a1 == xRDI || a2 == xRDI || a3 == xRDI || a4 == xRDI || a5 == xRDI || a6 == xRDI) {
+        MV(x3, xRDI);
+        if (a1 == xRDI) a1 = x3;
+        if (a2 == xRDI) a2 = x3;
+        if (a3 == xRDI) a3 = x3;
+        if (a4 == xRDI) a4 = x3;
+        if (a5 == xRDI) a5 = x3;
+        if (a6 == xRDI) a6 = x3;
+    }
     if (saveflags) {
         RESTORE_EFLAGS(reg);
         ST_D(xFlags, xEmu, offsetof(x64emu_t, eflags));
@@ -529,12 +540,12 @@ void call_c(dynarec_la64_t* dyn, int ninst, la64_consts_t fnc, int reg, int ret,
     }
     TABLE64C(reg, fnc);
     MV(A0, xEmu);
-    if (arg1) MV(A1, arg1);
-    if (arg2) MV(A2, arg2);
-    if (arg3) MV(A3, arg3);
-    if (arg4) MV(A4, arg4);
-    if (arg5) MV(A5, arg5);
-    if (arg6) MV(A6, arg6);
+    if (a1) MV(A1, a1);
+    if (a2) MV(A2, a2);
+    if (a3) MV(A3, a3);
+    if (a4) MV(A4, a4);
+    if (a5) MV(A5, a5);
+    if (a6) MV(A6, a6);
     JIRL(xRA, reg, 0);
     if (ret >= 0) {
         MV(ret, A0);

--- a/src/dynarec/rv64/dynarec_rv64_helper.c
+++ b/src/dynarec/rv64/dynarec_rv64_helper.c
@@ -594,6 +594,17 @@ void call_c(dynarec_rv64_t* dyn, int ninst, rv64_consts_t fnc, int reg, int ret,
     MAYUSE(fnc);
     if (savereg == 0)
         savereg = x87pc;
+    // If any arg lives in xRDI (A0), preserve it before overwriting A0 with xEmu.
+    int a1 = arg1, a2 = arg2, a3 = arg3, a4 = arg4, a5 = arg5, a6 = arg6;
+    if (a1 == xRDI || a2 == xRDI || a3 == xRDI || a4 == xRDI || a5 == xRDI || a6 == xRDI) {
+        MV(x3, xRDI);
+        if (a1 == xRDI) a1 = x3;
+        if (a2 == xRDI) a2 = x3;
+        if (a3 == xRDI) a3 = x3;
+        if (a4 == xRDI) a4 = x3;
+        if (a5 == xRDI) a5 = x3;
+        if (a6 == xRDI) a6 = x3;
+    }
     if (saveflags) {
         FLAGS_ADJUST_TO11(xFlags, xFlags, reg);
         SD(xFlags, xEmu, offsetof(x64emu_t, eflags));
@@ -613,12 +624,12 @@ void call_c(dynarec_rv64_t* dyn, int ninst, rv64_consts_t fnc, int reg, int ret,
     }
     TABLE64C(reg, fnc);
     MV(A0, xEmu);
-    if (arg1) MV(A1, arg1);
-    if (arg2) MV(A2, arg2);
-    if (arg3) MV(A3, arg3);
-    if (arg4) MV(A4, arg4);
-    if (arg5) MV(A5, arg5);
-    if (arg6) MV(A6, arg6);
+    if (a1) MV(A1, a1);
+    if (a2) MV(A2, a2);
+    if (a3) MV(A3, a3);
+    if (a4) MV(A4, a4);
+    if (a5) MV(A5, a5);
+    if (a6) MV(A6, a6);
     JALR(xRA, reg);
     if (ret >= 0) {
         MV(ret, A0);


### PR DESCRIPTION
In the LA64 dynarec's call_c(), writing A0=xEmu first causes the helper parameter from xRDI to be overwritten. Since the xRDI and A0 registers overlap, it causes a div64 calculation error (discovered through the NumPy test case timedelta floor_divide running exception).

```
import numpy as np

op1 = np.timedelta64(1, 'm')
op2 = np.timedelta64(31, 's')

for i in range(3):
    print("iter", i, op1 // op2)
```
FAIL_LOG:
```
[BOX64] Using emulated /home/yzw/python-trans/python-standalone/lib/python3.11/site-packages/numpy/_core/_multiarray_umath.cpython-311d-x86_64-linux-gnu.so
[BOX64] Using emulated /usr/lib/box64-x86_64-linux-gnu/libstdc++.so.6
[BOX64] Using emulated /usr/lib/box64-x86_64-linux-gnu/libgcc_s.so.1
[BOX64] Using emulated /home/yzw/python-trans/python-standalone/lib/python3.11/site-packages/numpy/linalg/_umath_linalg.cpython-311d-x86_64-linux-gnu.so
iter 0 3
iter 1 3
iter 2 3

```

SUCCESS_LOG:
```
[BOX64] Using emulated /home/yzw/python-trans/python-standalone/lib/python3.11/site-packages/numpy/_core/_multiarray_umath.cpython-311d-x86_64-linux-gnu.so
[BOX64] Using emulated /usr/lib/box64-x86_64-linux-gnu/libstdc++.so.6
[BOX64] Using emulated /usr/lib/box64-x86_64-linux-gnu/libgcc_s.so.1
[BOX64] Using emulated /home/yzw/python-trans/python-standalone/lib/python3.11/site-packages/numpy/linalg/_umath_linalg.cpython-311d-x86_64-linux-gnu.so
iter 0 1
iter 1 1
iter 2 1
```