### PR TITLE
[LA64_DYNAREC] Close the fastnan path for MINSS/MAXSS/VMINSS/VMAXSS to correct NaN semantics.

### DIFF
--- a/src/dynarec/la64/dynarec_la64_avx_f3_0f.c
+++ b/src/dynarec/la64/dynarec_la64_avx_f3_0f.c
@@ -343,12 +343,8 @@ uintptr_t dynarec64_AVX_F3_0F(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip,
             GETEYSS(v2, 0, 0);
             GETGYx_empty(v0);
             q0 = fpu_get_scratch(dyn);
-            if (BOX64ENV(dynarec_fastnan)) {
-                FMIN_S(q0, v1, v2);
-            } else {
-                FCMP_S(fcc0, v2, v1, cULE);
-                FSEL(q0, v1, v2, fcc0);
-            }
+            FCMP_S(fcc0, v2, v1, cULE);
+            FSEL(q0, v1, v2, fcc0);
             if (v0 != v1) VOR_V(v0, v1, v1);
             VEXTRINS_W(v0, q0, 0);
             break;
@@ -378,12 +374,8 @@ uintptr_t dynarec64_AVX_F3_0F(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip,
             GETEYSS(v2, 0, 0);
             GETGYx_empty(v0);
             q0 = fpu_get_scratch(dyn);
-            if (BOX64ENV(dynarec_fastnan)) {
-                FMAX_S(q0, v1, v2);
-            } else {
-                FCMP_S(fcc0, v2, v1, cLT);
-                FSEL(q0, v2, v1, fcc0);
-            }
+            FCMP_S(fcc0, v2, v1, cLT);
+            FSEL(q0, v2, v1, fcc0);
             if (v0 != v1) VOR_V(v0, v1, v1);
             VEXTRINS_W(v0, q0, 0);
             break;

--- a/src/dynarec/la64/dynarec_la64_f30f.c
+++ b/src/dynarec/la64/dynarec_la64_f30f.c
@@ -361,12 +361,8 @@ uintptr_t dynarec64_F30F(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int 
             GETGX(d0, 1);
             GETEXSS(d1, 0, 0);
             q0 = fpu_get_scratch(dyn);
-            if (BOX64ENV(dynarec_fastnan)) {
-                FMIN_S(q0, d0, d1);
-            } else {
-                FCMP_S(fcc0, d1, d0, cULE);
-                FSEL(q0, d0, d1, fcc0);
-            }
+            FCMP_S(fcc0, d1, d0, cULE);
+            FSEL(q0, d0, d1, fcc0);
             VEXTRINS_W(d0, q0, 0);
             break;
         case 0x5E:
@@ -384,12 +380,8 @@ uintptr_t dynarec64_F30F(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int 
             GETGX(d0, 1);
             GETEXSS(d1, 0, 0);
             q0 = fpu_get_scratch(dyn);
-            if (BOX64ENV(dynarec_fastnan)) {
-                FMAX_S(q0, d0, d1);
-            } else {
-                FCMP_S(fcc0, d1, d0, cLT);
-                FSEL(q0, d1, d0, fcc0);
-            }
+            FCMP_S(fcc0, d1, d0, cLT);
+            FSEL(q0, d1, d0, fcc0);
             VEXTRINS_W(d0, q0, 0);
             break;
         case 0x6F:


### PR DESCRIPTION
**Problem:**
 LoongArch's `FMIN_S`/`FMAX_S` rules for determining NaN are inconsistent with x86's `MINSS`/`MAXSS`.

This causes NaN handling errors when `dynarec_fastnan=1` (error scenario observed: `numpy max`/`argmax` returns 1.0 instead of `nan`).

**Test Code:**
```
#gcc -O0 -mavx -o test test.c 
#include <immintrin.h>
#include <stdio.h>
#include <math.h>

int main() {
    float a = 1.0f;
    float b = NAN;

    __m128 va = _mm_set_ss(a);   // dest
    __m128 vb = _mm_set_ss(b);   // src
    __m128 vc = _mm_max_ss(va, vb); 

    float out;
    _mm_store_ss(&out, vc);
    printf("vmaxss out=%f\n", out);
    return 0;
}
```
If we need to check whether d0/d1 is NaN in order to preserve fastnan(FMAX_S), it might actually be slower.

