### PR TITLE
[WRAPPER] Fix dbus callback return type and format string bugs

### DIFF
--- a/src/wrapped/wrappeddbus.c
+++ b/src/wrapped/wrappeddbus.c
@@ -311,9 +311,9 @@ static void* findDBusObjectPathUnregisterFunctionFct(void* fct)
 // DBusObjectPathMessageFunction
 #define GO(A)   \
 static uintptr_t my_DBusObjectPathMessageFunction_fct_##A = 0;   \
-static void my_DBusObjectPathMessageFunction_##A(void* connection, void* message, void* data)     \
+static int my_DBusObjectPathMessageFunction_##A(void* connection, void* message, void* data)     \
 {                                       \
-    RunFunctionFmt(my_DBusObjectPathMessageFunction_fct_##A, "ppp", connection, message, data);\
+    return (int)RunFunctionFmt(my_DBusObjectPathMessageFunction_fct_##A, "ppp", connection, message, data);\
 }
 SUPER()
 #undef GO
@@ -359,7 +359,7 @@ static void* finddbus_internal_padFct(void* fct)
 static uintptr_t my_DBusNewConnectionFunction_fct_##A = 0;                      \
 static void my_DBusNewConnectionFunction_##A(void* a, void* b, void* c)         \
 {                                                                               \
-    RunFunctionFmt(my_DBusNewConnectionFunction_fct_##A, "pppp", a, b, c);  \
+    RunFunctionFmt(my_DBusNewConnectionFunction_fct_##A, "ppp", a, b, c);  \
 }
 SUPER()
 #undef GO

--- a/src/wrapped32/wrappeddbus.c
+++ b/src/wrapped32/wrappeddbus.c
@@ -316,9 +316,9 @@ static void* findDBusObjectPathUnregisterFunctionFct(void* fct)
 // DBusObjectPathMessageFunction
 #define GO(A)   \
 static uintptr_t my_DBusObjectPathMessageFunction_fct_##A = 0;   \
-static void my_DBusObjectPathMessageFunction_##A(void* connection, void* message, void* data)     \
+static int my_DBusObjectPathMessageFunction_##A(void* connection, void* message, void* data)     \
 {                                       \
-    RunFunctionFmt(my_DBusObjectPathMessageFunction_fct_##A, "ppp", connection, message, data);\
+    return (int)RunFunctionFmt(my_DBusObjectPathMessageFunction_fct_##A, "ppp", connection, message, data);\
 }
 SUPER()
 #undef GO
@@ -364,7 +364,7 @@ static void* finddbus_internal_padFct(void* fct)
 static uintptr_t my_DBusNewConnectionFunction_fct_##A = 0;                      \
 static void my_DBusNewConnectionFunction_##A(void* a, void* b, void* c)         \
 {                                                                               \
-    RunFunctionFmt(my_DBusNewConnectionFunction_fct_##A, "pppp", a, b, c);  \
+    RunFunctionFmt(my_DBusNewConnectionFunction_fct_##A, "ppp", a, b, c);  \
 }
 SUPER()
 #undef GO


### PR DESCRIPTION
## Summary
- Fix `DBusObjectPathMessageFunction` callback bridge returning `void` instead of `DBusHandlerResult` (int). The native dbus library reads the return register to determine message handling disposition (`DBUS_HANDLER_RESULT_HANDLED`, `NOT_YET_HANDLED`, etc.), so returning void causes indeterminate behavior.
- Fix `DBusNewConnectionFunction` `RunFunctionFmt` format string using `"pppp"` (4 args) when only 3 arguments are passed. Correct signature is `void (*)(DBusServer*, DBusConnection*, void*)` — 3 pointer args.
- Both fixes applied to `src/wrapped/wrappeddbus.c` and `src/wrapped32/wrappeddbus.c`.

Verified callback signatures against [dbus API docs](https://dbus.freedesktop.org/doc/api/html/dbus-connection_8h_source.html):
- `DBusObjectPathMessageFunction` returns `DBusHandlerResult` (line 380)
- `DBusNewConnectionFunction` takes 3 params (server, new_connection, data)

Should help #3632

## AI Disclosure
AI (Claude) was used to assist with identifying the callback signature mismatches and generating the wrapper corrections, per CONTRIBUTING.md guidelines for wrapper callback handling. All changes were manually reviewed and verified against the dbus API documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)