### PR TITLE
[WRAPPER] Fix g_type_module_register_type forgot to findFct other callbacks for my_GTypeInfo_t

### DIFF
--- a/src/include/gtkclass.h
+++ b/src/include/gtkclass.h
@@ -2424,7 +2424,6 @@ typedef struct my_GtkTypeInfo_s {
 my_GTypeValueTable_t* findFreeGTypeValueTable(my_GTypeValueTable_t* fcts);
 my_GTypeInfo_t* findFreeGTypeInfo(my_GTypeInfo_t* fcts, size_t parent);
 my_GtkTypeInfo_t* findFreeGtkTypeInfo(my_GtkTypeInfo_t* fcts, size_t parent);
-void* find_class_init_Fct(void* fct, size_t parent);
 // defined in wrappedgio2.c
 my_GDBusInterfaceVTable_t* findFreeGDBusInterfaceVTable(my_GDBusInterfaceVTable_t* fcts);
 

--- a/src/tools/gtkclass.c
+++ b/src/tools/gtkclass.c
@@ -5885,7 +5885,7 @@ static int my_class_init_##A(void* a, void* b)                              \
 }
 SUPER()
 #undef GO
-void* find_class_init_Fct(void* fct, size_t parent)
+static void* find_class_init_Fct(void* fct, size_t parent)
 {
     if(!fct) return fct;
     if(GetNativeFnc((uintptr_t)fct))  return GetNativeFnc((uintptr_t)fct);

--- a/src/wrapped/wrappedgobject2.c
+++ b/src/wrapped/wrappedgobject2.c
@@ -938,10 +938,7 @@ EXPORT void my_g_type_module_add_interface(x64emu_t* emu, my_GTypeModule_t* modu
 
 EXPORT size_t my_g_type_module_register_type(x64emu_t* emu, my_GTypeModule_t* module, size_t parent_type, char* type_name, my_GTypeInfo_t* type_info, uint32_t flags)
 {
-    if (type_info) {
-        type_info->class_init = find_class_init_Fct(type_info->class_init, parent_type);
-    }
-    return my->g_type_module_register_type(module, parent_type, type_name, type_info, flags);
+    return my->g_type_module_register_type(module, parent_type, type_name, findFreeGTypeInfo(type_info, parent_type), flags);
 }
 
 #define PRE_INIT \


### PR DESCRIPTION
Hi,

Fix g_type_module_register_type forgot to findFct other callbacks for my_GTypeInfo_t for https://github.com/ptitSeb/box64/commit/daeff6fc41f7c2e879d9d8d95b9b7a8530e3073a.

Testcase: [glib-2.58.3/tests/gobject/dynamictype](https://github.com/GNOME/glib/blob/2.58.3/tests/gobject/dynamictype.c) Passed.
make test Passed.

Please review my patch.

Thanks,
Leslie Zhai