### PR TITLE
Fix incorrect bit shift in fpu_do_free

### DIFF
--- a/src/emu/x87emu_private.c
+++ b/src/emu/x87emu_private.c
@@ -13,7 +13,7 @@
 
 void fpu_do_free(x64emu_t* emu, int i)
 {
-    emu->fpu_tags |= 0b11 << (i);   // empty
+    emu->fpu_tags |= 0b11 << (i*2);   // empty
     // check if all empty
     if(emu->fpu_tags != TAGS_EMPTY)
         return;


### PR DESCRIPTION
The FPU tag word uses 2 bits per register. The previous implementation shifted the mask by 'i' instead of 'i * 2'.