### PR TITLE
 [PPC64LE_DYNAREC] Fix SCRATCH_USAGE placement for MOV opcodes (0xC6, 0xC7)

### DIFF
--- a/src/dynarec/ppc64le/dynarec_ppc64le_00.c
+++ b/src/dynarec/ppc64le/dynarec_ppc64le_00.c
@@ -327,7 +327,6 @@ uintptr_t dynarec64_00(dynarec_ppc64le_t* dyn, uintptr_t addr, uintptr_t ip, int
             INST_NAME("MOV Eb, Ib");
             nextop = F8;
             if (MODREG) { // reg <= u8
-                SCRATCH_USAGE(1);
                 u8 = F8;
                 if (!rex.rex) {
                     ed = (nextop & 7);


### PR DESCRIPTION
- Remove unnecessary `SCRATCH_USAGE(1)` from the `MODREG` (register) path of opcode 0xC6 (MOV Eb, Ib), since scratch register `x3` is only needed alongside `geted()` in the memory path