### PR TITLE
Fix memory leak of mmaplist_t->chunks and allocator mismatch

### DIFF
--- a/src/custommem.c
+++ b/src/custommem.c
@@ -1565,6 +1565,7 @@ void DelMmaplist(mmaplist_t* list)
             } else
                 rb_unset(mapallmem, (uintptr_t)addr, (uintptr_t)addr+size);
         }
+    box_free(list->chunks);
     box_free(list);
 }
 
@@ -3132,9 +3133,9 @@ void fini_custommem_helper(box64context_t *ctx)
             for (int i=0; i<head->size; ++i) {
                 InternalMunmap(head->chunks[i]->block-sizeof(blocklist_t), head->chunks[i]->size+sizeof(blocklist_t));
             }
-            free(head);
+            box_free(head->chunks);
+            box_free(head);
         }
-        box_free(mmaplist);
         #ifdef JMPTABL_SHIFT4
         uintptr_t**** box64_jmptbl3;
         for(int i4 = 0; i4 < (1<< JMPTABL_SHIFT4); ++i4)


### PR DESCRIPTION
mmaplist_t->chunks (blocklist_t**) is a heap-allocated pointer array grown via box_realloc in MmaplistAddBlock/MmaplistAddNBlocks. The individual elements chunks[i] point into InternalMmap regions and are correctly freed by InternalMunmap, but the pointer array itself was never freed.

DelMmaplist(): add box_free(list->chunks) before box_free(list). This function is called at runtime from RemoveMapping (env.c) on dlclose/munmap, so the leak accumulates over the program lifetime.

fini_custommem_helper(): add box_free(head->chunks) before freeing the struct. Remove box_free(mmaplist) which was dead code — mmaplist was already set to NULL before the if(head) block. Also fix allocator mismatch: the struct is allocated via box_calloc in NewMmaplist() but was freed with raw free() instead of box_free().

Verified with valgrind on ARM64:
https://github.com/devarajabc/box64_test_cases/tree/main/003_mmaplist_chunks_leak