### PR TITLE
Fix execl/execle/execlp varargs argument corruption

### DIFF
--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -2778,7 +2778,7 @@ EXPORT int32_t my_execl(x64emu_t* emu, const char* path)
     char* argv[cnt+1];
     memset(argv, 0, sizeof(argv));
     for(int i=0; i<cnt; ++i)
-        argv[i] = getVargN(emu, cnt+1);
+        argv[i] = getVargN(emu, i+1);
     return my_execv(emu, path, argv);
 }
 
@@ -2793,7 +2793,7 @@ EXPORT int32_t my_execle(x64emu_t* emu, const char* path)
     char* argv[cnt+1];
     memset(argv, 0, sizeof(argv));
     for(int i=0; i<cnt; ++i)
-        argv[i] = getVargN(emu, cnt+1);
+        argv[i] = getVargN(emu, i+1);
     return my_execve(emu, path, argv, envp);
 }
 
@@ -2806,7 +2806,7 @@ EXPORT int32_t my_execlp(x64emu_t* emu, const char* path)
     char* argv[cnt+1];
     memset(argv, 0, sizeof(argv));
     for(int i=0; i<cnt; ++i)
-        argv[i] = getVargN(emu, cnt+1);
+        argv[i] = getVargN(emu, i+1);
     return my_execvp(emu, path, argv);
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug where `my_execl()`, `my_execle()`, and `my_execlp()` always read the **last** vararg instead of each argument in sequence.

The argument-filling loop used `getVargN(emu, cnt+1)` (constant index — always the last arg before NULL) instead of `getVargN(emu, i+1)` (incrementing index — each arg in order). This corrupted the `argv` array passed to `execv`/`execve`/`execvp`.

**Before (broken):**
```c
for(int i=0; i<cnt; ++i)
    argv[i] = getVargN(emu, cnt+1);  // always reads last arg
```

**After (fixed):**
```c
for(int i=0; i<cnt; ++i)
    argv[i] = getVargN(emu, i+1);    // reads each arg in order
```

For example, `execl("./game", "-fullscreen", "-nosound", NULL)` would produce `argv = [NULL, NULL]` (reading past the args) instead of `argv = ["-fullscreen", "-nosound"]`.

Fixes #3542

## Test plan
- [ ] Compile on ARM64
- [ ] Test with an x64 binary that calls `execl()` to re-exec itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)