### PR TITLE
[WRAPPERHELPER] Added an x86-specific inclusion specification file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ backup/
 /wrapperhelper/sanleak
 /wrapperhelper/sanundefined
 /wrapperhelper/src/machine.gen
+/wrapperhelper/src/machine_x86.gen
 /wrapperhelper/*.h
 !/wrapperhelper/example-libc.h
 

--- a/wrapperhelper/Makefile
+++ b/wrapperhelper/Makefile
@@ -233,14 +233,18 @@ $(eval $(call compile_wrapperhelper_c,,parse,parse))
 $(eval $(call compile_wrapperhelper_c,,prepare,prepare))
 $(eval $(call compile_wrapperhelper_c,,preproc,preproc))
 $(eval $(call compile_wrapperhelper_c,,vector,vector))
-$(call wrapperhelper_o,,machine,machine): src/machine.gen
+$(call wrapperhelper_o,,machine,machine) makedir/machine.mk: src/machine.gen src/machine_x86.gen
 $(call wrapperhelper_o,,generator,generator): CFLAGS+= -fno-analyzer # Too slow
 $(call wrapperhelper_o,,preproc,preproc): CFLAGS+= -fno-analyzer
 $(call wrapperhelper_o,,parse,parse): CFLAGS+= -fno-analyzer
 
+src/machine_x86.gen:
+	$(call colorize,96,GEN,33,Generating $@)
+	$(SILENCER)touch $@
+
 src/machine.gen:
 	$(call colorize,96,GEN,33,Generating $@)
-	$(SILENCER)echo | LC_ALL=C LANG=C $(CC) $(CPPFLAGS) -E -v - 2>&1 | sed ':l; $$ ! { N; b l }; s/.*#include <...> search starts here:\n//; s/End of search list.*//; s/^ /DO_PATH("/; s/\n /")\nDO_PATH("/g; s/\n$$/")/' >src/machine.gen
+	$(SILENCER)echo | LC_ALL=C LANG=C $(CC) $(CPPFLAGS) -E -v - 2>&1 | sed ':l; $$ ! { N; b l }; s/.*#include <...> search starts here:\n//; s/End of search list.*//; s/^ /DO_PATH("/; s/\n /")\nDO_PATH("/g; s/\n$$/")/' >$@
 
 #$(eval $(call compile_test_cxx,core/number))
 

--- a/wrapperhelper/README.md
+++ b/wrapperhelper/README.md
@@ -18,6 +18,8 @@ This project has been compiled and tested with `GCC 14.2.1 20240805` on an `x86_
 
 You may also use the `make clean` and `make distclean` commands to remove output files (`clean`) and directories (`distclean`).
 
+You may edit the `src/machine_x86.gen` file as you need. This file should be used to populate the `x86`-specific include paths.
+
 ## Usage
 
 To use the wrapper helper, run the following command in the folder containing this `README.md`:

--- a/wrapperhelper/src/machine.c
+++ b/wrapperhelper/src/machine.c
@@ -41,6 +41,7 @@ int init_machines(size_t npaths, const char *const *extra_include_path) {
 	
 	size_t paths_offset_post = 0;
 #define DO_PATH(_path) ++paths_offset_post;
+#include "machine_x86.gen"
 #include "machine.gen"
 #undef DO_PATH
 	
@@ -58,6 +59,7 @@ int init_machines(size_t npaths, const char *const *extra_include_path) {
 	machine_x86_64.unnamed_bitfield_aligns = 0;
 	INIT_PATHS
 #define DO_PATH ADD_PATH
+#include "machine_x86.gen"
 #include "machine.gen"
 #undef DO_PATH
 #undef CUR_MACHINE


### PR DESCRIPTION
This PR adds the `src/machine_x86.gen` file, which should be used to fill `x86`/`x86_64`-specific inclusion paths in a similar format as `src/machine.gen`. This file is included during path population.