### PR TITLE
[LA64_DYNAREC] Removed assert in x87_get_current_cache ([RV64_DYNAREC] too)

### DIFF
--- a/src/dynarec/la64/dynarec_la64_helper.c
+++ b/src/dynarec/la64/dynarec_la64_helper.c
@@ -1207,7 +1207,6 @@ int x87_get_current_cache(dynarec_la64_t* dyn, int ninst, int st, int t)
 #endif
             return i;
         }
-        assert(dyn->lsx.x87cache[i] < 8);
     }
     return -1;
 }
@@ -1252,7 +1251,7 @@ int x87_get_lsxcache(dynarec_la64_t* dyn, int ninst, int s1, int s2, int st)
                 || dyn->lsx.lsxcache[ii].t == LSX_CACHE_ST_I64)
             && dyn->lsx.lsxcache[ii].n == st)
             return ii;
-    assert(0);
+    dynarec_log(LOG_NONE, "Warning: x87_get_lsxcache didn't find cache for ninst=%d\n", ninst);
     return -1;
 }
 int x87_get_st(dynarec_la64_t* dyn, int ninst, int s1, int s2, int a, int t)

--- a/src/dynarec/rv64/dynarec_rv64_helper.c
+++ b/src/dynarec/rv64/dynarec_rv64_helper.c
@@ -1097,7 +1097,6 @@ int x87_get_current_cache(dynarec_rv64_t* dyn, int ninst, int st, int t)
 #endif
             return i;
         }
-        assert(dyn->e.x87cache[i] < 8);
     }
     return -1;
 }
@@ -1144,7 +1143,7 @@ int x87_get_extcache(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int st)
                 || dyn->e.extcache[ii].t == EXT_CACHE_ST_I64)
             && dyn->e.extcache[ii].n == st)
             return ii;
-    assert(0);
+    dynarec_log(LOG_NONE, "Warning: x87_get_extcache didn't find cache for ninst=%d\n", ninst);
     return -1;
 }
 int x87_get_st(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int a, int t)


### PR DESCRIPTION
It's fine to have the logical ST exceeds 8. This fixes sequence like
```
fsubr st0, st7
fxtract
fucompp
```