### PR TITLE
Fix missing return in openat syscall wrapper

### DIFF
--- a/src/emu/x64syscall.c
+++ b/src/emu/x64syscall.c
@@ -1168,7 +1168,7 @@ long EXPORT my_syscall(x64emu_t *emu)
         #endif
         #ifndef NOALIGN
         case 257:
-            syscall(__NR_openat, S_ESI, (void*)R_RDX, of_convert(S_ECX), R_R8d);
+            return syscall(__NR_openat, S_ESI, (void*)R_RDX, of_convert(S_ECX), R_R8d);
         #endif
         case 262:
             return my_fstatat(emu, S_RSI, (char*)R_RDX, (void*)R_RCX, S_R8d);


### PR DESCRIPTION
Previously, the __NR_openat (257) case lacked a return statement.
This caused case 257 to fall through to case 262 (fstatat)