### PR TITLE
[FIX]: separate sse4_2 and sha_ni

### DIFF
--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -1962,7 +1962,7 @@ void CreateCPUInfoFile(int fd)
                       "sse4_1%s%s%s lzcnt popcnt%s%s%s%s%s%s%s%s%s\n",
                       BOX64ENV(pclmulqdq)?" pclmulqdq":"",
                       BOX64ENV(aes)?" aes":"",
-                      BOX64ENV(sse42)?" sse4_2":"", BOX64ENV(avx)?" avx":"", BOX64ENV(shaext)?"sha_ni":"",
+                      BOX64ENV(sse42)?" sse4_2":"", BOX64ENV(avx)?" avx":"", BOX64ENV(shaext)?" sha_ni":"",
                       BOX64ENV(avx)?" bmi1":"", BOX64ENV(avx2)?" avx2":"", BOX64ENV(avx)?" bmi2":"",
                       (BOX64ENV(avx2)&&BOX64ENV(aes))?" vaes":"", BOX64ENV(avx2)?" fma":"",
                       BOX64ENV(avx)?" xsave":"", BOX64ENV(avx)?" f16c":"", BOX64ENV(avx2)?" randr":"",


### PR DESCRIPTION
NumPy's `test_cpu_features.py::Test_X86_Features` file **performs feature checks by reading the `flags` line from `/proc/cpuinfo`**, performing a consistency check with `__cpu_features__` (derived from CPUID).

The check fails because the `flags` string generated by `CreateCPUInfoFile()` is missing a space between `sse4_2` and `sha_ni`.