### PR TITLE
[BOX32][WRAPPER] Fix inverted condition in del_cond()

### DIFF
--- a/src/libtools/threads32.c
+++ b/src/libtools/threads32.c
@@ -519,7 +519,7 @@ static void del_cond(void* cond)
         return;
     mutex_lock(&my_context->mutex_thread);
     khint_t k = kh_get(mapcond, mapcond, (uintptr_t)cond);
-    if(k==kh_end(mapcond)) {
+    if(k!=kh_end(mapcond)) {
         box_free(kh_value(mapcond, k));
         kh_del(mapcond, mapcond, k);
     }


### PR DESCRIPTION
del_cond() had an inverted kh_end check introduced in bebae710e. 
k==kh_end(mapcond) means key "not found".
so it was never freed from the map, leaking memory on every                                                                                                                                           call.  
This causes use-after-free when cond is not in map and fails to delete 
when it is in the map.                                                           


Fix: change == to != to match the correct khash idiom used elsewhere.