### PR TITLE
Fix ELF loader crash on hosts with >4KB page sizes (e.g. 64KB)

### DIFF
--- a/src/elfs/elfloader.c
+++ b/src/elfs/elfloader.c
@@ -399,8 +399,6 @@ int AllocLoadElfMemory(box64context_t* context, elfheader_t* head, int mainbin)
                         return 1;
                     }
                 }
-                if(!(prot&PROT_WRITE) && (paddr==(paddr&~(box64_pagesize-1)) && (asize==ALIGN(asize))))
-                    mprotect((void*)paddr, asize, prot);
             }
 #ifdef DYNAREC
             if(BOX64ENV(dynarec) && (e->p_flags & PF_X)) {
@@ -426,6 +424,20 @@ int AllocLoadElfMemory(box64context_t* context, elfheader_t* head, int mainbin)
             // zero'd difference between filesz and memsz
             if(e->p_filesz != e->p_memsz)
                 memset(dest+e->p_filesz, 0, e->p_memsz - e->p_filesz);
+        }
+    }
+    // deferred mprotect: apply final protections after all segments are loaded
+    // this avoids the case where mprotect on a shared host page (e.g. 64KB) strips
+    // PROT_WRITE before a later segment that shares the same page has been read into memory
+    for (int j = 0; j < n; j++) {
+        if(!(head->multiblocks[j].flags & PF_W)) {
+            uintptr_t start = head->multiblocks[j].paddr & ~(box64_pagesize-1);
+            uintptr_t end = ALIGN(head->multiblocks[j].paddr + head->multiblocks[j].asize);
+            for(uintptr_t page = start; page < end; page += box64_pagesize) {
+                uint32_t prot = getProtection(page);
+                if(prot && !(prot & PROT_WRITE))
+                    mprotect((void*)page, box64_pagesize, prot & ~PROT_CUSTOM);
+            }
         }
     }
     // record map

--- a/src/elfs/elfloader32.c
+++ b/src/elfs/elfloader32.c
@@ -308,8 +308,6 @@ int AllocLoadElfMemory32(box64context_t* context, elfheader_t* head, int mainbin
                         return 1;
                     }
                 }
-                if(!(prot&PROT_WRITE) && (paddr==(paddr&~(box64_pagesize-1)) && (asize==ALIGN(asize))))
-                    mprotect((void*)paddr, asize, prot);
             }
 #ifdef DYNAREC
             if(BOX64ENV(dynarec) && (e->p_flags & PF_X)) {
@@ -335,6 +333,20 @@ int AllocLoadElfMemory32(box64context_t* context, elfheader_t* head, int mainbin
             // zero'd difference between filesz and memsz
             if(e->p_filesz != e->p_memsz)
                 memset(dest+e->p_filesz, 0, e->p_memsz - e->p_filesz);
+        }
+    }
+    // deferred mprotect: apply final protections after all segments are loaded
+    // this avoids the case where mprotect on a shared host page (e.g. 64KB) strips
+    // PROT_WRITE before a later segment that shares the same page has been read into memory
+    for (int j = 0; j < n; j++) {
+        if(!(head->multiblocks[j].flags & PF_W)) {
+            uintptr_t start = head->multiblocks[j].paddr & ~(box64_pagesize-1);
+            uintptr_t end = ALIGN(head->multiblocks[j].paddr + head->multiblocks[j].asize);
+            for(uintptr_t page = start; page < end; page += box64_pagesize) {
+                uint32_t prot = getProtection(page);
+                if(prot && !(prot & PROT_WRITE))
+                    mprotect((void*)page, box64_pagesize, prot & ~PROT_CUSTOM);
+            }
         }
     }
     // record map


### PR DESCRIPTION
When host page size exceeds the ELF segment alignment (e.g. 64KB pages on ppc64le vs 4KB-aligned x86-64 segments), multiple LOAD segments can share the same host page. The old code called mprotect() to strip PROT_WRITE from a segment's page immediately after loading it. If a later segment mapped to the same host page, fread() into that address would SIGSEGV because the shared page was already made read-only.

Fix: defer mprotect calls until after ALL segments are loaded. A new loop iterates over multiblocks and applies final protections using getProtection() which reflects the merged protection from all segments sharing each host page.


Fixes: https://github.com/ptitSeb/box64/issues/3516