### PR TITLE
Fix incorrect page-alignment test preventing mprotect()

### DIFF
--- a/src/elfs/elfloader.c
+++ b/src/elfs/elfloader.c
@@ -399,7 +399,7 @@ int AllocLoadElfMemory(box64context_t* context, elfheader_t* head, int mainbin)
                         return 1;
                     }
                 }
-                if(!(prot&PROT_WRITE) && (paddr==(paddr&(box64_pagesize-1)) && (asize==ALIGN(asize))))
+                if(!(prot&PROT_WRITE) && (paddr==(paddr&~(box64_pagesize-1)) && (asize==ALIGN(asize))))
                     mprotect((void*)paddr, asize, prot);
             }
 #ifdef DYNAREC

--- a/src/elfs/elfloader32.c
+++ b/src/elfs/elfloader32.c
@@ -308,7 +308,7 @@ int AllocLoadElfMemory32(box64context_t* context, elfheader_t* head, int mainbin
                         return 1;
                     }
                 }
-                if(!(prot&PROT_WRITE) && (paddr==(paddr&(box64_pagesize-1)) && (asize==ALIGN(asize))))
+                if(!(prot&PROT_WRITE) && (paddr==(paddr&~(box64_pagesize-1)) && (asize==ALIGN(asize))))
                     mprotect((void*)paddr, asize, prot);
             }
 #ifdef DYNAREC


### PR DESCRIPTION
The fallback ELF loader tests alignment with:
    `paddr == (paddr & (box64_pagesize - 1))`

This check will always fail, so mprotect() is skipped. 
Fix it to use `~(box64_pagesize - 1)`.