### PR TITLE
[WRAPPERHELPER] Fixed x86-specific inclusion specification file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ backup/
 /wrapperhelper/sanundefined
 /wrapperhelper/src/machine.gen
 /wrapperhelper/src/machine_x86.gen
+/wrapperhelper/src/machine_x86_64.gen
 /wrapperhelper/*.h
 !/wrapperhelper/example-libc.h
 

--- a/wrapperhelper/Makefile
+++ b/wrapperhelper/Makefile
@@ -233,12 +233,13 @@ $(eval $(call compile_wrapperhelper_c,,parse,parse))
 $(eval $(call compile_wrapperhelper_c,,prepare,prepare))
 $(eval $(call compile_wrapperhelper_c,,preproc,preproc))
 $(eval $(call compile_wrapperhelper_c,,vector,vector))
-$(call wrapperhelper_o,,machine,machine) makedir/machine.mk: src/machine.gen src/machine_x86.gen
+$(call wrapperhelper_o,,machine,machine) makedir/machine.mk: src/machine.gen src/machine_x86.gen src/machine_x86_64.gen
+$(call wrapperhelper_o,,machine,machine): CFLAGS+= -Wno-unused-macros
 $(call wrapperhelper_o,,generator,generator): CFLAGS+= -fno-analyzer # Too slow
 $(call wrapperhelper_o,,preproc,preproc): CFLAGS+= -fno-analyzer
 $(call wrapperhelper_o,,parse,parse): CFLAGS+= -fno-analyzer
 
-src/machine_x86.gen:
+src/machine_x86.gen src/machine_x86_64.gen:
 	$(call colorize,96,GEN,33,Generating $@)
 	$(SILENCER)touch $@
 
@@ -261,9 +262,9 @@ all: wrapperhelper alltests
 clean:
 	$(call remove,$(OBJLIST))
 	$(call remove,bin/wrapperhelper)
-	$(call remove,$(TESTS:%=obj/$(OBJDIR)/tests/%.o))
-	$(call remove,$(TESTS:%=tests/%))
-	$(call remove,src/machine.gen)
+#	$(call remove,$(TESTS:%=obj/$(OBJDIR)/tests/%.o))
+#	$(call remove,$(TESTS:%=tests/%))
+	$(call remove,src/machine.gen src/machine_x86.gen src/machine_x86_64.gen)
 .PHONY: clean
 distclean:
 	$(call remove,makedir)

--- a/wrapperhelper/src/machine.c
+++ b/wrapperhelper/src/machine.c
@@ -41,7 +41,7 @@ int init_machines(size_t npaths, const char *const *extra_include_path) {
 	
 	size_t paths_offset_post = 0;
 #define DO_PATH(_path) ++paths_offset_post;
-#include "machine_x86.gen"
+#include "machine_x86_64.gen"
 #include "machine.gen"
 #undef DO_PATH
 	
@@ -59,11 +59,17 @@ int init_machines(size_t npaths, const char *const *extra_include_path) {
 	machine_x86_64.unnamed_bitfield_aligns = 0;
 	INIT_PATHS
 #define DO_PATH ADD_PATH
-#include "machine_x86.gen"
+#include "machine_x86_64.gen"
 #include "machine.gen"
 #undef DO_PATH
 #undef CUR_MACHINE
 	
+#define DO_PATH(_path) --paths_offset_post;
+#include "machine_x86_64.gen"
+#undef DO_PATH
+#define DO_PATH(_path) ++paths_offset_post;
+#include "machine_x86.gen"
+#undef DO_PATH
 #define CUR_MACHINE x86
 	machine_x86.size_long = 4;
 	machine_x86.align_longdouble = 4;
@@ -76,10 +82,14 @@ int init_machines(size_t npaths, const char *const *extra_include_path) {
 	machine_x86.unnamed_bitfield_aligns = 0;
 	INIT_PATHS
 #define DO_PATH ADD_PATH
+#include "machine_x86.gen"
 #include "machine.gen"
 #undef DO_PATH
 #undef CUR_MACHINE
 	
+#define DO_PATH(_path) --paths_offset_post;
+#include "machine_x86.gen"
+#undef DO_PATH
 #define CUR_MACHINE aarch64
 	machine_aarch64.size_long = 8;
 	machine_aarch64.align_longdouble = 16;


### PR DESCRIPTION
This PR fixes some issues with the last PR #3601 and adds a `machine_x86_64.gen` file for `x86_64`-specific includes.