### PR TITLE
[LA64_DYNAREC] fix COMISS/UCOMISS flags state handling

### DIFF
--- a/src/dynarec/la64/dynarec_la64_0f.c
+++ b/src/dynarec/la64/dynarec_la64_0f.c
@@ -417,7 +417,7 @@ uintptr_t dynarec64_0F(dynarec_la64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
             } else {
                 INST_NAME("UCOMISS Gx, Ex");
             }
-            SETFLAGS(X_ALL, SF_SET_DF, NAT_FLAGS_NOFUSION);
+            SETFLAGS(X_ALL, SF_SET, NAT_FLAGS_NOFUSION);
             nextop = F8;
             GETGX(d0, 0);
             GETEXSS(v0, 0, 0);


### PR DESCRIPTION
The reason for canceling DF is that using SF_SET_DF in the 0F 2E/2F path of LA64 dynarec causes single-precision SVD results from scipy.linalg to be incorrect. The corresponding double-precision COMISD/UCOMISD (66 0F 2E/2F) uses the immediate flags path (SF_SET), so it does not have the same problem.


Reproduce code:
You will need an x86 [Python](https://github.com/astral-sh/python-build-standalone/releases/download/20260303/cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-debug-full.tar.zst) program and the relevant packages (scipy && numpy) installed.
```python
#pip3 install numpy scipy
./box64 python3 - <<'PY'  import numpy as np
from scipy.linalg.lapack import sgesvd
A = np.array([[1.,2.,3.],[4.,5.,6.],[7.,8.,10.]], dtype=np.float32, order='F')
u, s, vt, info = sgesvd(A, compute_uv=1, full_matrices=1, overwrite_a=0)
print(s, info)
PY                                               

```

I suspect that arm64 also has a similar problem.[dynarec_arm64_0f.c](https://github.com/ptitSeb/box64/blob/main/src/dynarec/arm64/dynarec_arm64_0f.c#L571)