### PR TITLE
[RV64_DYNAREC] Use SRLIW for 32-bit SF extraction in emit_cmp32_0

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_emit_tests.c
+++ b/src/dynarec/rv64/dynarec_rv64_emit_tests.c
@@ -269,7 +269,7 @@ void emit_cmp32_0(dynarec_rv64_t* dyn, int ninst, rex_t rex, uint8_t nextop, int
         if (rex.w) {
             SET_FLAGS_LTZ(s1, F_SF, s3, s4);
         } else {
-            SRLI(s3, s1, 31);
+            SRLIW(s3, s1, 31);
             SET_FLAGS_NEZ(s3, F_SF, s4);
         }
     }


### PR DESCRIPTION
SRLI on a 64-bit register with dirty upper 32 bits produces wrong SF. Unlike 8/16-bit paths where callers mask s1 beforehand, 32-bit callers pass raw registers. SRLIW correctly ignores the upper 32 bits.