### PR TITLE
[BOX32] Add library path used by Debian "cross" packages

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -497,6 +497,8 @@ void LoadLDPath(box64context_t *context)
             AddPath("/usr/lib/i386-linux-gnu", &context->box64_ld_lib, 1);
         if(FileExist("/usr/i386-linux-gnu/lib", 0))
             AddPath("/usr/i386-linux-gnu/lib", &context->box64_ld_lib, 1);
+        if(FileExist("/usr/i686-linux-gnu/lib", 0))
+            AddPath("/usr/i686-linux-gnu/lib", &context->box64_ld_lib, 1);
         if(FileExist("/usr/lib/box64-i386-linux-gnu", 0))
             AddPath("/usr/lib/box64-i386-linux-gnu", &context->box64_ld_lib, 1);
         if(FileExist("/opt/box64/lib32", 0))


### PR DESCRIPTION
This is mainly for Debian (and Ubuntu), where the emulated libraries required by Box32 (libgcc_s and libstdc++) could be conviniently installed through provided cross-compilation packages, but the installation path (`/usr/i686-linux-gnu/lib`) has to be supported first. 

(see: https://packages.debian.org/sid/all/libgcc-s1-i386-cross/filelist)