### PR TITLE
[WRAPPERHELPER] Added support for versioned symbols (libpthread) and other minor features

### DIFF
--- a/wrapperhelper/Makefile
+++ b/wrapperhelper/Makefile
@@ -170,7 +170,7 @@ define add_deptree =
 makedir/$(2).mk: | $$$$(@D)
 	$(call colorize,95,DEP,33,Creating $(3) dependancies)
 	$(SILENCER)set -e; $(1) -MM src/$(3) \
-	 | sed 's,\($$(notdir $$(basename $(3)))\)\.o[ :]*,$$(dir obj/$(OBJDIR)/$(3))\1.o: $$@'"\n"'$$(dir obj/$(OBJDIR)/$(3))\1.o $$@: ,g' >$$@
+	 | sed 's,\($$(notdir $$(basename $(3)))\)\.o[ :]*,$$(dir obj/$(OBJDIR)/$(3))\1.o: $$@'"\n"'$$(dir obj/$(OBJDIR)/$(3))\1.o $$@: ,g; s,src/machine.gen,,g' >$$@
 include makedir/$(2).mk
 endef
 endif
@@ -233,7 +233,6 @@ $(eval $(call compile_wrapperhelper_c,,parse,parse))
 $(eval $(call compile_wrapperhelper_c,,prepare,prepare))
 $(eval $(call compile_wrapperhelper_c,,preproc,preproc))
 $(eval $(call compile_wrapperhelper_c,,vector,vector))
-$(call wrapperhelper_o,,machine,machine) makedir/machine.mk: src/machine.gen src/machine_x86.gen src/machine_x86_64.gen
 $(call wrapperhelper_o,,machine,machine): CFLAGS+= -Wno-unused-macros
 $(call wrapperhelper_o,,generator,generator): CFLAGS+= -fno-analyzer # Too slow
 $(call wrapperhelper_o,,preproc,preproc): CFLAGS+= -fno-analyzer
@@ -246,6 +245,9 @@ src/machine_x86.gen src/machine_x86_64.gen:
 src/machine.gen:
 	$(call colorize,96,GEN,33,Generating $@)
 	$(SILENCER)echo | LC_ALL=C LANG=C $(CC) $(CPPFLAGS) -E -v - 2>&1 | sed ':l; $$ ! { N; b l }; s/.*#include <...> search starts here:\n//; s/End of search list.*//; s/^ /DO_PATH("/; s/\n /")\nDO_PATH("/g; s/\n$$/")/' >$@
+# Always rebuild this file, since system updates may break search paths
+.PHONY: src/machine.gen
+$(call wrapperhelper_o,,machine,machine): src/machine.gen
 
 #$(eval $(call compile_test_cxx,core/number))
 

--- a/wrapperhelper/src/generator.c
+++ b/wrapperhelper/src/generator.c
@@ -24,10 +24,12 @@ void request_print(const request_t *req) {
 	case RQT_FUN_MY:
 	case RQT_FUN_D:
 		if (req->def.fun.typ) {
-			printf(" function%s%s %s%s%s",
+			printf(" function%s%s %s%s%s%s%s",
 				rft2str[req->def.rty],
 				req->def.fun.needs_S ? " (with S)" : "",
 				string_content(req->def.fun.typ),
+				req->sym_ver ? "@" : "",
+				req->sym_ver ? string_content(req->sym_ver) : "",
 				req->def.fun.fun2 ? " -> " : "",
 				req->def.fun.fun2 ? string_content(req->def.fun.fun2) : "");
 		} else {
@@ -52,10 +54,12 @@ void request_print(const request_t *req) {
 		case RQT_FUN_MY:
 		case RQT_FUN_D:
 			if (req->val.fun.typ) {
-				printf(" function%s%s %s%s%s",
+				printf(" function%s%s %s%s%s%s%s",
 					rft2str[req->val.rty],
 					req->val.fun.needs_S ? " (with S)" : "",
 					string_content(req->val.fun.typ),
+					req->sym_ver ? "@" : "",
+					req->sym_ver ? string_content(req->sym_ver) : "",
 					req->val.fun.fun2 ? " -> " : "",
 					req->val.fun.fun2 ? string_content(req->val.fun.fun2) : "");
 			} else {
@@ -110,8 +114,10 @@ void request_print_check(const request_t *req) {
 			       && !strcmp(string_content(req->def.fun.typ) + 2, string_content(req->val.fun.typ) + 3);
 		}
 		if (!similar) {
-			printf("%s%s: function with %s%sdefault%s%s%s%s%s%s and dissimilar %ssolved%s%s%s%s%s%s\n",
+			printf("%s%s%s%s: function with %s%sdefault%s%s%s%s%s%s and dissimilar %ssolved%s%s%s%s%s%s\n",
 				string_content(req->obj_name),
+				req->sym_ver ? "@" : "",
+				req->sym_ver ? string_content(req->sym_ver) : "",
 				req->weak ? " (weak)" : "",
 				req->default_comment ? "commented " : "",
 				req->def.fun.typ ? "" : "untyped ",
@@ -170,6 +176,7 @@ void references_print_check(const VECTOR(references) *refs) {
 
 static void request_del(request_t *req) {
 	string_del(req->obj_name);
+	if (req->sym_ver) string_del(req->sym_ver);
 	switch (req->def.rty) {
 	case RQT_FUN:    if (req->def.fun.typ) string_del(req->def.fun.typ);                                                       break;
 	case RQT_FUN_2:  if (req->def.fun.typ) string_del(req->def.fun.typ); if (req->def.fun.fun2) string_del(req->def.fun.fun2); break;
@@ -230,18 +237,22 @@ static void request_output(FILE *f, const request_t *req) {
 	if (!req->has_val) {
 		if (IS_RQT_FUNCTION(req->def.rty)) {
 			if (!req->def.fun.typ) {
-				fprintf(f, "//GO%s%s%s(%s, \n",
+				fprintf(f, "//GO%s%s%s(%s%s%s, \n",
 					req->weak ? "W" : "",
 					req->def.fun.needs_S ? "S" : "",
 					rqt_suffix[req->def.rty],
-					string_content(req->obj_name));
+					string_content(req->obj_name),
+					req->sym_ver ? "@" : "",
+					req->sym_ver ? string_content(req->sym_ver) : "");
 			} else {
-				fprintf(f, "%sGO%s%s%s(%s, %s%s%s%s%s)%s\n",
+				fprintf(f, "%sGO%s%s%s(%s%s%s, %s%s%s%s%s)%s\n",
 					req->default_comment ? "//" : "",
 					req->weak ? "W" : "",
 					req->def.fun.needs_S ? "S" : "",
 					rqt_suffix[req->def.rty],
 					string_content(req->obj_name),
+					req->sym_ver ? "@" : "",
+					req->sym_ver ? string_content(req->sym_ver) : "",
 					valid_reqtype(req->def.fun.typ) ? "" : "\"",
 					string_content(req->def.fun.typ),
 					valid_reqtype(req->def.fun.typ) ? "" : "\"",
@@ -270,12 +281,14 @@ static void request_output(FILE *f, const request_t *req) {
 			int is_comment =
 				(IS_RQT_FUNCTION(req->def.rty) && req->def.fun.typ && !req->default_comment)
 				  ? (req->val.rty != req->def.rty) : (req->val.rty != RQT_FUN);
-			fprintf(f, "%sGO%s%s%s(%s, %s%s%s)\n",
+			fprintf(f, "%sGO%s%s%s(%s%s%s, %s%s%s)\n",
 				is_comment ? "//" : "",
 				req->weak ? "W" : "",
 				req->val.fun.needs_S ? "S" : "",
 				rqt_suffix[req->val.rty],
 				string_content(req->obj_name),
+				req->sym_ver ? "@" : "",
+				req->sym_ver ? string_content(req->sym_ver) : "",
 				string_content(req->val.fun.typ),
 				IS_RQT_FUN2(req->val.rty) ? ", " : "",
 				IS_RQT_FUN2(req->val.rty) ? req->val.fun.fun2 ? string_content(req->val.fun.fun2) : "<error: no val>" : "");
@@ -503,6 +516,7 @@ VECTOR(references) *references_from_file(const char *filename, FILE *f) {
 				.has_val = 0,
 				.ignored = 0,
 				.obj_name = NULL,
+				.sym_ver = NULL,
 				.weak = isweak,
 				.def = {
 					.rty =
@@ -532,13 +546,17 @@ VECTOR(references) *references_from_file(const char *filename, FILE *f) {
 			req.obj_name = tok.tokv.str;
 			// Token moved
 			tok = pre_next_token(prep, 0);
-			if ((tok.tokt != PPTOK_SYM) || (tok.tokv.sym != SYM_COMMA)) {
+			if (tok.tokt == PPTOK_AT_SYM) {
+				// Empty destructor
+				tok = pre_next_string_token_comma(prep);
+				req.sym_ver = tok.tokv.str;
+			} else if ((tok.tokt != PPTOK_SYM) || (tok.tokv.sym != SYM_COMMA)) {
 				log_error(&tok.loginfo, "invalid reference file: invalid GO line %d (comma)\n", lineno);
 				string_del(req.obj_name);
 				preproc_token_del(&tok);
 				goto failed;
 			}
-			// Empty destructor
+			// Empty destructor or token moved
 			tok = pre_next_token(prep, 0);
 			if ((tok.tokt == PPTOK_IDENT) || (tok.tokt == PPTOK_STRING)) {
 				req.def.fun.typ = (tok.tokt == PPTOK_STRING) ? tok.tokv.sstr : tok.tokv.str;
@@ -728,10 +746,10 @@ success:
 // Simple versions (in practice, only use x86_64 and aarch64 as emu/target pair)
 static int is_simple_type_ptr_to_simple(type_t *typ, int *needs_D, int *needs_my, khash_t(conv_map) *conv_map) {
 	if (typ->converted) {
-		// printf("Warning: %s uses a converted type but is not the converted type\n", string_content(obj_name));
+		// log_warning_nopos("%s uses a converted type but is not the converted type\n", string_content(obj_name));
 		*needs_my = 1;
 	} else if (kh_get(conv_map, conv_map, typ) != kh_end(conv_map)) {
-		// printf("Warning: %s uses a converted type but is not the converted type\n", string_content(obj_name));
+		// log_warning_nopos("%s uses a converted type but is not the converted type\n", string_content(obj_name));
 		*needs_my = 1;
 	}
 	switch (typ->typ) {
@@ -762,16 +780,16 @@ static int is_simple_type_ptr_to_simple(type_t *typ, int *needs_D, int *needs_my
 		*needs_my = 1;
 		return 1;
 	default:
-		printf("Error: is_simple_type_ptr_to_simple on unknown type %u\n", typ->typ);
+		log_error_nopos("is_simple_type_ptr_to_simple on unknown type %u\n", typ->typ);
 		return 0;
 	}
 }
 static int is_simple_type_simple(type_t *typ, int *needs_D, int *needs_my, khash_t(conv_map) *conv_map) {
 	if (typ->converted) {
-		// printf("Warning: %s uses a converted type but is not the converted type\n", string_content(obj_name));
+		// log_warning_nopos("%s uses a converted type but is not the converted type\n", string_content(obj_name));
 		*needs_my = 1;
 	} else if (kh_get(conv_map, conv_map, typ) != kh_end(conv_map)) {
-		// printf("Warning: %s uses a converted type but is not the converted type\n", string_content(obj_name));
+		// log_warning_nopos("%s uses a converted type but is not the converted type\n", string_content(obj_name));
 		*needs_my = 1;
 	}
 	switch (typ->typ) {
@@ -805,7 +823,7 @@ static int is_simple_type_simple(type_t *typ, int *needs_D, int *needs_my, khash
 		// Functions should be handled differently (GO instead of DATA)
 		return 0;
 	default:
-		printf("Error: is_simple_type_simple on unknown type %u\n", typ->typ);
+		log_error_nopos("is_simple_type_simple on unknown type %u\n", typ->typ);
 		return 0;
 	}
 }
@@ -814,7 +832,7 @@ static int convert_type_simple(string_t *dest, type_t *emu_typ, type_t *target_t
                                int is_ret, int *needs_D, int *needs_my, khash_t(conv_map) *conv_map, string_t *obj_name) {
 	if (emu_typ->converted) {
 		if (!string_add_string(dest, emu_typ->converted)) {
-			printf("Error: failed to add explicit type conversion\n");
+			log_error_nopos("failed to add explicit type conversion\n");
 			return 0;
 		}
 		return 1;
@@ -822,17 +840,17 @@ static int convert_type_simple(string_t *dest, type_t *emu_typ, type_t *target_t
 	khiter_t it = kh_get(conv_map, conv_map, emu_typ);
 	if (it != kh_end(conv_map)) {
 		if (!string_add_string(dest, kh_val(conv_map, it))) {
-			printf("Error: failed to add explicit type conversion\n");
+			log_error_nopos("failed to add explicit type conversion\n");
 			return 0;
 		}
 		return 1;
 	}
 	if ((emu_typ->is_atomic) || (target_typ->is_atomic)) {
-		printf("Error: TODO: convert_type_simple for atomic types\n");
+		log_TODO_nopos("convert_type_simple for atomic types\n");
 		return 0;
 	}
 	if (emu_typ->typ != target_typ->typ) {
-		printf("Error: %s: %s type is different between emulated and target\n", string_content(obj_name), is_ret ? "return" : "argument");
+		log_error_nopos("%s: %s type is different between emulated and target\n", string_content(obj_name), is_ret ? "return" : "argument");
 		*needs_my = 1;
 	}
 	switch (emu_typ->typ) {
@@ -877,48 +895,48 @@ static int convert_type_simple(string_t *dest, type_t *emu_typ, type_t *target_t
 		case BTT_LONGDOUBLE: *needs_D = 1; has_char = 1; c = 'D'; break;
 		case BTT_CLONGDOUBLE: *needs_D = 1; has_char = 1; c = 'Y'; break;
 		case BTT_ILONGDOUBLE: *needs_D = 1; has_char = 1; c = 'D'; break;
-		case BTT_FLOAT128: printf("Error: TODO: %s\n", builtin2str[emu_typ->val.builtin]); return 0;
-		case BTT_CFLOAT128: printf("Error: TODO: %s\n", builtin2str[emu_typ->val.builtin]); return 0;
-		case BTT_IFLOAT128: printf("Error: TODO: %s\n", builtin2str[emu_typ->val.builtin]); return 0;
+		case BTT_FLOAT128: log_TODO_nopos("%s\n", builtin2str[emu_typ->val.builtin]); return 0;
+		case BTT_CFLOAT128: log_TODO_nopos("%s\n", builtin2str[emu_typ->val.builtin]); return 0;
+		case BTT_IFLOAT128: log_TODO_nopos("%s\n", builtin2str[emu_typ->val.builtin]); return 0;
 		case BTT_VA_LIST: *needs_my = 1; has_char = 1; c = 'A'; break;
 		default:
-			printf("Error: convert_type_simple on unknown builtin %u\n", emu_typ->val.builtin);
+			log_error_nopos("convert_type_simple on unknown builtin %u\n", emu_typ->val.builtin);
 			return 0;
 		}
 		if (has_char) {
 			if (!string_add_char(dest, c)) {
-				printf("Error: failed to add type char for %s\n", builtin2str[emu_typ->val.builtin]);
+				log_error_nopos("failed to add type char for %s\n", builtin2str[emu_typ->val.builtin]);
 				return 0;
 			}
 			return 1;
 		} else {
-			printf("Internal error: unknown state builtin=%u\n", emu_typ->val.builtin);
+			log_internal_nopos("unknown state builtin=%u\n", emu_typ->val.builtin);
 			return 0;
 		} }
 	case TYPE_ARRAY:
-		printf("Error: convert_type_simple on raw array\n");
+		log_error_nopos("convert_type_simple on raw array\n");
 		return 0;
 	case TYPE_STRUCT_UNION:
 		if (!emu_typ->is_validated || emu_typ->is_incomplete) {
-			printf("Error: incomplete structure for %s\n", string_content(obj_name));
+			log_error_nopos("incomplete structure for %s\n", string_content(obj_name));
 			return 0;
 		}
 		if (is_ret) {
 			if (emu_typ->szinfo.size <= 8) {
 				if (!string_add_char(dest, 'U')) {
-					printf("Error: failed to add type char for structure return\n");
+					log_error_nopos("failed to add type char for structure return\n");
 					return 0;
 				}
 				return 1;
 			} else if (emu_typ->szinfo.size <= 16) {
 				if (!string_add_char(dest, 'H')) {
-					printf("Error: failed to add type char for large structure return\n");
+					log_error_nopos("failed to add type char for large structure return\n");
 					return 0;
 				}
 				return 1;
 			} else {
 				if (!string_add_char(dest, 'p')) {
-					printf("Error: failed to add type char for very large structure return\n");
+					log_error_nopos("failed to add type char for very large structure return\n");
 					return 0;
 				}
 				return 1;
@@ -927,7 +945,7 @@ static int convert_type_simple(string_t *dest, type_t *emu_typ, type_t *target_t
 			if ((emu_typ->val.st->nmembers == 1) && (target_typ->typ == TYPE_STRUCT_UNION) && (target_typ->val.st->nmembers == 1)) {
 				return convert_type_simple(dest, emu_typ->val.st->members[0].typ, target_typ->val.st->members[0].typ, is_ret, needs_D, needs_my, conv_map, obj_name);
 			}
-			printf("Error: TODO: convert_type_simple on structure as argument (%s)\n", string_content(obj_name));
+			log_TODO_nopos("convert_type_simple on structure as argument (%s)\n", string_content(obj_name));
 			return 0;
 		}
 	case TYPE_ENUM:
@@ -940,30 +958,30 @@ static int convert_type_simple(string_t *dest, type_t *emu_typ, type_t *target_t
 	case TYPE_PTR:
 		if (is_simple_type_ptr_to_simple(emu_typ->val.typ, needs_D, needs_my, conv_map)) {
 			if (!string_add_char(dest, 'p')) {
-				printf("Error: failed to add type char for simple pointer\n");
+				log_error_nopos("failed to add type char for simple pointer\n");
 				return 0;
 			}
 			return 1;
 		} else {
 			*needs_my = 1;
 			if (!string_add_char(dest, 'p')) {
-				printf("Error: failed to add type char for complex pointer\n");
+				log_error_nopos("failed to add type char for complex pointer\n");
 				return 0;
 			}
 			return 1;
 		}
 	case TYPE_FUNCTION:
-		printf("Error: convert_type_simple on raw function\n");
+		log_error_nopos("convert_type_simple on raw function\n");
 		return 0;
 	default:
-		printf("Error: convert_type_simple on unknown type %u\n", emu_typ->typ);
+		log_error_nopos("convert_type_simple on unknown type %u\n", emu_typ->typ);
 		return 0;
 	}
 }
 static int convert_type_post_simple(string_t *dest, type_t *emu_typ, type_t *target_typ, string_t *obj_name) {
 	if (emu_typ->converted) return 1;
 	if (emu_typ->is_atomic) {
-		printf("Error: TODO: convert_type_post_simple for atomic types\n");
+		log_TODO_nopos("convert_type_post_simple for atomic types\n");
 		return 0;
 	}
 	(void)target_typ;
@@ -972,14 +990,14 @@ static int convert_type_post_simple(string_t *dest, type_t *emu_typ, type_t *tar
 	case TYPE_ARRAY: return 1;
 	case TYPE_STRUCT_UNION:
 		if (!emu_typ->is_validated || emu_typ->is_incomplete) {
-			printf("Error: incomplete structure for %s\n", string_content(obj_name));
+			log_error_nopos("incomplete structure for %s\n", string_content(obj_name));
 			return 0;
 		}
 		if (emu_typ->szinfo.size <= 16) {
 			return 1;
 		} else {
 			if (!string_add_char(dest, 'p')) {
-				printf("Error: failed to add type char for very large structure return as parameter\n");
+				log_error_nopos("failed to add type char for very large structure return as parameter\n");
 				return 0;
 			}
 			return 2;
@@ -988,46 +1006,49 @@ static int convert_type_post_simple(string_t *dest, type_t *emu_typ, type_t *tar
 	case TYPE_PTR: return 1;
 	case TYPE_FUNCTION: return 1;
 	}
-	printf("Error: convert_type_post_simple on unknown type %u\n", emu_typ->typ);
+	log_error_nopos("convert_type_post_simple on unknown type %u\n", emu_typ->typ);
 	return 0;
 }
 
 int solve_request_simple(request_t *req, type_t *emu_typ, type_t *target_typ, khash_t(conv_map) *conv_map) {
 	if (emu_typ->typ != target_typ->typ) {
-		printf("Error: %s: emulated and target types are different (emulated is %u, target is %u)\n",
+		log_error_nopos("%s: emulated and target types are different (emulated is %u, target is %u)\n",
 			string_content(req->obj_name), emu_typ->typ, target_typ->typ);
 		return 0;
 	}
 	if (emu_typ->typ == TYPE_FUNCTION) {
-		int needs_D = 0, needs_my = req->def.fun.typ && (req->def.rty == RQT_FUN_MY), needs_2 = 0;
+		int needs_D = 0;
+		int needs_my = req->def.fun.typ && (req->def.rty == RQT_FUN_MY);
+		int needs_e = req->def.fun.typ && (req->def.rty == RQT_FUN_2) && !strncmp(string_content(req->def.fun.fun2), "my_", 3);
+		int needs_2 = 0;
 		int convert_post;
 		size_t idx_conv;
 		req->val.fun.typ = string_new();
 		if (!req->val.fun.typ) {
-			printf("Error: failed to create function type string\n");
+			log_error_nopos("failed to create function type string\n");
 			return 0;
 		}
 		if (!convert_type_simple(req->val.fun.typ, emu_typ->val.fun.ret, target_typ->val.fun.ret, 1, &needs_D, &needs_my, conv_map, req->obj_name))
 			goto fun_fail;
 		idx_conv = string_len(req->val.fun.typ);
 		if (!string_add_char(req->val.fun.typ, 'F')) {
-			printf("Error: failed to add convention char\n");
+			log_error_nopos("failed to add convention char\n");
 			goto fun_fail;
 		}
 		convert_post = convert_type_post_simple(req->val.fun.typ, emu_typ->val.fun.ret, target_typ->val.fun.ret, req->obj_name);
 		if (!convert_post) goto fun_fail;
 		if (emu_typ->val.fun.nargs == (size_t)-1) {
-			printf("Warning: %s: assuming empty specification is void specification\n", string_content(req->obj_name));
+			log_warning_nopos("%s: assuming empty specification is void specification\n", string_content(req->obj_name));
 			if (convert_post == 1) {
 				if (!string_add_char(req->val.fun.typ, 'v')) {
-					printf("Error: failed to add void specification char\n");
+					log_error_nopos("failed to add void specification char\n");
 					goto fun_fail;
 				}
 			}
 		} else if (!emu_typ->val.fun.nargs && !emu_typ->val.fun.has_varargs) {
 			if (convert_post == 1) {
 				if (!string_add_char(req->val.fun.typ, 'v')) {
-					printf("Error: failed to add void specification char\n");
+					log_error_nopos("failed to add void specification char\n");
 					goto fun_fail;
 				}
 			}
@@ -1043,7 +1064,7 @@ int solve_request_simple(request_t *req, type_t *emu_typ, type_t *target_typ, kh
 				      && ((string_content(req->def.fun.typ)[string_len(req->val.fun.typ)] == 'M')
 				       || (string_content(req->def.fun.typ)[string_len(req->val.fun.typ)] == 'N'))) {
 					if (!string_add_char(req->val.fun.typ, string_content(req->def.fun.typ)[string_len(req->val.fun.typ)])) {
-						printf("Error: failed to add type char '%c' for %s\n",
+						log_error_nopos("failed to add type char '%c' for %s\n",
 							string_content(req->def.fun.typ)[string_len(req->val.fun.typ)],
 							builtin2str[emu_typ->val.builtin]);
 						goto fun_fail;
@@ -1051,7 +1072,7 @@ int solve_request_simple(request_t *req, type_t *emu_typ, type_t *target_typ, kh
 				} else {
 					needs_my = 1;
 					if (!string_add_char(req->val.fun.typ, 'V')) {
-						printf("Error: failed to add type char 'V' for %s\n", builtin2str[emu_typ->val.builtin]);
+						log_error_nopos("failed to add type char 'V' for %s\n", builtin2str[emu_typ->val.builtin]);
 						goto fun_fail;
 					}
 				}
@@ -1060,11 +1081,12 @@ int solve_request_simple(request_t *req, type_t *emu_typ, type_t *target_typ, kh
 		
 	// fun_succ:
 		// Add 'E' by default, unless we have the same function as before
-		if (needs_my && (req->default_comment
-		                  || (req->def.rty != RQT_FUN_MY)
-		                  || strcmp(string_content(req->def.fun.typ), string_content(req->val.fun.typ)))) {
+		if ((needs_my || needs_e) &&
+		    (req->default_comment
+		      || (req->def.rty != RQT_FUN_MY)
+		      || strcmp(string_content(req->def.fun.typ), string_content(req->val.fun.typ)))) {
 			if (!string_add_char_at(req->val.fun.typ, 'E', idx_conv + 1)) {
-				printf("Error: failed to add emu char\n");
+				log_error_nopos("failed to add emu char\n");
 				goto fun_fail;
 			}
 		}
@@ -1072,20 +1094,20 @@ int solve_request_simple(request_t *req, type_t *emu_typ, type_t *target_typ, kh
 			needs_2 = 1;
 			req->val.fun.fun2 = string_dup(req->def.fun.fun2);
 			if (!req->val.fun.fun2) {
-				printf("Error: failed to duplicate string (request for function %s with default redirection)\n", string_content(req->obj_name));
+				log_error_nopos("failed to duplicate string (request for function %s with default redirection)\n", string_content(req->obj_name));
 				return 0;
 			}
 		} else if (req->def.fun.typ && (req->def.rty == RQT_FUN_D) && !needs_my) {
 			needs_2 = 0;
 			req->val.fun.fun2 = string_dup(req->def.fun.fun2);
 			if (!req->val.fun.fun2) {
-				printf("Error: failed to duplicate string (request for function %s with long double types)\n", string_content(req->obj_name));
+				log_error_nopos("failed to duplicate string (request for function %s with long double types)\n", string_content(req->obj_name));
 				return 0;
 			}
 		} else if (!needs_my && needs_D) {
 			req->val.fun.fun2 = string_new();
 			if (!req->val.fun.fun2) {
-				printf("Error: failed to create empty string (request for function %s with long double types)\n", string_content(req->obj_name));
+				log_error_nopos("failed to create empty string (request for function %s with long double types)\n", string_content(req->obj_name));
 				return 0;
 			}
 		}
@@ -1117,34 +1139,33 @@ int solve_request_simple(request_t *req, type_t *emu_typ, type_t *target_typ, kh
 	}
 }
 int solve_request_map_simple(request_t *req, khash_t(decl_map) *emu_decl_map, khash_t(decl_map) *target_decl_map, khash_t(conv_map) *conv_map) {
-	int hasemu = 0, hastarget = 0;
-	khiter_t emuit, targetit;
-	emuit = kh_get(decl_map, emu_decl_map, string_content(req->obj_name));
-	if (emuit == kh_end(emu_decl_map)) {
-		goto failed;
+	khiter_t emuit = kh_get(decl_map, emu_decl_map, string_content(req->obj_name));
+	khiter_t targetit = kh_get(decl_map, target_decl_map, string_content(req->obj_name));
+	int hasemu = (emuit != kh_end(emu_decl_map));
+	int hastarget = (targetit != kh_end(target_decl_map));
+	if (hasemu &&
+	    ((kh_val(emu_decl_map, emuit)->storage == STORAGE_STATIC) ||
+	     (kh_val(emu_decl_map, emuit)->storage == STORAGE_TLS_STATIC))) {
+		hasemu = 0;
 	}
-	if ((kh_val(emu_decl_map, emuit)->storage == STORAGE_STATIC) || (kh_val(emu_decl_map, emuit)->storage == STORAGE_TLS_STATIC)) {
-		goto failed;
+	if (hastarget &&
+	    ((kh_val(target_decl_map, targetit)->storage == STORAGE_STATIC) ||
+	     (kh_val(target_decl_map, targetit)->storage == STORAGE_TLS_STATIC))) {
+		hastarget = 0;
 	}
-	targetit = kh_get(decl_map, target_decl_map, string_content(req->obj_name));
-	if (targetit == kh_end(target_decl_map)) {
-		goto failed;
+	if (hasemu && hastarget) {
+		return solve_request_simple(req, kh_val(emu_decl_map, emuit)->typ, kh_val(target_decl_map, targetit)->typ, conv_map);
 	}
-	if ((kh_val(target_decl_map, targetit)->storage == STORAGE_STATIC) || (kh_val(target_decl_map, targetit)->storage == STORAGE_TLS_STATIC)) {
-		goto failed;
-	}
-	return solve_request_simple(req, kh_val(emu_decl_map, emuit)->typ, kh_val(target_decl_map, targetit)->typ, conv_map);
 	
-failed:
 	if (string_content(req->obj_name)[0] != '_') {
 		if (!hasemu && !hastarget) {
-			printf("Error: %s was not declared in the emulated and target architectures\n", string_content(req->obj_name));
+			log_error_nopos("%s was not declared in the emulated and target architectures\n", string_content(req->obj_name));
 		} else if (!hasemu) {
-			printf("Error: %s was not declared only in the emulated architecture\n", string_content(req->obj_name));
+			log_error_nopos("%s was not declared only in the emulated architecture\n", string_content(req->obj_name));
 		} else if (!hastarget) {
-			printf("Error: %s was not declared only in the target architecture\n", string_content(req->obj_name));
+			log_error_nopos("%s was not declared only in the target architecture\n", string_content(req->obj_name));
 		} else {
-			printf("Error: internal error: failed but found for %s\n", string_content(req->obj_name));
+			log_error_nopos("internal error: failed but found for %s\n", string_content(req->obj_name));
 		}
 	}
 	return 0;
@@ -1191,61 +1212,61 @@ enum safeness_e {
 };
 static enum safeness_e get_safeness_ptr(type_t *emu_typ, type_t *target_typ, int *needs_D, int *needs_my, khash_t(conv_map) *conv_map, string_t *obj_name) {
 	if (emu_typ->typ != target_typ->typ) {
-		printf("Error: %s: pointer with different types between emu and target\n", string_content(obj_name));
+		log_error_nopos("%s: pointer with different types between emu and target\n", string_content(obj_name));
 		return SAFE_ABORT;
 	}
 	if (emu_typ->converted) {
-		printf("Warning: %s uses a converted type but is not the converted type\n", string_content(obj_name));
+		log_warning_nopos("%s uses a converted type but is not the converted type\n", string_content(obj_name));
 		*needs_my = 1;
 		return SAFE_OK;
 	} else if (kh_get(conv_map, conv_map, emu_typ) != kh_end(conv_map)) {
-		printf("Warning: %s uses a converted type but is not the converted type\n", string_content(obj_name));
+		log_warning_nopos("%s uses a converted type but is not the converted type\n", string_content(obj_name));
 		*needs_my = 1;
 		return SAFE_OK;
 	}
 	switch (emu_typ->typ) {
 	case TYPE_BUILTIN:
 		if (emu_typ->val.builtin != target_typ->val.builtin) {
-			// printf("Warning: %s: emu and target have pointers to different size type\n", string_content(obj_name));
+			// log_warning_nopos("%s: emu and target have pointers to different size type\n", string_content(obj_name));
 			return SAFE_ABORT;
 		}
 		if (emu_typ->szinfo.size != target_typ->szinfo.size) {
-			// printf("Warning: %s: emu and target have pointers to different size type\n", string_content(obj_name));
+			// log_warning_nopos("%s: emu and target have pointers to different size type\n", string_content(obj_name));
 			return SAFE_EXPAND;
 		}
 		/* if (emu_typ->szinfo.align != target_typ->szinfo.align) {
-			// printf("Warning: %s: emu and target have pointers to different alignment type\n", string_content(obj_name));
+			// log_warning_nopos("%s: emu and target have pointers to different alignment type\n", string_content(obj_name));
 			return SAFE_EXPAND;
 		} */
 		// Assume pointers to builtins of the same size and alignment are simple
 		return SAFE_OK;
 	case TYPE_ARRAY:
 		if (emu_typ->szinfo.size != target_typ->szinfo.size) {
-			// printf("Warning: %s: emu and target have pointers to arrays with different size type\n", string_content(obj_name));
+			// log_warning_nopos("%s: emu and target have pointers to arrays with different size type\n", string_content(obj_name));
 			return SAFE_EXPAND;
 		}
 		if (emu_typ->szinfo.align != target_typ->szinfo.align) {
-			// printf("Warning: %s: emu and target have pointers to arrays with different alignment type\n", string_content(obj_name));
+			// log_warning_nopos("%s: emu and target have pointers to arrays with different alignment type\n", string_content(obj_name));
 			return SAFE_EXPAND;
 		}
 		if (emu_typ->val.array.array_sz != target_typ->val.array.array_sz) {
-			printf("Error: %s: emu and target have arrays of different size\n", string_content(obj_name));
+			log_error_nopos("%s: emu and target have arrays of different size\n", string_content(obj_name));
 			return SAFE_ABORT; // Shouldn't happen
 		}
 		// Elements also have the same size
 		if ((emu_typ->val.array.array_sz == (size_t)-1) || (target_typ->val.array.array_sz == (size_t)-1)) {
-			printf("Error: %s: has variable length arrays\n", string_content(obj_name));
+			log_error_nopos("%s: has variable length arrays\n", string_content(obj_name));
 			return SAFE_ABORT; // VLA require manual intervention
 		}
 		return get_safeness_ptr(emu_typ->val.array.typ, target_typ->val.array.typ, needs_D, needs_my, conv_map, obj_name);
 	case TYPE_STRUCT_UNION:
 		if (emu_typ->val.st->is_struct != target_typ->val.st->is_struct) {
-			printf("Error: %s: incoherent struct/union type between emulated and target architectures for %s\n",
+			log_error_nopos("%s: incoherent struct/union type between emulated and target architectures for %s\n",
 				string_content(obj_name), emu_typ->val.st->tag ? string_content(emu_typ->val.st->tag) : "<no tag>");
 			return SAFE_ABORT;
 		}
 		if (emu_typ->is_incomplete != target_typ->is_incomplete) {
-			printf("Error: %s: incoherent struct/union completion type between emulated and target architectures for %s\n",
+			log_error_nopos("%s: incoherent struct/union completion type between emulated and target architectures for %s\n",
 				string_content(obj_name), emu_typ->val.st->tag ? string_content(emu_typ->val.st->tag) : "<no tag>");
 			return SAFE_ABORT;
 		}
@@ -1253,7 +1274,7 @@ static enum safeness_e get_safeness_ptr(type_t *emu_typ, type_t *target_typ, int
 			return SAFE_OK; // Undefined structures are OK since they are opaque
 		}
 		if (emu_typ->val.st->nmembers != target_typ->val.st->nmembers) {
-			printf("Error: %s: struct/union %s has different number of members between emulated and target architectures\n",
+			log_error_nopos("%s: struct/union %s has different number of members between emulated and target architectures\n",
 				string_content(obj_name), emu_typ->val.st->tag ? string_content(emu_typ->val.st->tag) : "<no tag>");
 			return SAFE_ABORT;
 		}
@@ -1300,21 +1321,21 @@ static enum safeness_e get_safeness_ptr(type_t *emu_typ, type_t *target_typ, int
 		*needs_my = 1;
 		return SAFE_OK;
 	default:
-		printf("Error: get_safeness_ptr on unknown type %u\n", emu_typ->typ);
+		log_error_nopos("get_safeness_ptr on unknown type %u\n", emu_typ->typ);
 		return SAFE_ABORT;
 	}
 }
 static enum safeness_e get_safeness(type_t *emu_typ, type_t *target_typ, int *needs_D, int *needs_my, khash_t(conv_map) *conv_map, string_t *obj_name) {
 	if (emu_typ->typ != target_typ->typ) {
-		printf("Error: %s: data with different types between emu and target\n", string_content(obj_name));
+		log_error_nopos("%s: data with different types between emu and target\n", string_content(obj_name));
 		return SAFE_ABORT; // Invalid type
 	}
 	if (emu_typ->converted) {
-		// printf("Warning: %s uses a converted type but is not the converted type\n", string_content(obj_name));
+		// log_warning_nopos("%s uses a converted type but is not the converted type\n", string_content(obj_name));
 		*needs_my = 1;
 		return SAFE_OK;
 	} else if (kh_get(conv_map, conv_map, emu_typ) != kh_end(conv_map)) {
-		// printf("Warning: %s uses a converted type but is not the converted type\n", string_content(obj_name));
+		// log_warning_nopos("%s uses a converted type but is not the converted type\n", string_content(obj_name));
 		*needs_my = 1;
 		return SAFE_OK;
 	}
@@ -1332,41 +1353,41 @@ static enum safeness_e get_safeness(type_t *emu_typ, type_t *target_typ, int *ne
 		return SAFE_OK;
 	case TYPE_ARRAY:
 		if (emu_typ->szinfo.size != target_typ->szinfo.size) {
-			// printf("Warning: %s: emu and target have pointers to different size type\n", string_content(obj_name));
+			// log_warning_nopos("%s: emu and target have pointers to different size type\n", string_content(obj_name));
 			return SAFE_EXPAND;
 		}
 		if (emu_typ->szinfo.align != target_typ->szinfo.align) {
-			// printf("Warning: %s: emu and target have pointers to different alignment type\n", string_content(obj_name));
+			// log_warning_nopos("%s: emu and target have pointers to different alignment type\n", string_content(obj_name));
 			return SAFE_EXPAND;
 		}
 		if (emu_typ->val.array.array_sz != target_typ->val.array.array_sz) {
-			printf("Error: %s: emu and target have arrays of different size\n", string_content(obj_name));
+			log_error_nopos("%s: emu and target have arrays of different size\n", string_content(obj_name));
 			return SAFE_ABORT; // Shouldn't happen
 		}
 		// Elements also have the same size
 		if ((emu_typ->val.array.array_sz == (size_t)-1) || (target_typ->val.array.array_sz == (size_t)-1)) {
-			printf("Error: %s: has variable length arrays\n", string_content(obj_name));
+			log_error_nopos("%s: has variable length arrays\n", string_content(obj_name));
 			return SAFE_ABORT; // VLA require manual intervention
 		}
 		return get_safeness_ptr(emu_typ->val.array.typ, target_typ->val.array.typ, needs_D, needs_my, conv_map, obj_name);
 	case TYPE_STRUCT_UNION:
 		if (emu_typ->val.st->is_struct != target_typ->val.st->is_struct) {
-			printf("Error: %s: incoherent struct/union type between emulated and target architectures for %s\n",
+			log_error_nopos("%s: incoherent struct/union type between emulated and target architectures for %s\n",
 				string_content(obj_name), emu_typ->val.st->tag ? string_content(emu_typ->val.st->tag) : "<no tag>");
 			return SAFE_ABORT;
 		}
 		if (emu_typ->is_incomplete != target_typ->is_incomplete) {
-			printf("Error: %s: incoherent struct/union completion type between emulated and target architectures for %s\n",
+			log_error_nopos("%s: incoherent struct/union completion type between emulated and target architectures for %s\n",
 				string_content(obj_name), emu_typ->val.st->tag ? string_content(emu_typ->val.st->tag) : "<no tag>");
 			return SAFE_ABORT;
 		}
 		if (emu_typ->is_incomplete) {
-			printf("Warning: %s: undefined struct/union %s considered as simple\n",
+			log_warning_nopos("%s: undefined struct/union %s considered as simple\n",
 				string_content(obj_name), emu_typ->val.st->tag ? string_content(emu_typ->val.st->tag) : "<no tag>");
 			return SAFE_OK; // Assume undefined structures are OK since they are opaque
 		}
 		if (emu_typ->val.st->nmembers != target_typ->val.st->nmembers) {
-			printf("Error: %s: struct/union %s has different number of members between emulated and target architectures\n",
+			log_error_nopos("%s: struct/union %s has different number of members between emulated and target architectures\n",
 				string_content(obj_name), emu_typ->val.st->tag ? string_content(emu_typ->val.st->tag) : "<no tag>");
 			return SAFE_ABORT;
 		}
@@ -1393,7 +1414,7 @@ static enum safeness_e get_safeness(type_t *emu_typ, type_t *target_typ, int *ne
 		// Functions should be handled differently (GO instead of DATA)
 		return SAFE_ABORT;
 	default:
-		printf("Error: get_safeness on unknown type %u\n", emu_typ->typ);
+		log_error_nopos("get_safeness on unknown type %u\n", emu_typ->typ);
 		return SAFE_ABORT;
 	}
 }
@@ -1403,7 +1424,7 @@ static int convert_type(string_t *dest, type_t *emu_typ, type_t *target_typ, int
                         _Bool *needs_S, int *needs_D, int *needs_my, khash_t(conv_map) *conv_map, string_t *obj_name) {
 	if (emu_typ->converted) {
 		if (!string_add_string(dest, emu_typ->converted)) {
-			printf("Error: failed to add explicit type conversion\n");
+			log_error_nopos("failed to add explicit type conversion\n");
 			return 0;
 		}
 		return 1;
@@ -1411,17 +1432,17 @@ static int convert_type(string_t *dest, type_t *emu_typ, type_t *target_typ, int
 	khiter_t it = kh_get(conv_map, conv_map, emu_typ);
 	if (it != kh_end(conv_map)) {
 		if (!string_add_string(dest, kh_val(conv_map, it))) {
-			printf("Error: failed to add explicit type conversion\n");
+			log_error_nopos("failed to add explicit type conversion\n");
 			return 0;
 		}
 		return 1;
 	}
 	if ((emu_typ->is_atomic) || (target_typ->is_atomic)) {
-		printf("Error: TODO: convert_type for atomic types\n");
+		log_TODO_nopos("convert_type for atomic types\n");
 		return 0;
 	}
 	if (emu_typ->typ != target_typ->typ) {
-		printf("Error: %s: %s type is different between emulated and target\n", string_content(obj_name), needs_S ? "return" : "argument");
+		log_error_nopos("%s: %s type is different between emulated and target\n", string_content(obj_name), needs_S ? "return" : "argument");
 		return 0;
 	}
 	switch (emu_typ->typ) {
@@ -1466,36 +1487,36 @@ static int convert_type(string_t *dest, type_t *emu_typ, type_t *target_typ, int
 		case BTT_LONGDOUBLE: *needs_D = 1; has_char = 1; c = 'D'; break;
 		case BTT_CLONGDOUBLE: *needs_D = 1; has_char = 1; c = 'Y'; break;
 		case BTT_ILONGDOUBLE: *needs_D = 1; has_char = 1; c = 'D'; break;
-		case BTT_FLOAT128: printf("Error: TODO: %s\n", builtin2str[emu_typ->val.builtin]); return 0;
-		case BTT_CFLOAT128: printf("Error: TODO: %s\n", builtin2str[emu_typ->val.builtin]); return 0;
-		case BTT_IFLOAT128: printf("Error: TODO: %s\n", builtin2str[emu_typ->val.builtin]); return 0;
+		case BTT_FLOAT128: log_TODO_nopos("%s\n", builtin2str[emu_typ->val.builtin]); return 0;
+		case BTT_CFLOAT128: log_TODO_nopos("%s\n", builtin2str[emu_typ->val.builtin]); return 0;
+		case BTT_IFLOAT128: log_TODO_nopos("%s\n", builtin2str[emu_typ->val.builtin]); return 0;
 		case BTT_VA_LIST: *needs_my = 1; has_char = 1; c = 'p'; break;
 		default:
-			printf("Error: convert_type on unknown builtin %u\n", emu_typ->val.builtin);
+			log_error_nopos("convert_type on unknown builtin %u\n", emu_typ->val.builtin);
 			return 0;
 		}
 		if (has_char) {
 			if (!string_add_char(dest, c)) {
-				printf("Error: failed to add type char for complex pointer\n");
+				log_error_nopos("failed to add type char for complex pointer\n");
 				return 0;
 			}
 			return 1;
 		} else {
-			printf("Internal error: unknown state builtin=%u\n", emu_typ->val.builtin);
+			log_internal_nopos("unknown state builtin=%u\n", emu_typ->val.builtin);
 			return 0;
 		} }
 	case TYPE_ARRAY: {
 		// May come from the content of a pointer or structure
 		if ((emu_typ->val.array.array_sz == (size_t)-1) || (target_typ->val.array.array_sz == (size_t)-1)) {
-			printf("Error: %s: has variable length arrays\n", string_content(obj_name));
+			log_error_nopos("%s: has variable length arrays\n", string_content(obj_name));
 			return 0; // VLA require manual intervention
 		}
 		if (emu_typ->val.array.array_sz != target_typ->val.array.array_sz) {
-			printf("Error: %s: emu and target have arrays of different size\n", string_content(obj_name));
+			log_error_nopos("%s: emu and target have arrays of different size\n", string_content(obj_name));
 			return 0; // Shouldn't happen
 		}
 		if (!emu_typ->val.array.array_sz) {
-			// printf("Warning: %s: has zero-length array\n", string_content(obj_name));
+			// log_warning_nopos("%s: has zero-length array\n", string_content(obj_name));
 			return 1;
 		}
 		size_t idx = string_len(dest);
@@ -1504,7 +1525,7 @@ static int convert_type(string_t *dest, type_t *emu_typ, type_t *target_typ, int
 		size_t end = string_len(dest);
 		if (idx == end) return 1;
 		if (!string_reserve(dest, idx + (end - idx) * emu_typ->val.array.array_sz)) {
-			printf("Error: failed to reserve string capacity (for array of type conversing length %zu and size %zu)\n",
+			log_error_nopos("failed to reserve string capacity (for array of type conversing length %zu and size %zu)\n",
 				end - idx, emu_typ->val.array.array_sz);
 			return 0;
 		}
@@ -1517,14 +1538,14 @@ static int convert_type(string_t *dest, type_t *emu_typ, type_t *target_typ, int
 		return 1; }
 	case TYPE_STRUCT_UNION:
 		if (!emu_typ->is_validated || emu_typ->is_incomplete) {
-			printf("Error: incomplete structure for %s\n", string_content(obj_name));
+			log_error_nopos("incomplete structure for %s\n", string_content(obj_name));
 			return 0;
 		}
 		if (needs_S) {
 			*needs_S = 1;
 			// TODO: remove this and add support in the python wrappers for structure returns
 			if (!string_add_char(dest, 'p')) {
-				printf("Error: failed to add type char for very large structure return\n");
+				log_error_nopos("failed to add type char for very large structure return\n");
 				return 0;
 			}
 			return 1;
@@ -1532,7 +1553,7 @@ static int convert_type(string_t *dest, type_t *emu_typ, type_t *target_typ, int
 			if ((emu_typ->val.st->nmembers == 1) && (target_typ->typ == TYPE_STRUCT_UNION) && (target_typ->val.st->nmembers == 1)) {
 				return convert_type(dest, emu_typ->val.st->members[0].typ, target_typ->val.st->members[0].typ, allow_nesting, needs_S, needs_D, needs_my, conv_map, obj_name);
 			}
-			printf("Error: TODO: convert_type on structure as argument (%s)\n", string_content(obj_name));
+			log_TODO_nopos("convert_type on structure as argument (%s)\n", string_content(obj_name));
 			return 0;
 		}
 	case TYPE_ENUM:
@@ -1540,7 +1561,7 @@ static int convert_type(string_t *dest, type_t *emu_typ, type_t *target_typ, int
 	case TYPE_PTR:
 		switch (get_safeness_ptr(emu_typ->val.typ, target_typ->val.typ, needs_D, needs_my, conv_map, obj_name)) {
 		default:
-			printf("Internal error: %s: pointer to unknown type\n", string_content(obj_name));
+			log_internal_nopos("%s: pointer to unknown type\n", string_content(obj_name));
 			return 0;
 			
 		case SAFE_ABORT:
@@ -1548,7 +1569,7 @@ static int convert_type(string_t *dest, type_t *emu_typ, type_t *target_typ, int
 			
 		case SAFE_OK:
 			if (!string_add_char(dest, 'p')) {
-				printf("Error: failed to add type char for simple pointer\n");
+				log_error_nopos("failed to add type char for simple pointer\n");
 				return 0;
 			}
 			return 1;
@@ -1558,13 +1579,13 @@ static int convert_type(string_t *dest, type_t *emu_typ, type_t *target_typ, int
 				// TODO remove this with a better rebuild_wrappers.py
 				*needs_my = 1;
 				if (!string_add_char(dest, 'p')) {
-					printf("Error: failed to add type char for simple pointer\n");
+					log_error_nopos("failed to add type char for simple pointer\n");
 					return 0;
 				}
 				return 1;
 			}
 			if (!string_add_char(dest, emu_typ->is_const ? 'r' : 'b')) {
-				printf("Error: failed to add start type char for wrapping pointer\n");
+				log_error_nopos("failed to add start type char for wrapping pointer\n");
 				return 0;
 			}
 			// Find the underlying type to convert
@@ -1584,7 +1605,7 @@ static int convert_type(string_t *dest, type_t *emu_typ, type_t *target_typ, int
 				break;
 			case TYPE_STRUCT_UNION:
 				if (!emu_typ->val.st->is_defined) {
-					printf("Internal error: EXPAND with undefined struct/union ptr\n");
+					log_internal_nopos("EXPAND with undefined struct/union ptr\n");
 					return 0;
 				}
 				if (emu_typ->val.st->nmembers == 1) { // Single-member struct/union
@@ -1617,16 +1638,16 @@ static int convert_type(string_t *dest, type_t *emu_typ, type_t *target_typ, int
 				break;
 			}
 			if (!string_add_char(dest, '_')) {
-				printf("Error: failed to add end type char for wrapping pointer\n");
+				log_error_nopos("failed to add end type char for wrapping pointer\n");
 				return 0;
 			}
 			return 1;
 		}
 	case TYPE_FUNCTION:
-		printf("Internal error: convert_type on raw function\n");
+		log_internal_nopos("convert_type on raw function\n");
 		return 1;
 	default:
-		printf("Error: convert_type on unknown type %u\n", emu_typ->typ);
+		log_error_nopos("convert_type on unknown type %u\n", emu_typ->typ);
 		return 0;
 	}
 }
@@ -1634,7 +1655,7 @@ static int convert_type(string_t *dest, type_t *emu_typ, type_t *target_typ, int
 static int convert_type_post(string_t *dest, type_t *emu_typ, type_t *target_typ, string_t *obj_name) {
 	if (emu_typ->converted) return 1;
 	if (emu_typ->is_atomic) {
-		printf("Error: TODO: convert_type_post for atomic types\n");
+		log_TODO_nopos("convert_type_post for atomic types\n");
 		return 0;
 	}
 	(void)target_typ;
@@ -1643,12 +1664,12 @@ static int convert_type_post(string_t *dest, type_t *emu_typ, type_t *target_typ
 	case TYPE_ARRAY: return 1;
 	case TYPE_STRUCT_UNION:
 		if (!emu_typ->is_validated || emu_typ->is_incomplete) {
-			printf("Error: incomplete structure for %s\n", string_content(obj_name));
+			log_error_nopos("incomplete structure for %s\n", string_content(obj_name));
 			return 0;
 		}
 		// Hard coded
 		if (!string_add_char(dest, 'p')) {
-			printf("Error: failed to add type char for very large structure return as parameter\n");
+			log_error_nopos("failed to add type char for very large structure return as parameter\n");
 			return 0;
 		}
 		return 2;
@@ -1656,13 +1677,13 @@ static int convert_type_post(string_t *dest, type_t *emu_typ, type_t *target_typ
 	case TYPE_PTR: return 1;
 	case TYPE_FUNCTION: return 1;
 	}
-	printf("Error: convert_type_post on unknown type %u\n", emu_typ->typ);
+	log_error_nopos("convert_type_post on unknown type %u\n", emu_typ->typ);
 	return 0;
 }
 
 int solve_request(request_t *req, type_t *emu_typ, type_t *target_typ, khash_t(conv_map) *conv_map) {
 	if (emu_typ->typ != target_typ->typ) {
-		printf("Error: %s: emulated and target types are different (emulated is %u, target is %u)\n",
+		log_error_nopos("%s: emulated and target types are different (emulated is %u, target is %u)\n",
 			string_content(req->obj_name), emu_typ->typ, target_typ->typ);
 		return 0;
 	}
@@ -1672,30 +1693,30 @@ int solve_request(request_t *req, type_t *emu_typ, type_t *target_typ, khash_t(c
 		size_t idx_conv;
 		req->val.fun.typ = string_new();
 		if (!req->val.fun.typ) {
-			printf("Error: failed to create function type string\n");
+			log_error_nopos("failed to create function type string\n");
 			return 0;
 		}
 		if (!convert_type(req->val.fun.typ, emu_typ->val.fun.ret, target_typ->val.fun.ret, 0, &req->val.fun.needs_S, &needs_D, &needs_my, conv_map, req->obj_name))
 			goto fun_fail;
 		idx_conv = string_len(req->val.fun.typ);
 		if (!string_add_char(req->val.fun.typ, 'F')) {
-			printf("Error: failed to add convention char\n");
+			log_error_nopos("failed to add convention char\n");
 			goto fun_fail;
 		}
 		convert_post = convert_type_post(req->val.fun.typ, emu_typ->val.fun.ret, target_typ->val.fun.ret, req->obj_name);
 		if (!convert_post) goto fun_fail;
 		if (emu_typ->val.fun.nargs == (size_t)-1) {
-			printf("Warning: %s: assuming empty specification is void specification\n", string_content(req->obj_name));
+			log_warning_nopos("%s: assuming empty specification is void specification\n", string_content(req->obj_name));
 			if (convert_post == 1) {
 				if (!string_add_char(req->val.fun.typ, 'v')) {
-					printf("Error: failed to add void specification char\n");
+					log_error_nopos("failed to add void specification char\n");
 					goto fun_fail;
 				}
 			}
 		} else if (!emu_typ->val.fun.nargs && !emu_typ->val.fun.has_varargs) {
 			if (convert_post == 1) {
 				if (!string_add_char(req->val.fun.typ, 'v')) {
-					printf("Error: failed to add void specification char\n");
+					log_error_nopos("failed to add void specification char\n");
 					goto fun_fail;
 				}
 			}
@@ -1711,7 +1732,7 @@ int solve_request(request_t *req, type_t *emu_typ, type_t *target_typ, khash_t(c
 				      && ((string_content(req->def.fun.typ)[string_len(req->val.fun.typ)] == 'M')
 				       || (string_content(req->def.fun.typ)[string_len(req->val.fun.typ)] == 'N'))) {
 					if (!string_add_char(req->val.fun.typ, string_content(req->def.fun.typ)[string_len(req->val.fun.typ)])) {
-						printf("Error: failed to add type char '%c' for %s\n",
+						log_error_nopos("failed to add type char '%c' for %s\n",
 							string_content(req->def.fun.typ)[string_len(req->val.fun.typ)],
 							builtin2str[emu_typ->val.builtin]);
 						goto fun_fail;
@@ -1719,7 +1740,7 @@ int solve_request(request_t *req, type_t *emu_typ, type_t *target_typ, khash_t(c
 				} else {
 					needs_my = 1;
 					if (!string_add_char(req->val.fun.typ, 'V')) {
-						printf("Error: failed to add type char 'V' for %s\n", builtin2str[emu_typ->val.builtin]);
+						log_error_nopos("failed to add type char 'V' for %s\n", builtin2str[emu_typ->val.builtin]);
 						goto fun_fail;
 					}
 				}
@@ -1732,7 +1753,7 @@ int solve_request(request_t *req, type_t *emu_typ, type_t *target_typ, khash_t(c
 		                  || (req->def.rty != RQT_FUN_MY)
 		                  || strcmp(string_content(req->def.fun.typ), string_content(req->val.fun.typ)))) {
 			if (!string_add_char_at(req->val.fun.typ, 'E', idx_conv + 1)) {
-				printf("Error: failed to add emu char\n");
+				log_error_nopos("failed to add emu char\n");
 				goto fun_fail;
 			}
 		}
@@ -1740,20 +1761,20 @@ int solve_request(request_t *req, type_t *emu_typ, type_t *target_typ, khash_t(c
 			needs_2 = 1;
 			req->val.fun.fun2 = string_dup(req->def.fun.fun2);
 			if (!req->val.fun.fun2) {
-				printf("Error: failed to duplicate string (request for function %s with default redirection)\n", string_content(req->obj_name));
+				log_error_nopos("failed to duplicate string (request for function %s with default redirection)\n", string_content(req->obj_name));
 				return 0;
 			}
 		} else if (req->def.fun.typ && (req->def.rty == RQT_FUN_D) && !needs_my) {
 			needs_2 = 0;
 			req->val.fun.fun2 = string_dup(req->def.fun.fun2);
 			if (!req->val.fun.fun2) {
-				printf("Error: failed to duplicate string (request for function %s with long double types)\n", string_content(req->obj_name));
+				log_error_nopos("failed to duplicate string (request for function %s with long double types)\n", string_content(req->obj_name));
 				return 0;
 			}
 		} else if (!needs_my && needs_D) {
 			req->val.fun.fun2 = string_new();
 			if (!req->val.fun.fun2) {
-				printf("Error: failed to create empty string (request for function %s with long double types)\n", string_content(req->obj_name));
+				log_error_nopos("failed to create empty string (request for function %s with long double types)\n", string_content(req->obj_name));
 				return 0;
 			}
 		}
@@ -1790,36 +1811,33 @@ int solve_request(request_t *req, type_t *emu_typ, type_t *target_typ, khash_t(c
 	}
 }
 int solve_request_map(request_t *req, khash_t(decl_map) *emu_decl_map, khash_t(decl_map) *target_decl_map, khash_t(conv_map) *conv_map) {
-	int hasemu = 0, hastarget = 0;
-	khiter_t emuit, targetit;
-	emuit = kh_get(decl_map, emu_decl_map, string_content(req->obj_name));
-	if (emuit == kh_end(emu_decl_map)) {
-		goto failed;
+	khiter_t emuit = kh_get(decl_map, emu_decl_map, string_content(req->obj_name));
+	khiter_t targetit = kh_get(decl_map, target_decl_map, string_content(req->obj_name));
+	int hasemu = (emuit != kh_end(emu_decl_map));
+	int hastarget = (targetit != kh_end(target_decl_map));
+	if (hasemu &&
+	    ((kh_val(emu_decl_map, emuit)->storage == STORAGE_STATIC) ||
+	     (kh_val(emu_decl_map, emuit)->storage == STORAGE_TLS_STATIC))) {
+		hasemu = 0;
 	}
-	if ((kh_val(emu_decl_map, emuit)->storage == STORAGE_STATIC) || (kh_val(emu_decl_map, emuit)->storage == STORAGE_TLS_STATIC)) {
-		goto failed;
+	if (hastarget &&
+	    ((kh_val(target_decl_map, targetit)->storage == STORAGE_STATIC) ||
+	     (kh_val(target_decl_map, targetit)->storage == STORAGE_TLS_STATIC))) {
+		hastarget = 0;
 	}
-	hasemu = 1;
-	targetit = kh_get(decl_map, target_decl_map, string_content(req->obj_name));
-	if (targetit == kh_end(target_decl_map)) {
-		goto failed;
+	if (hasemu && hastarget) {
+		return solve_request(req, kh_val(emu_decl_map, emuit)->typ, kh_val(target_decl_map, targetit)->typ, conv_map);
 	}
-	if ((kh_val(target_decl_map, targetit)->storage == STORAGE_STATIC) || (kh_val(target_decl_map, targetit)->storage == STORAGE_TLS_STATIC)) {
-		goto failed;
-	}
-	hastarget = 1;
-	return solve_request(req, kh_val(emu_decl_map, emuit)->typ, kh_val(target_decl_map, targetit)->typ, conv_map);
 	
-failed:
 	if (string_content(req->obj_name)[0] != '_') {
 		if (!hasemu && !hastarget) {
-			printf("Error: %s was not declared in the emulated and target architectures\n", string_content(req->obj_name));
+			log_error_nopos("%s was not declared in the emulated and target architectures\n", string_content(req->obj_name));
 		} else if (!hasemu) {
-			printf("Error: %s was not declared only in the emulated architecture\n", string_content(req->obj_name));
+			log_error_nopos("%s was not declared only in the emulated architecture\n", string_content(req->obj_name));
 		} else if (!hastarget) {
-			printf("Error: %s was not declared only in the target architecture\n", string_content(req->obj_name));
+			log_error_nopos("%s was not declared only in the target architecture\n", string_content(req->obj_name));
 		} else {
-			printf("Error: internal error: failed but found for %s\n", string_content(req->obj_name));
+			log_error_nopos("internal error: failed but found for %s\n", string_content(req->obj_name));
 		}
 	}
 	return 0;

--- a/wrapperhelper/src/generator.h
+++ b/wrapperhelper/src/generator.h
@@ -10,6 +10,7 @@
 
 typedef struct request_s {
 	string_t *obj_name;
+	string_t *sym_ver;
 	_Bool default_comment;
 	_Bool has_val, ignored;
 	_Bool weak;

--- a/wrapperhelper/src/lang.c
+++ b/wrapperhelper/src/lang.c
@@ -43,6 +43,7 @@ preproc_token_t preproc_token_dup(preproc_token_t tok) {
 	case PPTOK_NEWLINE:
 	case PPTOK_BLANK:
 	case PPTOK_START_LINE_COMMENT:
+	case PPTOK_AT_SYM:
 	case PPTOK_EOF:
 		ret.tokv.c = tok.tokv.c;
 		break;
@@ -66,6 +67,7 @@ void preproc_token_del(preproc_token_t *tok) {
 	case PPTOK_NEWLINE:
 	case PPTOK_BLANK:
 	case PPTOK_START_LINE_COMMENT:
+	case PPTOK_AT_SYM:
 	case PPTOK_EOF:
 		break;
 	}
@@ -191,6 +193,9 @@ void preproc_token_print(const preproc_token_t *tok) {
 	case PPTOK_START_LINE_COMMENT:
 		printf("%7s\n", "\e[2;31m( // ) \e[m");
 		break;
+	case PPTOK_AT_SYM:
+		printf("%7s\n", "\e[2;31m( @ )  \e[m");
+		break;
 	case PPTOK_EOF:
 		printf("%7s\n", "EOF");
 		break;
@@ -210,6 +215,7 @@ int preproc_token_isend(const preproc_token_t *tok) {
 	case PPTOK_NEWLINE:
 	case PPTOK_BLANK:
 	case PPTOK_START_LINE_COMMENT:
+	case PPTOK_AT_SYM:
 		return 0;
 	case PPTOK_INVALID:
 	case PPTOK_EOF:

--- a/wrapperhelper/src/lang.h
+++ b/wrapperhelper/src/lang.h
@@ -74,6 +74,7 @@ typedef struct preproc_token_s {
 		PPTOK_NEWLINE,
 		PPTOK_BLANK,
 		PPTOK_START_LINE_COMMENT,
+		PPTOK_AT_SYM,
 		PPTOK_EOF
 	} tokt;
 	loginfo_t loginfo;

--- a/wrapperhelper/src/prepare.c
+++ b/wrapperhelper/src/prepare.c
@@ -268,6 +268,12 @@ preproc_token_t pre_next_token(prepare_t *src, int allow_comments) {
 				.loginfo = c.li,
 				.tokv.c = (char)c.c
 			};
+		} else if (c.c == '@') {
+			return (preproc_token_t){
+				.tokt = PPTOK_AT_SYM,
+				.loginfo = c.li,
+				.tokv.c = (char)c.c
+			};
 		} else {
 			return (preproc_token_t){
 				.tokt = PPTOK_INVALID,
@@ -465,6 +471,13 @@ start_next_token:
 			unget_char(src, c2);
 		}
 	}
+	if (c.c == '@') {
+		return (preproc_token_t){
+			.tokt = PPTOK_AT_SYM,
+			.loginfo = c.li,
+			.tokv.c = (char)c.c
+		};
+	}
 	
 	struct symbs_s const *sym = NULL;
 	for (int i = 0; i < BASE_NSYMS; ++i) {
@@ -571,6 +584,16 @@ int pre_next_newline_token(prepare_t *src, string_t *buf) {
 			return 0;
 		}
 	}
+}
+
+preproc_token_t pre_next_string_token_comma(prepare_t *src) {
+	preproc_token_t ret;
+	ret.tokt = PPTOK_STRING;
+	ret.loginfo = (loginfo_t){ .filename = src->li.filename, .lineno = src->li.lineno, .colno = src->li.colno, .lineno_end = 0, .colno_end = 0 };
+	ret.tokv.sisstr = 0;
+	ret.tokv.sstr = string_new();
+	fill_str(src, ret.tokv.sstr, ',', 0, &ret.loginfo.lineno_end, &ret.loginfo.colno_end);
+	return ret;
 }
 
 void prepare_cleanup(void) {

--- a/wrapperhelper/src/prepare.h
+++ b/wrapperhelper/src/prepare.h
@@ -19,6 +19,8 @@ void prepare_set_line(prepare_t *src, char *filename, size_t lineno); // Takes o
 void prepare_mark_nocomment(prepare_t *src); // Change the state (usually from COMMENT) to NONE
 int pre_next_newline_token(prepare_t *src, string_t *buf); // In a comment append everything until the EOL or EOF to the buffer
 
+preproc_token_t pre_next_string_token_comma(prepare_t *src); // Return everything as a string until EOL, EOF or comma symbol (also eat the comma)
+
 void prepare_cleanup(void); // Frees loginfo filenames
 
 #endif // PREPARE_H

--- a/wrapperhelper/src/preproc.c
+++ b/wrapperhelper/src/preproc.c
@@ -584,6 +584,7 @@ static VECTOR(preproc) *preproc_solve_macro(loginfo_t *li,
 					case PPTOK_NEWLINE:
 					case PPTOK_BLANK:
 					case PPTOK_START_LINE_COMMENT:
+					case PPTOK_AT_SYM:
 					case PPTOK_EOF: tok2 = (preproc_token_t){.tokt = tok1->tokt, .loginfo = *li, .tokv.c = tok1->tokv.c}; break;
 					case PPTOK_SYM: tok2 = (preproc_token_t){.tokt = tok1->tokt, .loginfo = *li, .tokv.sym = tok1->tokv.sym}; break;
 					case PPTOK_IDENT:
@@ -681,6 +682,7 @@ static VECTOR(preproc) *preproc_solve_macro(loginfo_t *li,
 					case PPTOK_NEWLINE:
 					case PPTOK_BLANK:
 					case PPTOK_START_LINE_COMMENT:
+					case PPTOK_AT_SYM:
 					case PPTOK_EOF: tok2 = (preproc_token_t){.tokt = tok1->tokt, .loginfo = *li, .tokv.c = tok1->tokv.c}; break;
 					case PPTOK_SYM: tok2 = (preproc_token_t){.tokt = tok1->tokt, .loginfo = *li, .tokv.sym = tok1->tokv.sym}; break;
 					case PPTOK_IDENT:
@@ -831,6 +833,7 @@ static VECTOR(preproc) *preproc_do_expand(loginfo_t *li, const khash_t(macros_ma
 		case PPTOK_NEWLINE:
 		case PPTOK_BLANK:
 		case PPTOK_START_LINE_COMMENT:
+		case PPTOK_AT_SYM:
 		case PPTOK_EOF: tok2 = (preproc_token_t){.tokt = tok->tokt, .loginfo = tok->loginfo, .tokv.c = tok->tokv.c}; break;
 		case PPTOK_SYM: tok2 = (preproc_token_t){.tokt = tok->tokt, .loginfo = tok->loginfo, .tokv.sym = tok->tokv.sym}; break;
 		case PPTOK_IDENT:
@@ -945,7 +948,8 @@ static VECTOR(preproc) *preproc_do_expand(loginfo_t *li, const khash_t(macros_ma
 							VECTOR(preproc) *marg = vector_new(preproc);
 							if (!marg) goto gather_args_err_mem;
 							
-							while (depth && (tok2 < vector_end(preproc, toks2) - 1) && (tok2->tokt != PPTOK_EOF) && (tok2->tokt != PPTOK_INVALID)) {
+							while (depth && (tok2 < vector_end(preproc, toks2) - 1) &&
+							       (tok2->tokt != PPTOK_EOF) && (tok2->tokt != PPTOK_AT_SYM) && (tok2->tokt != PPTOK_INVALID)) {
 								++tok2;
 								if ((depth == 1) && (tok2->tokt == PPTOK_SYM) && (tok2->tokv.sym == SYM_COMMA)) {
 									// Possible optimization: emplace NULL if vector_size(marg) == 0
@@ -1018,8 +1022,8 @@ static VECTOR(preproc) *preproc_do_expand(loginfo_t *li, const khash_t(macros_ma
 		}
 			/* FALLTHROUGH */
 		abort_macro:
-		case PPTOK_IDENT_UNEXP:
 		case PPTOK_INVALID:
+		case PPTOK_IDENT_UNEXP:
 		case PPTOK_NUM:
 		case PPTOK_STRING:
 		case PPTOK_INCL:
@@ -1027,6 +1031,7 @@ static VECTOR(preproc) *preproc_do_expand(loginfo_t *li, const khash_t(macros_ma
 		case PPTOK_NEWLINE:
 		case PPTOK_BLANK:
 		case PPTOK_START_LINE_COMMENT:
+		case PPTOK_AT_SYM:
 		case PPTOK_EOF:
 			if (!vector_push(preproc, ret, *tok)) {
 				log_memory("failed to add token to output vector during full macro expansion\n");
@@ -1907,7 +1912,10 @@ check_if_depth:
 			while (1) {
 				preproc_token_t tok = ppsrc_next_token(src);
 			skip_cur_token:
-				if (tok.tokt == PPTOK_INVALID) {
+				if ((tok.tokt == PPTOK_AT_SYM) || (tok.tokt == PPTOK_INVALID)) {
+					if (tok.tokt == PPTOK_AT_SYM) {
+						log_error(&tok.loginfo, "invalid character 0x%02X (@)\n", (unsigned)'@');
+					}
 					src->st = PPST_NONE;
 					proc_token_t ret;
 					ret.tokt = PTOK_INVALID;
@@ -1960,7 +1968,7 @@ check_if_depth:
 							}
 							tok = ppsrc_next_token(src);
 							loginfo_t li = tok.loginfo;
-							while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_INVALID)) {
+							while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_AT_SYM) && (tok.tokt != PPTOK_INVALID)) {
 								li.lineno_end = tok.loginfo.lineno_end ? tok.loginfo.lineno_end : tok.loginfo.lineno;
 								li.colno_end = tok.loginfo.colno_end ? tok.loginfo.colno_end : tok.loginfo.colno;
 								if (!vector_push(preproc, cond, tok)) {
@@ -2019,7 +2027,7 @@ check_if_depth:
 								// EOF has an empty destructor
 								// Note that since we have opened the file, the previous file had ok_depth == cond_depth
 								goto check_next_token;
-							} else /* if (tok.tokt == PPTOK_INVALID) */ {
+							} else /* if ((tok.tokt == PPTOK_AT_SYM) || (tok.tokt == PPTOK_INVALID)) */ {
 								src->st = PPST_NONE;
 								return (proc_token_t){ .tokt = PTOK_INVALID, .tokv.c = tok.tokv.c };
 							}
@@ -2084,7 +2092,7 @@ check_if_depth:
 					
 					log_warning(&tok.loginfo, "Unknown ignored pp command %s, skipping until EOL\n", string_content(tok.tokv.str));
 				preproc_ignore_remaining:
-					while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_INVALID)) {
+					while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_AT_SYM) && (tok.tokt != PPTOK_INVALID)) {
 						preproc_token_del(&tok);
 						tok = ppsrc_next_token(src);
 					}
@@ -2094,7 +2102,7 @@ check_if_depth:
 					goto skip_cur_token;
 					
 				preproc_ignore_remaining_goto:
-					while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_INVALID)) {
+					while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_AT_SYM) && (tok.tokt != PPTOK_INVALID)) {
 						preproc_token_del(&tok);
 						tok = ppsrc_next_token(src);
 					}
@@ -2122,6 +2130,7 @@ start_next_token:
 start_cur_token:
 	switch (tok.tokt) {
 	case PPTOK_INVALID:
+	case PPTOK_AT_SYM:
 		src->st = PPST_NONE;
 		ret.tokt = PTOK_INVALID;
 		ret.loginfo = tok.loginfo;
@@ -2149,7 +2158,7 @@ start_cur_token:
 						if (!margs) goto solve_err_mem;
 						VECTOR(preproc) *marg = vector_new(preproc);
 						if (!marg) goto solve_err_mem;
-						while (need_solve && (tok2.tokt != PPTOK_EOF) && (tok2.tokt != PPTOK_INVALID)) {
+						while (need_solve && (tok2.tokt != PPTOK_EOF) && (tok2.tokt != PPTOK_AT_SYM) && (tok2.tokt != PPTOK_INVALID)) {
 							tok2 = ppsrc_next_token(src);
 							if ((need_solve == 1) && (tok2.tokt == PPTOK_SYM) && (tok2.tokv.sym == SYM_COMMA)) {
 								// Possible optimization: emplace NULL if vector_size(marg) == 0
@@ -2313,7 +2322,7 @@ start_cur_token:
 					is_sys = is_next || !tok.tokv.sisstr;
 					tok = ppsrc_next_token(src); // Token was moved
 					loginfo_t ignored_infos = tok.loginfo; int has_ignored = 0;
-					while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_INVALID)) {
+					while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_AT_SYM) && (tok.tokt != PPTOK_INVALID)) {
 						has_ignored = 1;
 						ignored_infos.lineno_end = tok.loginfo.lineno_end ? tok.loginfo.lineno_end : tok.loginfo.lineno;
 						ignored_infos.colno_end = tok.loginfo.colno_end ? tok.loginfo.colno_end : tok.loginfo.colno;
@@ -2334,7 +2343,7 @@ start_cur_token:
 						ret.tokv.c = '\0';
 						return ret;
 					}
-					while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_INVALID)) {
+					while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_AT_SYM) && (tok.tokt != PPTOK_INVALID)) {
 						if (!vector_push(preproc, incl, tok)) {
 							log_memory("failed to add token to #include tokens vector\n");
 							vector_del(preproc, incl);
@@ -2431,6 +2440,7 @@ start_cur_token:
 							case PPTOK_NEWLINE:
 							case PPTOK_BLANK:
 							case PPTOK_START_LINE_COMMENT:
+							case PPTOK_AT_SYM:
 							case PPTOK_EOF:
 							default:
 								log_error(&li, "TODO: add token type %u to include string\n", tok2->tokt);
@@ -2509,7 +2519,7 @@ start_cur_token:
 						ok = 1;
 					} else {
 						ok = 0;
-						while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_INVALID)) {
+						while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_AT_SYM) && (tok.tokt != PPTOK_INVALID)) {
 							if ((tok.tokt == PPTOK_SYM) && (tok.tokv.sym == SYM_VARIADIC)) {
 								m.has_varargs = 1;
 								int kh_ret;
@@ -2631,7 +2641,7 @@ start_cur_token:
 				int state = 0;
 #define ST_CONCAT 1
 #define ST_STR 2
-				while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_INVALID)) {
+				while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_AT_SYM) && (tok.tokt != PPTOK_INVALID)) {
 					if ((tok.tokt == PPTOK_SYM) && (tok.tokv.sym == SYM_HASH)) {
 						if (state & ST_STR) {
 							log_warning(&tok.loginfo, "duplicated stringify in macro definition (defining %s)\n", string_content(defname));
@@ -2724,7 +2734,7 @@ start_cur_token:
 #undef ST_CONCAT
 #undef ST_STR
 				if (args) argid_map_del(args);
-				if (tok.tokt == PPTOK_INVALID) {
+				if ((tok.tokt == PPTOK_AT_SYM) || (tok.tokt == PPTOK_INVALID)) {
 					// Abort
 					log_error(&tok.loginfo, "unexpected invalid input token\n");
 					string_del(defname);
@@ -2784,7 +2794,7 @@ start_cur_token:
 				}
 				string_t *mname = tok.tokv.str;
 				tok = ppsrc_next_token(src); // Token was moved
-				while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_INVALID)) {
+				while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_AT_SYM) && (tok.tokt != PPTOK_INVALID)) {
 					// TODO: Print warning 'ignored token(s)'
 					preproc_token_del(&tok);
 					tok = ppsrc_next_token(src);
@@ -2805,7 +2815,7 @@ start_cur_token:
 				log_error(&tok.loginfo, "#error command:");
 				string_del(tok.tokv.str);
 				tok = ppsrc_next_token(src);
-				while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_INVALID)) {
+				while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_AT_SYM) && (tok.tokt != PPTOK_INVALID)) {
 					switch (tok.tokt) {
 					case PPTOK_IDENT:
 					case PPTOK_IDENT_UNEXP:
@@ -2824,6 +2834,7 @@ start_cur_token:
 					case PPTOK_NEWLINE:
 					case PPTOK_BLANK:
 					case PPTOK_START_LINE_COMMENT:
+					case PPTOK_AT_SYM:
 					case PPTOK_EOF:
 					default:
 						printf(" <unknown token type %u>", tok.tokt);
@@ -2840,7 +2851,7 @@ start_cur_token:
 			} else if (!strcmp(string_content(tok.tokv.str), "warning")) {
 				log_warning(&tok.loginfo, "#warning command:");
 				tok = ppsrc_next_token(src);
-				while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_INVALID)) {
+				while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_AT_SYM) && (tok.tokt != PPTOK_INVALID)) {
 					switch (tok.tokt) {
 					case PPTOK_IDENT:
 					case PPTOK_IDENT_UNEXP:
@@ -2859,6 +2870,7 @@ start_cur_token:
 					case PPTOK_NEWLINE:
 					case PPTOK_BLANK:
 					case PPTOK_START_LINE_COMMENT:
+					case PPTOK_AT_SYM:
 					case PPTOK_EOF:
 					default:
 						printf(" <unknown token type %u>", tok.tokt);
@@ -2895,11 +2907,11 @@ start_cur_token:
 						goto preproc_hash_err;
 					} else if (!strcmp(string_content(tok.tokv.str), "allow_ints_ext")) {
 						ret.loginfo = tok.loginfo;
-						while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_INVALID)) {
+						while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_AT_SYM) && (tok.tokt != PPTOK_INVALID)) {
 							preproc_token_del(&tok);
 							tok = ppsrc_next_token(src);
 						}
-						if (tok.tokt == PPTOK_INVALID) goto start_cur_token;
+						if ((tok.tokt == PPTOK_AT_SYM) || (tok.tokt == PPTOK_INVALID)) goto start_cur_token;
 						else {
 							ret.tokt = PTOK_PRAGMA;
 							ret.tokv.pragma.typ = PRAGMA_ALLOW_INTS;
@@ -2918,11 +2930,11 @@ start_cur_token:
 						ret.tokv.pragma.typ = PRAGMA_SIMPLE_SU;
 						ret.tokv.pragma.val = tok.tokv.str;
 						tok = ppsrc_next_token(src);
-						while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_INVALID)) {
+						while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_AT_SYM) && (tok.tokt != PPTOK_INVALID)) {
 							preproc_token_del(&tok);
 							tok = ppsrc_next_token(src);
 						}
-						if (tok.tokt == PPTOK_INVALID) {
+						if ((tok.tokt == PPTOK_AT_SYM) || (tok.tokt == PPTOK_INVALID)) {
 							string_del(ret.tokv.pragma.val);
 							goto start_cur_token;
 						} else {
@@ -2958,6 +2970,19 @@ start_cur_token:
 						log_error(&tok.loginfo, "unknown pragma wrappers directive '%s', skipping until EOL\n", string_content(tok.tokv.str));
 						goto preproc_hash_err;
 					}
+				} else if (!strcmp(string_content(tok.tokv.str), "GCC")) {
+					string_del(tok.tokv.str);
+					tok = ppsrc_next_token(src);
+					if ((tok.tokt != PPTOK_IDENT) && (tok.tokt != PPTOK_IDENT_UNEXP)) {
+						log_error(&tok.loginfo, "unknown pragma GCC directive, skipping until EOL\n");
+						goto preproc_hash_err;
+					} else if (!strcmp(string_content(tok.tokv.str), "diagnostic")) {
+						// Silently ignore pragma directive
+						goto preproc_hash_err;
+					} else {
+						log_error(&tok.loginfo, "unknown pragma GCC directive '%s', skipping until EOL\n", string_content(tok.tokv.str));
+						goto preproc_hash_err;
+					}
 				} else {
 					log_error(&tok.loginfo, "unknown pragma directive '%s', skipping until EOL\n", string_content(tok.tokv.str));
 					goto preproc_hash_err;
@@ -2983,7 +3008,7 @@ start_cur_token:
 				}
 				tok = ppsrc_next_token(src);
 				loginfo_t li = tok.loginfo;
-				while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_INVALID)) {
+				while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_AT_SYM) && (tok.tokt != PPTOK_INVALID)) {
 					if (!vector_push(preproc, cond, tok)) {
 						log_memory("failed to add token to #if condition vector\n");
 						vector_del(preproc, cond);
@@ -3199,7 +3224,7 @@ start_cur_token:
 			
 			log_warning(&tok.loginfo, "Unknown preprocessor command %s, skipping until EOL\n", string_content(tok.tokv.str));
 		preproc_hash_err:
-			while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_INVALID)) {
+			while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_AT_SYM) && (tok.tokt != PPTOK_INVALID)) {
 				preproc_token_del(&tok);
 				tok = ppsrc_next_token(src);
 			}
@@ -3207,7 +3232,7 @@ start_cur_token:
 			else goto start_cur_token;
 			
 		preproc_hash_err_goto:
-			while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_INVALID)) {
+			while ((tok.tokt != PPTOK_NEWLINE) && (tok.tokt != PPTOK_EOF) && (tok.tokt != PPTOK_AT_SYM) && (tok.tokt != PPTOK_INVALID)) {
 				preproc_token_del(&tok);
 				tok = ppsrc_next_token(src);
 			}


### PR DESCRIPTION
This PR adds support for versioned function symbols in reference files, as well as outputting versioned symbols.
This PR also silences "unknown pragma" warnings for `#pragma GCC diagnostic`, and marks the `src/machine.gen` file as `.PHONY` to allow system updates to regenerate this file.