### PR TITLE
[DYNAREC] Replace hardcoded jmpnext trampoline size with per-arch JMPNEXT_SIZE macro

### DIFF
--- a/src/dynarec/dynarec_arch.h
+++ b/src/dynarec/dynarec_arch.h
@@ -39,6 +39,7 @@ extern void* create_updateflags();
 
 #define ARCH_NOP    0b11010101000000110010000000011111
 #define ARCH_UDF    0xcafe
+#define JMPNEXT_SIZE    (4*sizeof(void*))
 #elif defined(LA64)
 
 #define instruction_native_t        instruction_la64_t
@@ -69,6 +70,7 @@ extern void* create_updateflags();
 #define ARCH_UNALIGNED(A, B) 0
 extern uint32_t la64_crc(void* p, uint32_t len);
 #define ARCH_CRC(A, B)       return la64_crc(A, B)
+#define JMPNEXT_SIZE    (4*sizeof(void*))
 
 #elif defined(RV64)
 
@@ -101,6 +103,7 @@ extern uint32_t la64_crc(void* p, uint32_t len);
 #define ARCH_ADJUST(A, B, C, D) {}
 #define STOP_NATIVE_FLAGS(A, B) {}
 #define ARCH_UNALIGNED(A, B) arch_unaligned(A, B)
+#define JMPNEXT_SIZE    (4*sizeof(void*))
 #else
 #error Unsupported platform
 #endif


### PR DESCRIPTION
## Summary

- Add `JMPNEXT_SIZE` macro to each architecture's section in `dynarec_arch.h`, all defined as `(4*sizeof(void*))` for ARM64, LA64, and RV64
- Replace all 10 hardcoded `4*sizeof(void*)`, `3*sizeof(void*)`, and `2*sizeof(void*)` jmpnext references in `dynarec_native.c` with expressions using `JMPNEXT_SIZE`
- Update the block layout comment to reflect the variable-size jmpnext area

## Problem

The jmpnext trampoline area was hardcoded as 32 bytes (`4*sizeof(void*)`) in ~10 places across `dynarec_native.c`. This works for ARM64/LA64/RV64 which fit their jmpnext code in 2-3 instructions, but prevents architectures that need more instructions (e.g. PPC64LE needs 5 instructions due to lacking PC-relative load and direct branch-through-GPR).

## Approach

Pure refactoring — no functional change. For all three existing architectures, `JMPNEXT_SIZE` evaluates to `4*sizeof(void*)`, producing identical compiled output. The `arm64/updateflags_arm64.c` references are left as-is since they're ARM64-specific code.

Fixes #3544