### PR TITLE
[WRAPPER] Fix my_fegetround() to convert native rounding mode to x86 format

### DIFF
--- a/src/wrapped/wrappedlibm.c
+++ b/src/wrapped/wrappedlibm.c
@@ -113,6 +113,19 @@ static int round_to_native(int round) {
 }
 #define TO_NATIVE(R) round_to_native(R)
 
+static int round_from_native(int round) {
+    switch(round) {
+        case FE_TONEAREST:  return X64_FE_TONEAREST;
+        case FE_DOWNWARD:   return X64_FE_DOWNWARD;
+        case FE_UPWARD:     return X64_FE_UPWARD;
+        case FE_TOWARDZERO: return X64_FE_TOWARDZERO;
+        default:
+            //should warn
+            return round;
+    }
+}
+#define FROM_NATIVE(R) round_from_native(R)
+
 static int x86_to_native_excepts(int e) {
     int n = 0;
     if (e & 0x01) n |= FE_INVALID;
@@ -198,7 +211,7 @@ EXPORT int my_fegetround(x64emu_t* emu)
     if (BOX64ENV(sync_rounding)) {
         return emu->cw.x16 & 0xc00;
     } else {
-        return fegetround();
+        return FROM_NATIVE(fegetround());
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `round_from_native()` (inverse of existing `round_to_native()`) to convert native `FE_*` rounding constants back to x86 format (`0x0`/`0x400`/`0x800`/`0xc00`)
- Use it in `my_fegetround()` so emulated programs receive correct x86 rounding values when `sync_rounding` is off

## Problem

`my_fegetround()` returns the raw native `fegetround()` value without converting it to x86 rounding constants. On x86 hosts, native and x86 constants happen to be identical, masking the bug. On all other architectures (AArch64, RISC-V, LoongArch, PPC64LE), the native `FE_TONEAREST`/`FE_DOWNWARD`/`FE_UPWARD`/`FE_TOWARDZERO` values differ, so emulated programs calling `fegetround()` receive incorrect values.

The bug was introduced in commit 87bf751b1 (PR #1030) which correctly added `TO_NATIVE()` for the x86→native direction in `my_fesetround()`, but missed the reverse direction in `my_fegetround()`.

Fixes #3545