### PR TITLE
Add per-thread native sigaltstack for internal signal handlers

### DIFF
--- a/src/include/signals.h
+++ b/src/include/signals.h
@@ -73,5 +73,6 @@ int my_syscall_rt_sigaction(x64emu_t* emu, int signum, const x64_sigaction_resto
 
 void init_signal_helper(box64context_t* context);
 void fini_signal_helper(void);
+void setupNativeAltStack(void);
 
 #endif //__SIGNALS_H__

--- a/src/libtools/signals.c
+++ b/src/libtools/signals.c
@@ -64,6 +64,51 @@ x64_stack_t* sigstack_getstack() {
     return (x64_stack_t*)pthread_getspecific(sigstack_key);
 }
 
+// Native alternate signal stack for box64's own signal handlers (SIGSEGV, etc.)
+// This ensures signals can be delivered even when the emulated program overflows its stack.
+static pthread_key_t native_altstack_key;
+static pthread_once_t native_altstack_key_once = PTHREAD_ONCE_INIT;
+
+static void native_altstack_destroy(void* p) {
+    if(p) {
+        // Disable the alt stack before freeing
+        stack_t disable = {0};
+        disable.ss_flags = SS_DISABLE;
+        sigaltstack(&disable, NULL);
+        box_free(p);
+    }
+}
+
+static void native_altstack_key_alloc() {
+    pthread_key_create(&native_altstack_key, native_altstack_destroy);
+}
+
+void setupNativeAltStack(void)
+{
+    pthread_once(&native_altstack_key_once, native_altstack_key_alloc);
+    // Check if this thread already has an alt stack set up
+    if(pthread_getspecific(native_altstack_key))
+        return;
+    // Use SIGSTKSZ or 64KB, whichever is larger, for the alt stack
+    size_t sz = (SIGSTKSZ > 65536) ? SIGSTKSZ : 65536;
+    void* mem = box_calloc(1, sz);
+    if(!mem) {
+        printf_log(LOG_INFO, "Warning: failed to allocate native signal alternate stack for thread %04d\n", GetTID());
+        return;
+    }
+    stack_t ss = {0};
+    ss.ss_sp = mem;
+    ss.ss_size = sz;
+    ss.ss_flags = 0;
+    if(sigaltstack(&ss, NULL) != 0) {
+        printf_log(LOG_INFO, "Warning: sigaltstack failed for thread %04d: %s\n", GetTID(), strerror(errno));
+        box_free(mem);
+        return;
+    }
+    pthread_setspecific(native_altstack_key, mem);
+    printf_log(LOG_DEBUG, "Native signal alt stack set up for thread %04d (%p, size=%zu)\n", GetTID(), mem, sz);
+}
+
 #ifndef DYNAREC
 dynablock_t* FindDynablockFromNativeAddress(void* addr) {return NULL;}
 uintptr_t getX64Address(dynablock_t* db, uintptr_t pc) {return 0;}
@@ -1680,17 +1725,19 @@ void init_signal_helper(box64context_t* context)
     for(int i=0; i<=MAX_SIGNAL; ++i) {
         context->signals[i] = 0;    // SIG_DFL
     }
+    // Set up native alternate signal stack for the main thread
+    setupNativeAltStack();
     struct sigaction action = {0};
-    action.sa_flags = SA_SIGINFO | SA_RESTART | SA_NODEFER;
+    action.sa_flags = SA_SIGINFO | SA_RESTART | SA_NODEFER | SA_ONSTACK;
     action.sa_sigaction = my_box64signalhandler;
     sigaction(SIGSEGV, &action, NULL);
-    action.sa_flags = SA_SIGINFO | SA_RESTART | SA_NODEFER;
+    action.sa_flags = SA_SIGINFO | SA_RESTART | SA_NODEFER | SA_ONSTACK;
     action.sa_sigaction = my_box64signalhandler;
     sigaction(SIGBUS, &action, NULL);
-    action.sa_flags = SA_SIGINFO | SA_RESTART | SA_NODEFER;
+    action.sa_flags = SA_SIGINFO | SA_RESTART | SA_NODEFER | SA_ONSTACK;
     action.sa_sigaction = my_box64signalhandler;
     sigaction(SIGILL, &action, NULL);
-    action.sa_flags = SA_SIGINFO | SA_RESTART | SA_NODEFER;
+    action.sa_flags = SA_SIGINFO | SA_RESTART | SA_NODEFER | SA_ONSTACK;
     action.sa_sigaction = my_box64signalhandler;
     sigaction(SIGABRT, &action, NULL);
 

--- a/src/libtools/threads.c
+++ b/src/libtools/threads.c
@@ -12,6 +12,7 @@
 #include "debug.h"
 #include "box64context.h"
 #include "threads.h"
+#include "signals.h"
 #include "emu/x64emu_private.h"
 #include "x64emu.h"
 #include "box64stack.h"
@@ -251,6 +252,8 @@ void thread_set_emu(x64emu_t* emu)
 	add_thread((void*)et->self, et);
 	#endif
 	pthread_setspecific(thread_key, et);
+	// Ensure this thread has a native signal alternate stack
+	setupNativeAltStack();
 }
 
 x64emu_t* thread_get_emu()
@@ -288,6 +291,9 @@ void thread_set_et(emuthread_t* et)
 	add_thread((void*)(et?et->self:pthread_self()), et);
 	#endif
 	pthread_setspecific(thread_key, et);
+	// Ensure this thread has a native signal alternate stack
+	if(et)
+		setupNativeAltStack();
 }
 
 static void* pthread_routine(void* p)
@@ -302,6 +308,8 @@ static void* pthread_routine(void* p)
 		}
 	}
 	pthread_setspecific(thread_key, p);
+	// setup native signal alternate stack for this thread
+	setupNativeAltStack();
 	// call the function
 	emuthread_t *et = (emuthread_t*)p;
 	et->emu->type = EMUTYPE_MAIN;


### PR DESCRIPTION
## Summary

- Allocate a native alternate signal stack (64KB or `SIGSTKSZ`, whichever is larger) per thread using `pthread_key_t` with destructor for automatic cleanup on thread exit
- Add `SA_ONSTACK` to the four internal signal handler registrations (`SIGSEGV`, `SIGBUS`, `SIGILL`, `SIGABRT`) so the kernel can deliver signals even when the native stack is exhausted
- Call `setupNativeAltStack()` from `init_signal_helper()` (main thread), `thread_set_emu()`, `thread_set_et()`, and `pthread_routine()` (spawned threads)

This is orthogonal to the emulated sigaltstack machinery that handles guest programs' own `sigaltstack`/`SA_ONSTACK` requests. Without this, if the native stack is exhausted (e.g., deep recursion in guest code), the kernel can't deliver signals to box64's internal handlers and just kills the process.

Fix #3552

## Files changed

- `src/libtools/signals.c` — `setupNativeAltStack()` implementation + `SA_ONSTACK` on handler registrations
- `src/include/signals.h` — `setupNativeAltStack()` declaration
- `src/libtools/threads.c` — calls to `setupNativeAltStack()` from thread entry points