### PR TITLE
[BOX32][WRAPPER] Fix XRRGetPanning shrinking wrong variable

### DIFF
--- a/src/wrapped32/wrappedlibxrandr.c
+++ b/src/wrapped32/wrappedlibxrandr.c
@@ -64,8 +64,8 @@ EXPORT void* my32_XRRGetPanning(x64emu_t* emu, void* dpy, void* res, XID crtc)
     inplace_XRRScreenResources_shrink(res);
     if(ret) {
         // shrink XRRPanning: L and 12i
-        *(ulong_t*)res = to_ulong(*(unsigned long*)res);
-        memmove(res+4, res+8, 12*4);
+        *(ulong_t*)ret = to_ulong(*(unsigned long*)ret);
+        memmove(ret+4, ret+8, 12*4);
     }
     return ret;
 }


### PR DESCRIPTION
Lines 67-68 were operating on res (XRRScreenResources* input) instead of ret (XRRPanning* return value), corrupting the input struct instead of shrinking the returned panning data.
it should be like this:
```
  32-bit app calls XRRGetPanning(dpy, res_32, crtc)                                                                                                                                                       
          │                                                                  
          ▼
  my32_XRRGetPanning:
    1. enlarge res (32-bit → 64-bit)     ← convert input for native call
    2. call native XRRGetPanning(dpy, res_64, crtc)
    3. shrink res (64-bit → 32-bit)      ← restore input to 32-bit form
    4. shrink ret (64-bit → 32-bit)      ← convert output for 32-bit caller
    5. return ret_32
          │
          ▼
  32-bit app gets back XRRPanning* in 32-bit layout
```