### PR TITLE
[LA64_DYNAREC] Fix call_c arg setup clobbering A0-mapped regs

### DIFF
--- a/src/dynarec/la64/dynarec_la64_helper.c
+++ b/src/dynarec/la64/dynarec_la64_helper.c
@@ -528,13 +528,13 @@ void call_c(dynarec_la64_t* dyn, int ninst, la64_consts_t fnc, int reg, int ret,
         ST_D(xRIP, xEmu, offsetof(x64emu_t, ip));
     }
     TABLE64C(reg, fnc);
-    MV(A0, xEmu);
     if (arg1) MV(A1, arg1);
     if (arg2) MV(A2, arg2);
     if (arg3) MV(A3, arg3);
     if (arg4) MV(A4, arg4);
     if (arg5) MV(A5, arg5);
     if (arg6) MV(A6, arg6);
+    MV(A0, xEmu);
     JIRL(xRA, reg, 0);
     if (ret >= 0) {
         MV(ret, A0);

--- a/src/dynarec/rv64/dynarec_rv64_helper.c
+++ b/src/dynarec/rv64/dynarec_rv64_helper.c
@@ -612,13 +612,13 @@ void call_c(dynarec_rv64_t* dyn, int ninst, rv64_consts_t fnc, int reg, int ret,
         SD(xRIP, xEmu, offsetof(x64emu_t, ip));
     }
     TABLE64C(reg, fnc);
-    MV(A0, xEmu);
     if (arg1) MV(A1, arg1);
     if (arg2) MV(A2, arg2);
     if (arg3) MV(A3, arg3);
     if (arg4) MV(A4, arg4);
     if (arg5) MV(A5, arg5);
     if (arg6) MV(A6, arg6);
+    MV(A0, xEmu);
     JALR(xRA, reg);
     if (ret >= 0) {
         MV(ret, A0);


### PR DESCRIPTION
NumPy test case timedelta floor_divide runtime exception revealed DIV/IDIV translation issues.
Before（buggy：First cover A0, then move A1)
```
[BOX64] 0x7fff001090bc: 48 F7 F7  DIV Ed
    ... (slowpath because RDX!=0)
    BEQ             xRDX, xZR, ...

[BOX64]   Table64: 0x3d
    ... resolve helper div64 target into x6 ...
    ADDI.D          xRDI, xEmu, 0        ; A0 <- emu   (clobber A0 which also holds xRDI)
    ADDI.D          xRSI, xRDI, 0        ; A1 <- A0    (arg1 was xRDI/A0, but now A0==emu => s becomes wrong)
    JIRL            r1, x6, 0           ; call div64(emu, s)

    ... restore regs ...
```
After modification (fixed: move A1 first, then overwrite A0),
```
[BOX64] 0x7fff001090bc: 48 F7 F7  DIV Ed
    ... (slowpath because RDX!=0)
    BEQ             xRDX, xZR, ...

[BOX64]   Table64: 0x3d
    ... resolve helper div64 target into x6 ...
    ADDI.D          xRSI, xRDI, 0        ; A1 <- xRDI  (preserve divisor s first)
    ADDI.D          xRDI, xEmu, 0        ; A0 <- emu   (set emu after arg copy)
    JIRL            r1, x6, 0           ; call div64(emu, s)

    ... restore regs ...
```