### PR TITLE
[PPC64LE_DYNAREC] Add stack and basic opcodes (PUSH/POP, NOP, XCHG, LEAVE)

### DIFF
--- a/src/dynarec/ppc64le/dynarec_ppc64le_00.c
+++ b/src/dynarec/ppc64le/dynarec_ppc64le_00.c
@@ -156,6 +156,11 @@ uintptr_t dynarec64_00(dynarec_ppc64le_t* dyn, uintptr_t addr, uintptr_t ip, int
                 MVxw(gd, x2);
             }
             break;
+        case 0xC9:
+            INST_NAME("LEAVE");
+            MVz(xRSP, xRBP);
+            POP1z(xRBP);
+            break;
 
         default:
             DEFAULT;


### PR DESCRIPTION
Related to https://github.com/ptitSeb/box64/issues/242

- Add NOP and XCHG EAX,Reg opcodes (0x90-0x97)
- Add PUSH reg and POP reg opcodes (0x50-0x5F)
- Add LEAVE opcode (0xC9)