### PR TITLE
Fix segfault when BOX64_VERSION env var is set (ftrace NULL dereference)

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -771,6 +771,7 @@ int initialize(int argc, const char **argv, char** env, x64emu_t** emulator, elf
     init_malloc_hook();
 #endif
     init_auxval(argc, argv, environ?environ:env);
+    ftrace = stderr;    // init early: BOX64_VERSION path below uses PrintfFtrace
     // analogue to QEMU_VERSION in qemu-user-mode emulation
     if(getenv("BOX64_VERSION")) {
         PrintBox64Version(0);


### PR DESCRIPTION
## Summary

Fix segfault when the `BOX64_VERSION` environment variable is set. The early-exit path in `initialize()` calls `PrintBox64Version(0)` → `PrintfFtrace()` before `ftrace` is initialized (still `NULL`), causing a NULL pointer dereference.

## Steps to Reproduce

```bash
export BOX64_VERSION=anything
box64 -v
# Segmentation fault (core dumped)

unset BOX64_VERSION
box64 -v
# box64 v0.4.1 ... (works fine)
```

## Root Cause

In `src/core.c`, the global `FILE* ftrace = NULL` is only assigned `stderr` on [line 801](https://github.com/ptitSeb/box64/blob/8ad838ecb7186dde4683967e54444cdf36ad84ec/src/core.c#L801), but the `getenv("BOX64_VERSION")` check on [line 775](https://github.com/ptitSeb/box64/blob/8ad838ecb7186dde4683967e54444cdf36ad84ec/src/core.c#L775) exits early via `PrintBox64Version(0)` → `PrintfFtrace()` which calls `fileno(ftrace)` with `ftrace = NULL` → **SIGSEGV**.

```
#0  __GI__IO_ftell (fp=0x0)   ← NULL FILE* dereference
#1  PrintfFtrace()
#2  PrintBox64Version()
#3  initialize()
```

## Fix

One-line addition: initialize `ftrace = stderr` before the `BOX64_VERSION` early-exit check. The later assignment on line 801 remains (idempotent, no side effects).

## How We Found This

We had `ENV BOX64_VERSION=v0.3.8` in a Dockerfile (intending to pin the git tag). This persisted as a runtime env var, causing box64 to segfault inside the container while the bare host (without the env var) worked fine. Took strace + GDB to trace it to the `ftrace = NULL` dereference.

## Environment

- **Platform**: aarch64 (Oracle Cloud Ampere A1, Neoverse-N1)
- **OS**: Ubuntu 24.04 (Docker container)
- **Box64**: `main` branch (v0.4.1, commit 8ad838e)
- **Build**: `-DARM_DYNAREC=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DADLINK=ON`