### PR TITLE
Fix use-before-set in inplace_XRRMonitorInfo_enlarge

### DIFF
--- a/src/libtools/my_x11_conv.c
+++ b/src/libtools/my_x11_conv.c
@@ -1498,8 +1498,6 @@ void* inplace_XRRMonitorInfo_enlarge(void* a, int n)
         src+=n-1;
         dst+=n-1;
         for(int i=n-1; i>=0; --i, --src, --dst) {
-            for(int j=dst->noutput-1; j>=0; --j)
-                ((unsigned long*)dst->outputs)[j] = from_ulong(dst->outputs[j]);
             dst->outputs = from_ptrv(src->outputs);
             dst->mheight = src->mheight;
             dst->mwidth = src->mwidth;
@@ -1511,6 +1509,8 @@ void* inplace_XRRMonitorInfo_enlarge(void* a, int n)
             dst->automatic = src->automatic;
             dst->primary = src->primary;
             dst->name = from_ulong(src->name);
+            for(int j=dst->noutput-1; j>=0; --j)
+                dst->outputs[j] = from_ulong(((ulong_t*)dst->outputs)[j]);
         }
     }
     return a;


### PR DESCRIPTION
In `inplace_XRRMonitorInfo_enlarge()`, `dst` and `src` alias the same memory with different struct layouts (64-bit vs 32-bit). The inner loop read `dst->noutput` and `dst->outputs` at 64-bit struct offsets before they were copied from src, so `dst->noutput` actually read `src->x`  and `dst->outputs` read past the 32-bit struct boundary.

Additionally, the loop used `from_ulong(dst->outputs[j])` which reads 8-byte unsigned long elements, but the source data contains 4-byte `ulong_t XID`s packed in the 32-bit layout.

Fix by saving `src->noutput` and `from_ptrv(src->outputs)` to local variables before the conversion loop, and reading source elements as `((ulong_t*)outputs)[j]` to match the 32-bit element size.

This could cause crashes or memory corruption in multi-monitor setups when enlarging XRRMonitorInfo arrays from 32-bit to 64-bit layout.