### PR TITLE
Fix ALSA callback copy-paste bugs in find* lookup functions

### DIFF
--- a/src/wrapped/wrappedlibasound.c
+++ b/src/wrapped/wrappedlibasound.c
@@ -102,7 +102,7 @@ static void* findPCMHookFct(void* fct)
 {
     if(!fct) return fct;
     if(GetNativeFnc((uintptr_t)fct))  return GetNativeFnc((uintptr_t)fct);
-    #define GO(A) if(my_pcm_hook_fct_##A == (uintptr_t)fct) return my_elem_##A;
+    #define GO(A) if(my_pcm_hook_fct_##A == (uintptr_t)fct) return my_pcm_hook_##A;
     SUPER()
     #undef GO
     #define GO(A) if(my_pcm_hook_fct_##A == 0) {my_pcm_hook_fct_##A = (uintptr_t)fct; return my_pcm_hook_##A; }
@@ -114,9 +114,9 @@ static void* findPCMHookFct(void* fct)
 //  snd_mixer_compare_t
 #define GO(A)   \
 static uintptr_t my_mixer_compare_fct_##A = 0;                       \
-static int my_mixer_compare_##A(void* a)                             \
+static int my_mixer_compare_##A(void* a, void* b)                    \
 {                                                               \
-    return (int)RunFunctionFmt(my_mixer_compare_fct_##A, "p", a);    \
+    return (int)RunFunctionFmt(my_mixer_compare_fct_##A, "pp", a, b); \
 }
 SUPER()
 #undef GO
@@ -124,7 +124,7 @@ static void* findMixerCompareFct(void* fct)
 {
     if(!fct) return fct;
     if(GetNativeFnc((uintptr_t)fct))  return GetNativeFnc((uintptr_t)fct);
-    #define GO(A) if(my_mixer_compare_fct_##A == (uintptr_t)fct) return my_elem_##A;
+    #define GO(A) if(my_mixer_compare_fct_##A == (uintptr_t)fct) return my_mixer_compare_##A;
     SUPER()
     #undef GO
     #define GO(A) if(my_mixer_compare_fct_##A == 0) {my_mixer_compare_fct_##A = (uintptr_t)fct; return my_mixer_compare_##A; }
@@ -146,7 +146,7 @@ static void* findPrivateFreeFct(void* fct)
 {
     if(!fct) return fct;
     if(GetNativeFnc((uintptr_t)fct))  return GetNativeFnc((uintptr_t)fct);
-    #define GO(A) if(my_private_free_fct_##A == (uintptr_t)fct) return my_elem_##A;
+    #define GO(A) if(my_private_free_fct_##A == (uintptr_t)fct) return my_private_free_##A;
     SUPER()
     #undef GO
     #define GO(A) if(my_private_free_fct_##A == 0) {my_private_free_fct_##A = (uintptr_t)fct; return my_private_free_##A; }
@@ -168,7 +168,7 @@ static void* findMixerEventFct(void* fct)
 {
     if(!fct) return fct;
     if(GetNativeFnc((uintptr_t)fct))  return GetNativeFnc((uintptr_t)fct);
-    #define GO(A) if(my_mixer_event_fct_##A == (uintptr_t)fct) return my_elem_##A;
+    #define GO(A) if(my_mixer_event_fct_##A == (uintptr_t)fct) return my_mixer_event_##A;
     SUPER()
     #undef GO
     #define GO(A) if(my_mixer_event_fct_##A == 0) {my_mixer_event_fct_##A = (uintptr_t)fct; return my_mixer_event_##A; }

--- a/src/wrapped32/wrappedlibasound.c
+++ b/src/wrapped32/wrappedlibasound.c
@@ -111,7 +111,7 @@ static void* findPCMHookFct(void* fct)
 {
     if(!fct) return fct;
     if(GetNativeFnc((uintptr_t)fct))  return GetNativeFnc((uintptr_t)fct);
-    #define GO(A) if(my32_pcm_hook_fct_##A == (uintptr_t)fct) return my32_elem_##A;
+    #define GO(A) if(my32_pcm_hook_fct_##A == (uintptr_t)fct) return my32_pcm_hook_##A;
     SUPER()
     #undef GO
     #define GO(A) if(my32_pcm_hook_fct_##A == 0) {my32_pcm_hook_fct_##A = (uintptr_t)fct; return my32_pcm_hook_##A; }
@@ -123,9 +123,9 @@ static void* findPCMHookFct(void* fct)
 //  snd_mixer_compare_t
 #define GO(A)   \
 static uintptr_t my32_mixer_compare_fct_##A = 0;                       \
-static int my32_mixer_compare_##A(void* a)                             \
+static int my32_mixer_compare_##A(void* a, void* b)                    \
 {                                                               \
-    return (int)RunFunctionFmt(my32_mixer_compare_fct_##A, "p", a);    \
+    return (int)RunFunctionFmt(my32_mixer_compare_fct_##A, "pp", a, b); \
 }
 SUPER()
 #undef GO
@@ -133,7 +133,7 @@ static void* findMixerCompareFct(void* fct)
 {
     if(!fct) return fct;
     if(GetNativeFnc((uintptr_t)fct))  return GetNativeFnc((uintptr_t)fct);
-    #define GO(A) if(my32_mixer_compare_fct_##A == (uintptr_t)fct) return my32_elem_##A;
+    #define GO(A) if(my32_mixer_compare_fct_##A == (uintptr_t)fct) return my32_mixer_compare_##A;
     SUPER()
     #undef GO
     #define GO(A) if(my32_mixer_compare_fct_##A == 0) {my32_mixer_compare_fct_##A = (uintptr_t)fct; return my32_mixer_compare_##A; }
@@ -155,7 +155,7 @@ static void* findPrivateFreeFct(void* fct)
 {
     if(!fct) return fct;
     if(GetNativeFnc((uintptr_t)fct))  return GetNativeFnc((uintptr_t)fct);
-    #define GO(A) if(my32_private_free_fct_##A == (uintptr_t)fct) return my32_elem_##A;
+    #define GO(A) if(my32_private_free_fct_##A == (uintptr_t)fct) return my32_private_free_##A;
     SUPER()
     #undef GO
     #define GO(A) if(my32_private_free_fct_##A == 0) {my32_private_free_fct_##A = (uintptr_t)fct; return my32_private_free_##A; }
@@ -177,7 +177,7 @@ static void* findMixerEventFct(void* fct)
 {
     if(!fct) return fct;
     if(GetNativeFnc((uintptr_t)fct))  return GetNativeFnc((uintptr_t)fct);
-    #define GO(A) if(my32_mixer_event_fct_##A == (uintptr_t)fct) return my32_elem_##A;
+    #define GO(A) if(my32_mixer_event_fct_##A == (uintptr_t)fct) return my32_mixer_event_##A;
     SUPER()
     #undef GO
     #define GO(A) if(my32_mixer_event_fct_##A == 0) {my32_mixer_event_fct_##A = (uintptr_t)fct; return my32_mixer_event_##A; }


### PR DESCRIPTION
## Summary

- **4 copy-paste bugs** in `findPCMHookFct`, `findMixerCompareFct`, `findPrivateFreeFct`, `findMixerEventFct`: the "already registered" check (`#define GO(A) if(my_xxx_fct_##A == (uintptr_t)fct) return ...`) incorrectly returns `my_elem_##A` / `my32_elem_##A` instead of their own bridge function. This means re-registering the same x86 callback pointer returns the `snd_mixer_elem_callback_t` bridge instead of the correct one.

- **1 missing argument** in `snd_mixer_compare_t` bridge: takes 1 arg but `snd_mixer_compare_t` is `int (*)(const snd_mixer_elem_t*, const snd_mixer_elem_t*)` — needs 2 args. Fixed bridge signature and format string from `"p"` to `"pp"`.

- Same 5 bugs fixed in both `src/wrapped/wrappedlibasound.c` and `src/wrapped32/wrappedlibasound.c` (**10 fixes total**).

## Bug class

Same copy-paste pattern found in the dbus fix (#3634). The `findXxxFct` functions were cloned from `findElemFct` but the first `#define GO` lookup was never updated to return the new bridge.

## Verification

- `snd_mixer_compare_t` signature confirmed against ALSA API docs: `int (*snd_mixer_compare_t)(const snd_mixer_elem_t *e1, const snd_mixer_elem_t *e2)`
- No `_private.h` changes, so no `rebuild_wrappers.py` needed
- Each find* function's two `#define GO` macros now consistently use the same bridge name

## AI Disclosure

Assisted by AI (Claude) for wrapper callback bug identification and fix. Every line reviewed and verified by contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)