### PR TITLE
[ARM64_DYNAREC] Fixed a edge case of df tracking for LOCK CMPXCHG16B opcode

### DIFF
--- a/src/dynarec/arm64/dynarec_arm64_f0.c
+++ b/src/dynarec/arm64/dynarec_arm64_f0.c
@@ -792,6 +792,8 @@ uintptr_t dynarec64_F0(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int nin
                                 }
                             }
                             MARK3;
+                            if(!ALIGNED_ATOMICxw && rex.w && BOX64DRENV(dynarec_safeflags)>1)
+                                FORCE_DFNONE();
                             UFLAG_IF {
                                 IFNATIVE(NF_EQ) {} else {BFIw(xFlags, x1, F_ZF, 1);}
                             }


### PR DESCRIPTION
call_c() was called in unaligned path when safeflags=2, which set status_none, where the aligned path don't. Fix this issue by explicitly calling FORCE_DFNONE() at the converge point.