### PR TITLE
Add missing ClearCache after ARCH_UDF

### DIFF
--- a/src/dynarec/dynablock.c
+++ b/src/dynarec/dynablock.c
@@ -189,6 +189,7 @@ void MarkDynablock(dynablock_t* db)
                 // mark all callrets to UDF
                 for(int i=0; i<db->callret_size; ++i)
                     *(uint32_t*)(db->block+db->callrets[i].offs) = ARCH_UDF;
+                ClearCache(db->block, db->size);
             }
         #endif
         }

--- a/src/dynarec/dynarec_native.c
+++ b/src/dynarec/dynarec_native.c
@@ -821,9 +821,11 @@ dynablock_t* FillBlock64(uintptr_t addr, int alternate, int is32bits, int inst_m
         dynarec_log(LOG_INFO, "Note: block marked as always dirty %p:%ld\n", block->x64_addr, block->x64_size);
         #ifdef ARCH_NOP
         // mark callrets to trigger SIGILL to check clean state
-        if(block->callret_size)
+        if(block->callret_size) {
             for(int i=0; i<block->callret_size; ++i)
                 *(uint32_t*)(block->block+block->callrets[i].offs) = ARCH_UDF;
+            ClearCache(block->block, block->size);
+        }
         #endif
     }
     redundant_helper = current_helper = NULL;


### PR DESCRIPTION
MarkDynablock() and the always_test path in dynarec_native.c write ARCH_UDF to callret slots to trigger SIGILL for dirty-block detection, but don't flush the I-cache afterward. On ARM64/RV64/LA64 the I-cache and D-cache are not coherent, so the CPU keeps executing the stale instruction and the dirty check never fires.

InvalidDynablock() already calls ClearCache after the same ARCH_UDF write. Add the missing calls to match.