### PR TITLE
Fix ogg_sync_pageout hook infinite recursion after 2df07b59

### DIFF
--- a/src/include/alternate.h
+++ b/src/include/alternate.h
@@ -11,6 +11,8 @@ void* getAlternate(void* addr);
 void addAlternate(void* addr, void* alt);
 void addCheckAlternate(void* addr, void* alt);
 void cleanAlternate(void);
+void suppressAlternate(void* addr);
+void unsuppressAlternate(void* addr);
 #ifdef HAVE_ALTJUMP
 uintptr_t getAlternateJump(void* addr, int is32bits);
 #endif

--- a/src/mallochook.c
+++ b/src/mallochook.c
@@ -881,8 +881,12 @@ static void*     ogg_page_body_copy = NULL;
 
 static int my_ogg_sync_pageout_32(void* oy, void* og)
 {
-    // Call the original emulated ogg_sync_pageout
+    // Suppress the alternate for the duration of the call to avoid
+    // infinite recursion: RunFunctionFmt -> EmuRun -> getAlternate
+    // would redirect back to this hook without suppression.
+    suppressAlternate((void*)real_ogg_sync_pageout_32);
     int ret = (int)RunFunctionFmt(real_ogg_sync_pageout_32, "pp", oy, og);
+    unsuppressAlternate((void*)real_ogg_sync_pageout_32);
 
     if(ret > 0 && og) {
         // ogg_sync_pageout succeeded — og now has pointers into oy->data

--- a/src/tools/alternate.c
+++ b/src/tools/alternate.c
@@ -20,8 +20,16 @@ typedef struct {
 KHASH_MAP_INIT_INT64(alternate, my_alternate_t)
 static kh_alternate_t *my_alternates = NULL;
 
+// Per-address suppression: when set, getAlternate/hasAlternate/getAlternateJump
+// will return "no alternate" for this specific address.  Used by hooks that need
+// to call through to the original emulated function via RunFunctionFmt without
+// triggering infinite recursion (EmuRun applies getAlternate every iteration).
+static uintptr_t alternate_suppress = 0;
+
 int hasAlternate(void* addr) {
     if(!my_alternates)
+        return 0;
+    if((uintptr_t)addr == alternate_suppress)
         return 0;
     khint_t k = kh_get(alternate, my_alternates, (uintptr_t)addr);
     if(k==kh_end(my_alternates))
@@ -31,6 +39,8 @@ int hasAlternate(void* addr) {
 
 void* getAlternate(void* addr) {
     if(!my_alternates)
+        return addr;
+    if((uintptr_t)addr == alternate_suppress)
         return addr;
     khint_t k = kh_get(alternate, my_alternates, (uintptr_t)addr);
     if(k!=kh_end(my_alternates))
@@ -53,6 +63,15 @@ void addAlternate(void* addr, void* alt) {
     #endif
 }
 
+void suppressAlternate(void* addr) {
+    alternate_suppress = (uintptr_t)addr;
+}
+
+void unsuppressAlternate(void* addr) {
+    (void)addr;
+    alternate_suppress = 0;
+}
+
 void addCheckAlternate(void* addr, void* alt) {
     if(!hasAlternate(addr))
         addAlternate(addr, alt);
@@ -69,6 +88,8 @@ void cleanAlternate() {
 #include "bridge_private.h"
 uintptr_t getAlternateJump(void* addr, int is32bits) {
     if(!my_alternates)
+        return 0;
+    if((uintptr_t)addr == alternate_suppress)
         return 0;
     khint_t k = kh_get(alternate, my_alternates, (uintptr_t)addr);
     if(k!=kh_end(my_alternates)) {


### PR DESCRIPTION
- Fix infinite recursion in the `ogg_sync_pageout` hook caused by commit 2df07b59 (`[DYNAREC] Refactored how Alt are undled with Dynarec`)
- Add `suppressAlternate`/`unsuppressAlternate` API to temporarily bypass alternate resolution for a specific address

I have tested it on PPC64LE, but love to get help from other backend contributors to see my changes would cause any issue