### PR TITLE
[WRAPPERHELPER] Added typedef translation pre-reservation

### DIFF
--- a/wrapperhelper/README.md
+++ b/wrapperhelper/README.md
@@ -49,6 +49,12 @@ Declarations of the form
 will mark the structure or union with tag `TAG`, or the structure or union aliased to `TAG` by a `typedef` if no such structure exist, as simple. This means that a pointer to such a structure will have a character output of `p`.
 This is not the same as making the pointer to the structure a complex type with conversion as `p` as e.g. pointers to pointers will behave differently.
 
+Declarations of the form
+```c
+#pragma wrappers prereserve_simple c IDENT
+```
+will mark the *future* type alias (`typedef`) `IDENT` as a simple type with a conversion as `c`. Note that the declaration must precede the type definition.
+
 System headers included (directly or indirectly) by the support file are overriden by the files in `include-fixed`.
 
 The first three lines of the input are ignored.

--- a/wrapperhelper/src/generator.c
+++ b/wrapperhelper/src/generator.c
@@ -745,7 +745,7 @@ success:
 
 // Simple versions (in practice, only use x86_64 and aarch64 as emu/target pair)
 static int is_simple_type_ptr_to_simple(type_t *typ, int *needs_D, int *needs_my, khash_t(conv_map) *conv_map) {
-	if (typ->converted) {
+	if (typ->converted && (typ->typ != TYPE_PRERESERVED)) {
 		// log_warning_nopos("%s uses a converted type but is not the converted type\n", string_content(obj_name));
 		*needs_my = 1;
 	} else if (kh_get(conv_map, conv_map, typ) != kh_end(conv_map)) {
@@ -753,6 +753,8 @@ static int is_simple_type_ptr_to_simple(type_t *typ, int *needs_D, int *needs_my
 		*needs_my = 1;
 	}
 	switch (typ->typ) {
+	case TYPE_PRERESERVED:
+		return typ->val.preres.is_simple;
 	case TYPE_BUILTIN:
 		return 1; // Assume pointers to builtin are simple
 	case TYPE_ARRAY:
@@ -793,6 +795,8 @@ static int is_simple_type_simple(type_t *typ, int *needs_D, int *needs_my, khash
 		*needs_my = 1;
 	}
 	switch (typ->typ) {
+	case TYPE_PRERESERVED:
+		return typ->val.preres.is_simple;
 	case TYPE_BUILTIN:
 		return (typ->val.builtin != BTT_FLOAT128)
 		    && (typ->val.builtin != BTT_CFLOAT128)
@@ -854,6 +858,9 @@ static int convert_type_simple(string_t *dest, type_t *emu_typ, type_t *target_t
 		*needs_my = 1;
 	}
 	switch (emu_typ->typ) {
+	case TYPE_PRERESERVED:
+		log_internal_nopos("convert_type_simple fallthrough to switch for TYPE_PRERESERVED\n");
+		return 0;
 	case TYPE_BUILTIN: {
 		int has_char = 0;
 		char c;
@@ -986,6 +993,7 @@ static int convert_type_post_simple(string_t *dest, type_t *emu_typ, type_t *tar
 	}
 	(void)target_typ;
 	switch (emu_typ->typ) {
+	case TYPE_PRERESERVED: return 1;
 	case TYPE_BUILTIN: return 1;
 	case TYPE_ARRAY: return 1;
 	case TYPE_STRUCT_UNION:
@@ -1215,7 +1223,7 @@ static enum safeness_e get_safeness_ptr(type_t *emu_typ, type_t *target_typ, int
 		log_error_nopos("%s: pointer with different types between emu and target\n", string_content(obj_name));
 		return SAFE_ABORT;
 	}
-	if (emu_typ->converted) {
+	if ((emu_typ->converted) && (emu_typ->typ != TYPE_PRERESERVED)) {
 		log_warning_nopos("%s uses a converted type but is not the converted type\n", string_content(obj_name));
 		*needs_my = 1;
 		return SAFE_OK;
@@ -1225,6 +1233,8 @@ static enum safeness_e get_safeness_ptr(type_t *emu_typ, type_t *target_typ, int
 		return SAFE_OK;
 	}
 	switch (emu_typ->typ) {
+	case TYPE_PRERESERVED:
+		return SAFE_ABORT;
 	case TYPE_BUILTIN:
 		if (emu_typ->val.builtin != target_typ->val.builtin) {
 			// log_warning_nopos("%s: emu and target have pointers to different size type\n", string_content(obj_name));
@@ -1330,7 +1340,7 @@ static enum safeness_e get_safeness(type_t *emu_typ, type_t *target_typ, int *ne
 		log_error_nopos("%s: data with different types between emu and target\n", string_content(obj_name));
 		return SAFE_ABORT; // Invalid type
 	}
-	if (emu_typ->converted) {
+	if ((emu_typ->converted) && (emu_typ->typ != TYPE_PRERESERVED)) {
 		// log_warning_nopos("%s uses a converted type but is not the converted type\n", string_content(obj_name));
 		*needs_my = 1;
 		return SAFE_OK;
@@ -1340,6 +1350,8 @@ static enum safeness_e get_safeness(type_t *emu_typ, type_t *target_typ, int *ne
 		return SAFE_OK;
 	}
 	switch (emu_typ->typ) {
+	case TYPE_PRERESERVED:
+		return SAFE_ABORT;
 	case TYPE_BUILTIN:
 		if ((emu_typ->val.builtin != target_typ->val.builtin)
 		    || (emu_typ->szinfo.size != target_typ->szinfo.size)
@@ -1446,6 +1458,9 @@ static int convert_type(string_t *dest, type_t *emu_typ, type_t *target_typ, int
 		return 0;
 	}
 	switch (emu_typ->typ) {
+	case TYPE_PRERESERVED:
+		log_internal_nopos("convert_type fallthrough to switch for TYPE_PRERESERVED\n");
+		return 0;
 	case TYPE_BUILTIN: {
 		int has_char = 0;
 		char c;
@@ -1593,6 +1608,9 @@ static int convert_type(string_t *dest, type_t *emu_typ, type_t *target_typ, int
 			target_typ = target_typ->val.typ;
 		do_expanded:
 			switch (emu_typ->typ) {
+			case TYPE_PRERESERVED:
+				log_internal_nopos("convert_type got SAFE_EXPAND for TYPE_PRERESERVED\n");
+				return 0;
 			case TYPE_BUILTIN:
 				if (!convert_type(dest, emu_typ, target_typ, 0, needs_S, needs_D, needs_my, conv_map, obj_name)) {
 					return 0;
@@ -1660,6 +1678,7 @@ static int convert_type_post(string_t *dest, type_t *emu_typ, type_t *target_typ
 	}
 	(void)target_typ;
 	switch (emu_typ->typ) {
+	case TYPE_PRERESERVED: return 1;
 	case TYPE_BUILTIN: return 1;
 	case TYPE_ARRAY: return 1;
 	case TYPE_STRUCT_UNION:

--- a/wrapperhelper/src/lang.c
+++ b/wrapperhelper/src/lang.c
@@ -89,6 +89,7 @@ void proc_token_del(proc_token_t *tok) {
 		case PRAGMA_SIMPLE_SU:
 		case PRAGMA_EXPLICIT_CONV:
 		case PRAGMA_EXPLICIT_CONV_STRICT:
+		case PRAGMA_PRERESERVE:
 			string_del(tok->tokv.pragma.val);
 			break;
 		case PRAGMA_ALLOW_INTS:
@@ -309,6 +310,9 @@ void proc_token_print(const proc_token_t *tok) {
 			break;
 		case PRAGMA_EXPLICIT_CONV_STRICT:
 			printf("%7s Strict explicit conversion: destination is %s\n", "PRAGMA", string_content(tok->tokv.pragma.val));
+			break;
+		case PRAGMA_PRERESERVE:
+			printf("%7s Prereserve: destination is %s\n", "PRAGMA", string_content(tok->tokv.pragma.val));
 			break;
 		default:
 			printf("%7s ??? %u\n", "PRAGMA", tok->tokv.pragma.typ);
@@ -753,6 +757,8 @@ void type_del(type_t *typ) {
 	if (--typ->nrefs) return;
 	if (typ->converted) string_del(typ->converted);
 	switch (typ->typ) {
+	case TYPE_PRERESERVED:
+		break;
 	case TYPE_BUILTIN:
 		break;
 	case TYPE_ARRAY:
@@ -888,7 +894,16 @@ int type_copy_into(type_t *dest, const type_t *ref) {
 	_Bool is_restrict = dest->is_restrict;
 	_Bool is_volatile = dest->is_volatile;
 	memcpy(dest, ref, sizeof *dest);
+	if (dest->converted) {
+		dest->converted = string_dup(dest->converted);
+		if (!dest->converted) {
+			log_memory("failed to duplicate conversion string\n");
+			return 0;
+		}
+	}
 	switch (ref->typ) {
+	case TYPE_PRERESERVED:
+		break;
 	case TYPE_BUILTIN:
 		break;
 	case TYPE_ARRAY:
@@ -945,6 +960,7 @@ struct_t *struct_new(int is_struct, string_t *tag) {
 
 khint_t type_t_hash(type_t *typ) {
 	switch (typ->typ) {
+	case TYPE_PRERESERVED: return kh_str_hash_func(string_content(typ->converted));
 	case TYPE_BUILTIN: return kh_int_hash_func(typ->val.builtin);
 	case TYPE_ARRAY: return kh_int_hash_func((typ->val.array.array_sz << 12) + type_t_hash(typ->val.array.typ));
 	case TYPE_STRUCT_UNION:
@@ -972,6 +988,7 @@ khint_t type_t_hash(type_t *typ) {
 	}
 }
 int type_t_equal_aux(type_t *typ1, type_t *typ2, int is_strict) {
+	if (typ1 == typ2) return 1;
 	if (is_strict && (
 	    (typ1->is_atomic != typ2->is_atomic) || (typ1->is_const != typ2->is_const)
 	 || (typ1->is_restrict != typ2->is_restrict) || (typ1->is_volatile != typ2->is_volatile))) {
@@ -979,6 +996,9 @@ int type_t_equal_aux(type_t *typ1, type_t *typ2, int is_strict) {
 	}
 	if (typ1->typ != typ2->typ) return 0;
 	switch (typ1->typ) {
+	case TYPE_PRERESERVED:
+		return (typ1->val.preres.is_simple == typ2->val.preres.is_simple) &&
+		       !strcmp(string_content(typ1->converted), string_content(typ2->converted));
 	case TYPE_BUILTIN: return typ1->val.builtin == typ2->val.builtin;
 	case TYPE_ARRAY: return (typ1->val.array.array_sz == typ2->val.array.array_sz) && type_t_equal_aux(typ1->val.array.typ, typ2->val.array.typ, is_strict);
 	case TYPE_STRUCT_UNION:
@@ -1028,6 +1048,7 @@ type_t *type_try_merge(type_t *typ, khash_t(type_set) *set) {
 	khiter_t it = kh_put(type_set, set, typ, &iret);
 	if (iret < 0) {
 		log_memory("Error: failed to add type to type_set\n");
+		type_del(typ);
 		return NULL;
 	} else if (iret == 0) {
 		if (typ == kh_key(set, it)) return typ;
@@ -1040,6 +1061,8 @@ type_t *type_try_merge(type_t *typ, khash_t(type_set) *set) {
 	}
 	type_t *typ2;
 	switch (typ->typ) {
+	case TYPE_PRERESERVED:
+		return typ;
 	case TYPE_BUILTIN:
 		return typ;
 	case TYPE_ARRAY:
@@ -1139,6 +1162,9 @@ void type_print(type_t *typ) {
 	if (typ->is_volatile) printf("volatile ");
 	if (typ->is_atomic) printf("_Atomic ");
 	switch (typ->typ) {
+	case TYPE_PRERESERVED:
+		printf("<%s prereserved>", typ->val.preres.is_simple ? "simple" : "complex");
+		break;
 	case TYPE_BUILTIN:
 		printf("<builtin %s (%u)>", builtin2str[typ->val.builtin], typ->val.builtin);
 		break;

--- a/wrapperhelper/src/lang.h
+++ b/wrapperhelper/src/lang.h
@@ -169,6 +169,7 @@ typedef struct proc_token_s {
 				PRAGMA_SIMPLE_SU,
 				PRAGMA_EXPLICIT_CONV,
 				PRAGMA_EXPLICIT_CONV_STRICT,
+				PRAGMA_PRERESERVE,
 			} typ;
 			string_t *val;
 		} pragma;
@@ -310,6 +311,7 @@ typedef struct type_s {
 	};
 	size_t nrefs;
 	enum type_type_e {
+		TYPE_PRERESERVED,  // pre-reserved by pragma
 		TYPE_BUILTIN,      // builtin
 		TYPE_ARRAY,        // array
 		TYPE_STRUCT_UNION, // st
@@ -318,6 +320,9 @@ typedef struct type_s {
 		TYPE_FUNCTION,     // fun
 	} typ;
 	union {
+		struct {
+			unsigned is_simple : 1;
+		} preres;
 		enum type_builtin_e {
 			BTT_VOID,
 			BTT_BOOL,

--- a/wrapperhelper/src/machine.c
+++ b/wrapperhelper/src/machine.c
@@ -158,6 +158,7 @@ void fill_self_recursion(type_t *typ, struct_t *st) {
 	if (typ->_internal_use) return; // Recursion, but not self recursion
 	typ->_internal_use = 1;
 	switch (typ->typ) {
+	case TYPE_PRERESERVED: break;
 	case TYPE_BUILTIN: break;
 	case TYPE_ARRAY:
 		fill_self_recursion(typ->val.array.typ, st);
@@ -210,6 +211,7 @@ int validate_type(loginfo_t *loginfo, machine_t *target, type_t *typ) {
 		}
 	}
 	switch (typ->typ) {
+	case TYPE_PRERESERVED: typ->szinfo.align = typ->szinfo.size = 0; return !!typ->converted;
 	case TYPE_BUILTIN:
 		switch (typ->val.builtin) {
 		case BTT_VOID:        typ->szinfo.align = typ->szinfo.size = 0; return 1;

--- a/wrapperhelper/src/parse.c
+++ b/wrapperhelper/src/parse.c
@@ -2966,13 +2966,13 @@ static int parse_declarator(machine_t *target, struct parse_declarator_dest_s *d
 						// Empty destructor
 						goto failed;
 					} else if (iret == 0) {
-						if (!type_t_equal(typ, kh_val(dest->f->type_map, it))) {
+						if ((kh_val(dest->f->type_map, it)->typ != TYPE_PRERESERVED) && !type_t_equal(typ, kh_val(dest->f->type_map, it))) {
 							log_error(&tok->loginfo, "'%s' is already in the type map with a different type\n", cident);
 							free(cident);
 							// Empty destructor
 							goto failed;
 						}
-						// We can safely ignore this since we have typedef-ed the same type
+						// We can safely ignore this since we have typedef-ed a prereserved type or the same type
 						free(cident);
 						type_del(typ);
 					} else {
@@ -3524,6 +3524,52 @@ file_t *parse_file(machine_t *target, const char *filename, FILE *file) {
 				string_trim(converted);
 				typ2->converted = converted;
 				// Empty destructor
+				break; }
+			case PRAGMA_PRERESERVE: {
+				string_t *converted = tok.tokv.pragma.val;
+				// Token moved
+				tok = proc_next_token(prep);
+				if (tok.tokt != PTOK_IDENT) {
+					log_error(&tok.loginfo, "unexpected token during pragma prereserve\n");
+					string_del(converted);
+					proc_token_del(&tok);
+					goto failed;
+				}
+				string_trim(converted);
+				string_trim(tok.tokv.str);
+				type_t *typ2 = type_new();
+				if (!typ2) {
+					log_memory("failed to create new type info structure\n");
+					string_del(converted);
+					type_del(typ2);
+					goto failed;
+				}
+				typ2->typ = TYPE_PRERESERVED;
+				typ2->val.preres.is_simple = 1;
+				typ2->converted = converted;
+				typ2 = type_try_merge(typ2, ret->type_set);
+				type_del(typ2);
+				if (!validate_type(&tok.loginfo, target, typ2)) {
+					string_del(converted);
+					string_del(tok.tokv.str);
+					goto failed;
+				}
+				int iret;
+				char *tname = string_steal(tok.tokv.str);
+				khiter_t it = kh_put(type_map, ret->type_map, tname, &iret);
+				if (iret < 0) {
+					log_memory("Error: failed to add prereserved type %s to type_map\n", tname);
+					free(tname);
+					goto failed;
+				} else if (iret == 0) {
+					log_error(&tok.loginfo, "failed to prereserve type %s: type already exists\n", tname);
+					free(tname);
+					goto failed;
+				} else {
+					kh_val(ret->type_map, it) = typ2;
+					++typ2->nrefs;
+				}
+				// Token moved
 				break; }
 			}
 		} else if (proc_token_iserror(&tok)) {

--- a/wrapperhelper/src/preproc.c
+++ b/wrapperhelper/src/preproc.c
@@ -2921,7 +2921,7 @@ start_cur_token:
 						string_del(tok.tokv.str);
 						tok = ppsrc_next_token(src);
 						if ((tok.tokt != PPTOK_IDENT) && (tok.tokt != PPTOK_IDENT_UNEXP)) {
-							log_error(&tok.loginfo, "invalid pragma wrappers explicit_simple directive, skipping until EOL\n");
+							log_error(&tok.loginfo, "invalid pragma wrappers mark_simple directive, skipping until EOL\n");
 							goto preproc_hash_err;
 						}
 						src->st = PPST_NL;
@@ -2944,7 +2944,7 @@ start_cur_token:
 						string_del(tok.tokv.str);
 						tok = ppsrc_next_token(src);
 						if ((tok.tokt != PPTOK_IDENT) && (tok.tokt != PPTOK_IDENT_UNEXP)) {
-							log_error(&tok.loginfo, "invalid pragma wrappers explicit_simple directive, skipping until EOL\n");
+							log_error(&tok.loginfo, "invalid pragma wrappers type_letters directive, skipping until EOL\n");
 							goto preproc_hash_err;
 						}
 						src->st = PPST_PRAGMA_EXPLICIT;
@@ -2957,13 +2957,26 @@ start_cur_token:
 						string_del(tok.tokv.str);
 						tok = ppsrc_next_token(src);
 						if ((tok.tokt != PPTOK_IDENT) && (tok.tokt != PPTOK_IDENT_UNEXP)) {
-							log_error(&tok.loginfo, "invalid pragma wrappers explicit_simple directive, skipping until EOL\n");
+							log_error(&tok.loginfo, "invalid pragma wrappers type_letters_exact directive, skipping until EOL\n");
 							goto preproc_hash_err;
 						}
 						src->st = PPST_PRAGMA_EXPLICIT;
 						ret.tokt = PTOK_PRAGMA;
 						ret.loginfo = tok.loginfo;
 						ret.tokv.pragma.typ = PRAGMA_EXPLICIT_CONV_STRICT;
+						ret.tokv.pragma.val = tok.tokv.str;
+						return ret;
+					} else if (!strcmp(string_content(tok.tokv.str), "prereserve_simple")) {
+						string_del(tok.tokv.str);
+						tok = ppsrc_next_token(src);
+						if ((tok.tokt != PPTOK_IDENT) && (tok.tokt != PPTOK_IDENT_UNEXP)) {
+							log_error(&tok.loginfo, "invalid pragma wrappers prereserve_simple directive, skipping until EOL\n");
+							goto preproc_hash_err;
+						}
+						src->st = PPST_PRAGMA_EXPLICIT;
+						ret.tokt = PTOK_PRAGMA;
+						ret.loginfo = tok.loginfo;
+						ret.tokv.pragma.typ = PRAGMA_PRERESERVE;
 						ret.tokv.pragma.val = tok.tokv.str;
 						return ret;
 					} else {


### PR DESCRIPTION
This PR adds a new pragma for the wrapper helper: `#pragma wrappers prereserve_simple c IDENT`. This declaration will define the future type alias `IDENT` to be converted into a `c`.

For example, the following declarations are built-in at the start of every parsing:
```c
#pragma wrappers prereserve_simple U uint64_t
#pragma wrappers prereserve_simple u uint32_t
#pragma wrappers prereserve_simple I int64_t
```