### PR TITLE
[WOW64] Fixed build on my machine

### DIFF
--- a/wine/ntdll.def
+++ b/wine/ntdll.def
@@ -1214,7 +1214,7 @@ EXPORTS
   _splitpath @1208
   _splitpath_s @1209
   _strcmpi=_stricmp @1210
-  _stricmp @1211
+  ; _stricmp @1211
   _strlwr @1212
   _strlwr_s @1213
   _strnicmp @1214


### PR DESCRIPTION
I had this error:

```
ld.lld: error: duplicate symbol: _stricmp
>>> defined at /home/ksco/Dev/box64/wine/common/crt.c:133
>>>            objects.a(crt.c.obj)
>>> defined at ntdll.a(ntdll.dll)
```