### PR TITLE
[BOX32] Fix missing get_attr()

### DIFF
--- a/src/libtools/threads32.c
+++ b/src/libtools/threads32.c
@@ -866,7 +866,7 @@ EXPORT int my32_pthread_attr_setaffinity_np(x64emu_t* emu, void* attr, uint32_t 
         cpusetsize = sizeof(cpu_set_t);
     } 
 
-    int ret = pthread_attr_setaffinity_np(attr, cpusetsize, cpuset);
+    int ret = pthread_attr_setaffinity_np(get_attr(attr), cpusetsize, cpuset);
     if(ret<0) {
         printf_log(LOG_INFO, "Warning, pthread_attr_setaffinity_np(%p, %d, %p) errored, with errno=%d\n", attr, cpusetsize, cpuset, errno);
     }


### PR DESCRIPTION
my32_pthread_attr_setaffinity_np() was passing the raw attr wrapper pointer directly to the native pthread_attr_setaffinity_np() instead of using get_attr(attr) to extract the native pthread_attr_t pointer.

This bug existed since the initial Box32 commit (b5105a1e). All other pthread_attr_* functions in threads32.c use get_attr(attr).