### PR TITLE
Fix epoll_create1 flag register in my_syscall handling

### DIFF
--- a/src/emu/x64syscall.c
+++ b/src/emu/x64syscall.c
@@ -1200,7 +1200,7 @@ long EXPORT my_syscall(x64emu_t *emu)
         #endif
         #ifndef NOALIGN
         case 291:   // sys__epoll_create1
-            return epoll_create1(of_convert(S_EDI));
+            return epoll_create1(of_convert(S_ESI));
         #endif
         case 317:   // sys_seccomp
             return 0;  // ignoring call


### PR DESCRIPTION
In `my_syscall`, which handles the C ABI `syscall()` wrapper from libc, the registers are mapped according to the C calling convention: the syscall number is in `RDI` (S_EDI), and the first actual syscall argument is in `RSI` (S_ESI).

For `epoll_create1` (syscall 291), the `#ifndef NOALIGN` fallback code was incorrectly passing `S_EDI` to `of_convert()`. This meant the syscall number itself (291) was being treated as the `flags` argument and passed through bitwise conversion, resulting in invalid flags being sent to the host's `epoll_create1`.