### PR TITLE
[BOX32][WRAPPER] Enable __isoc99_vfscanf and __isoc99_vsscanf in wrapped libc

### DIFF
--- a/src/wrapped32/wrappedlibc_private.h
+++ b/src/wrapped32/wrappedlibc_private.h
@@ -916,10 +916,10 @@ GO2(__isoc99_fscanf, iEESpV, my32_fscanf)
 // __isoc99_scanf
 GOM(__isoc99_sscanf, iEEppV)  //%%
 GOM(__isoc99_swscanf, iEEppV)   //%%
-//GOM(__isoc99_vfscanf, iEEppp) //%%
+GOM(__isoc99_vfscanf, iEEppp) //%%
 // __isoc99_vfwscanf
 // __isoc99_vscanf
-//GOM(__isoc99_vsscanf, iEEppp) //%% TODO: check if ok
+GOM(__isoc99_vsscanf, iEEppp) //%%
 // __isoc99_vswscanf
 // __isoc99_vwscanf
 // __isoc99_wscanf


### PR DESCRIPTION
## Summary

- Uncomment `GOM(__isoc99_vfscanf, iEEppp)` and `GOM(__isoc99_vsscanf, iEEppp)` registrations in `src/wrapped32/wrappedlibc_private.h`

## Details

The implementations already exist as aliases in `wrappedlibc.c`:
- `my32___isoc99_vfscanf` → alias to `my32_vfscanf` (line 1088)
- `my32___isoc99_vsscanf` → alias to `my32_vsscanf` (line 1100)

The `__isoc23_vsscanf` variant using the same underlying function is already enabled (line 928).

Without these symbols registered, 32-bit binaries that depend on `__isoc99_vsscanf@GLIBC_2.7` (e.g. Grim Fandango Remastered's bundled SDL2) fail to resolve the symbol and exit immediately.

Fix #3568