### PR TITLE
[Fix] Crash caused by concurrent operation of the exit phase and worker threads (teardown lifecycle race)

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -688,6 +688,25 @@ void endBox64()
     // unload needed libs
     needed_libs_t* needed = my_context->elfs[0]->needed;
     printf_log(LOG_DEBUG, "Unloaded main elf: Will Dec RefCount of %d libs\n", needed?needed->size:0);
+    int workers = get_active_emu_workers();
+    if (workers > 0) {
+        const int sleep_us = 10000;   // 10ms
+        const int max_wait_ms = 2000; // 2s
+        int waited_ms = 0;
+
+        printf_log(LOG_INFO, "endBox64: waiting emu workers to exit (n=%d)\n", workers);
+        while ((workers = get_active_emu_workers()) > 0 && waited_ms < max_wait_ms) {
+            usleep(sleep_us);
+            waited_ms += sleep_us / 1000;
+        }
+
+        if (workers > 0) {
+            printf_log(LOG_INFO,
+                "endBox64: %d emu workers still alive after %dms, skip unload/free to avoid UAF crash\n",
+                workers, waited_ms);
+            return;
+        }
+    }
     if(needed)
         for(int i=0; i<needed->size; ++i)
             DecRefCount(&needed->libs[i], emu);

--- a/src/include/threads.h
+++ b/src/include/threads.h
@@ -4,7 +4,6 @@
 
 typedef struct box64context_s box64context_t;
 typedef struct x64emu_s x64emu_t;
-
 typedef struct emuthread_s {
 	uintptr_t 	fnc;
 	void*		arg;
@@ -16,7 +15,7 @@ typedef struct emuthread_s {
 	int			cancel_cap, cancel_size;
 	void**		cancels;
 } emuthread_t;
-
+int get_active_emu_workers(void);
 void CleanStackSize(box64context_t* context);
 
 void init_pthread_helper(void);

--- a/src/libtools/threads.c
+++ b/src/libtools/threads.c
@@ -34,7 +34,9 @@
 #include "box32.h"
 #include "threads32.h"
 #endif
+#include <stdatomic.h>
 
+static _Atomic int g_active_emu_workers = 0;
 //void _pthread_cleanup_push_defer(void* buffer, void* routine, void* arg);	// declare hidden functions
 //void _pthread_cleanup_pop_restore(void* buffer, int exec);
 typedef void (*vFppp_t)(void*, void*, void*);
@@ -218,6 +220,7 @@ static void emuthread_cancel(void* p)
 	box_free(et->cancels);
 	et->cancels=NULL;
 	et->cancel_size = et->cancel_cap = 0;
+	atomic_fetch_sub_explicit(&g_active_emu_workers, 1, memory_order_relaxed);
 }
 void thread_forget_emu()
 {
@@ -298,6 +301,7 @@ void thread_set_et(emuthread_t* et)
 
 static void* pthread_routine(void* p)
 {
+	atomic_fetch_add_explicit(&g_active_emu_workers, 1, memory_order_relaxed);
 	// free current emuthread if it exist
 	{
 		void* t = pthread_getspecific(thread_key);
@@ -333,8 +337,13 @@ static void* pthread_routine(void* p)
 	DynaRun(emu);
 	pthread_cleanup_pop(0);
 	void* ret = (void*)R_RAX;
+	atomic_fetch_sub_explicit(&g_active_emu_workers, 1, memory_order_relaxed);
 	//void* ret = (void*)RunFunctionWithEmu(et->emu, 0, et->fnc, 1, et->arg);
 	return ret;
+}
+
+	int get_active_emu_workers(void) {
+		return atomic_load_explicit(&g_active_emu_workers, memory_order_relaxed);
 }
 
 #ifdef NOALIGN


### PR DESCRIPTION
**Problem Background：**

During the Box64 exit phase, `endBox64()` performs cleanup and unloading logic.

When the simulated program (OpenBLAS) has background worker threads, the main thread may enter unloading/release before the worker is still executing, resulting in SIGSEGV/SIGBUS errors upon exit.

Essentially, the resource release occurs before the `emu_worker` thread's lifecycle ends.

**Solution:**

`threads.c`: Increase the active emu worker count (atomic counting).

Increment the count when a worker thread enters the execution path. Decrement the count upon normal return. Decrement the count when the cancel/cleanup path ends. Provide a query interface `get_active_emu_workers()`.

`core.c`: Check the number of active workers after `RunElfFini(...)`.

If worker > 0, wait for 2 seconds (polling).

If the count is not zero after the timeout, skip subsequent unload/free operations and return directly to avoid crashes.

**Minimal reproducible code:**

```
// repro_teardown_worker.c
#define _GNU_SOURCE
#include <pthread.h>
#include <stdatomic.h>
#include <stdint.h>
#include <stdio.h>
#include <unistd.h>

#ifndef WORKERS
#define WORKERS 64
#endif

static pthread_t g_tid[WORKERS];
static _Atomic int g_run = 1;

__attribute__((noinline))
static void hot_fn(uint64_t *x) {
    *x = (*x * 1664525u) + 1013904223u;
}

static void* worker(void* arg) {
    (void)arg;
    uint64_t x = 1;
    for (;;) {
        for (int i = 0; i < (1 << 20); ++i) {
            hot_fn(&x); 
        }
        if (!atomic_load_explicit(&g_run, memory_order_relaxed)) {
            break;
        }
    }
    return NULL;
}

__attribute__((constructor))
static void lib_init(void) {
    for (int i = 0; i < WORKERS; ++i) {
        pthread_create(&g_tid[i], NULL, worker, NULL);
    }
    fprintf(stderr, "[repro] ctor: started %d workers\n", WORKERS);
}

__attribute__((destructor))
static void lib_fini(void) {
    atomic_store_explicit(&g_run, 0, memory_order_relaxed);
    fprintf(stderr, "[repro] dtor: stop signaled (no join)\n");
}

// repro_teardown_main.c
#include <dlfcn.h>
#include <stdio.h>
#include <stdlib.h>

int main(void) {
    void* h = dlopen("./librepro_teardown_worker.so", RTLD_NOW | RTLD_GLOBAL);
    if (!h) {
        fprintf(stderr, "dlopen failed: %s\n", dlerror());
        return 1;
    }
    puts("ok");
    return 0;
}
```

** Output before modification:**

```
[BOX64] Using emulated ./librepro_teardown_worker.so
[repro] ctor: started 64 workers
ok
Bus error                  (core dumped) ./box64 ../repro_teardown_main

```

** Output (Modify):**
```
[BOX64] Using emulated ./librepro_teardown_worker.so
[repro] ctor: started 64 workers
ok
[BOX64] endBox64: waiting emu workers to exit (n=63)
[BOX64] endBox64: 64 emu workers still alive after 2000ms, skip unload/free to avoid UAF crash

```