### PR TITLE
[LA64_DYNAREC] Fix call_n clobbering x64 arg regs in fast wrapper path

### DIFF
--- a/box64-bundle-x86-libs.sh
+++ b/box64-bundle-x86-libs.sh
@@ -127,7 +127,7 @@ done
 # Manually create additional symlinks that are useful to have.
 cd "${dir_tmp}"/bundle-libs/usr/lib/box64-x86_64-linux-gnu/
 ln -s libmbedcrypto.so.7 libmbedcrypto.so.3
-ln -s libmbedcrypto.so.14 libmbedcrypto.so.12
+ln -s libmbedtls.so.14 libmbedtls.so.12
 ln -s libmbedx509.so.1 libmbedx509.so.0
 
 # generate the bundle libraries archive

--- a/src/dynarec/la64/dynarec_la64_00.c
+++ b/src/dynarec/la64/dynarec_la64_00.c
@@ -2647,7 +2647,27 @@ uintptr_t dynarec64_00(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
                     if (tmp < 0 || (tmp & 15) > 1)
                         tmp = 0; // TODO: removed when FP is in place
                     if ((BOX64ENV(log) < 2 && !BOX64ENV(rolling_log)) && tmp) {
+                        int nret = tmp & 0xF;
+                        // Preserve caller-owned arg regs around the fast native wrapper call.
+                        ADDI_D(xSP, xSP, -64);
+                        ST_D(xRAX, xSP, 0);
+                        ST_D(xRDI, xSP, 8);
+                        ST_D(xRSI, xSP, 16);
+                        ST_D(xRDX, xSP, 24);
+                        ST_D(xRCX, xSP, 32);
+                        ST_D(xR8, xSP, 40);
+                        ST_D(xR9, xSP, 48);
                         call_n(dyn, ninst, (void*)(addr + 8), tmp);
+                        if (nret < 1)
+                            LD_D(xRAX, xSP, 0);
+                        LD_D(xRDI, xSP, 8);
+                        LD_D(xRSI, xSP, 16);
+                        if (nret < 2)
+                            LD_D(xRDX, xSP, 24);
+                        LD_D(xRCX, xSP, 32);
+                        LD_D(xR8, xSP, 40);
+                        LD_D(xR9, xSP, 48);
+                        ADDI_D(xSP, xSP, 64);
                         SMWRITE2();
                         addr += 8 + 8;
                     } else {


### PR DESCRIPTION
In the LA64 dynarec fast bridging path, the called `call_n()` function does not preserve the x64 caller's parameter register state.

For wrappers such as `pFp` (single GPR return), `A1` is always written back to `RDX`, and the call-overridden parameter registers (`RDI/RSI/RCX/R8/R9`) may leak into the emulated x64 state. This is semantically inconsistent with the slow path and can cause real workload crashes (e.g., `update-mime-database`, bus errors/SIGSEGV).

**Remediation:**

- In the fast path, save/restore the caller parameter registers around `call_n()`.

- Make the write-back operation of `RDX` dependent on `nret` (the count of the wrapper return register): only write `A1 -> RDX` if `nret > 1`; otherwise, restore the previous `RDX`.