### PR TITLE
Fix box64 -t for systems with page sizes larger than 4K

### DIFF
--- a/src/test.c
+++ b/src/test.c
@@ -297,7 +297,7 @@ static void loadTest(const char** filepath, const char* include_path)
     }
 
     close(mkstemp(binname));
-    const char* ld_cmd[] = { X86_64_LD, objname, "-Ttext=0x10000", "-w", "-m", box64_is32bits ? "elf_i386" : "elf_x86_64", "-o", binname, NULL };
+    const char* ld_cmd[] = { X86_64_LD, objname, "-Ttext=0x10000", "-n", "-w", "-m", box64_is32bits ? "elf_i386" : "elf_x86_64", "-o", binname, NULL };
 
     fork_result = fork();
     if (fork_result == 0) {
@@ -348,7 +348,7 @@ int unittest(int argc, const char** argv)
         include_path = argv[4];
     }
 
-    box64_pagesize = 4096;
+    box64_pagesize = sysconf(_SC_PAGESIZE);
     LoadEnvVariables();
     InitializeSystemInfo();
     ftrace = stdout;


### PR DESCRIPTION
This fixes GitHub issue #3621 by addressing two problems:

1. Add `-n` flag to linker command to prevent creation of separate LOAD segment for ELF headers at `0xf000`, which isn't aligned to larger page boundaries (16K, 64K)

2. Use `sysconf(_SC_PAGESIZE)` instead of hardcoded 4096 to get actual host page size

Tested on:
- PPC64LE with 64K pages: eliminates 'error=22/Invalid argument' failure
- ARM64 with 4K and 16K pages: eliminates 'Warning: cannot create memory map' message
