### PR TITLE
Change function type in wrappedlibxcbrenderutil_private.h

### DIFF
--- a/src/wrapped/wrappedlibxcbrenderutil_private.h
+++ b/src/wrapped/wrappedlibxcbrenderutil_private.h
@@ -9,8 +9,8 @@
 //GO(xcb_render_util_composite_text_stream, 
 //GO(xcb_render_util_disconnect, 
 //GO(xcb_render_util_find_format, 
-GO(xcb_render_util_find_standard_format, uFpi)
-GO(xcb_render_util_find_visual_format, pFpp)
+GO(xcb_render_util_find_standard_format, pFpi)
+GO(xcb_render_util_find_visual_format, pFpu)
 //GO(xcb_render_util_glyphs_16, 
 //GO(xcb_render_util_glyphs_32, 
 //GO(xcb_render_util_glyphs_8, 


### PR DESCRIPTION
when testing  an application, I find 2 errors.
(1) xcb_render_util_find_standard_format should be "pFpi". const xcb_render_pictforminfo_t *
xcb_render_util_find_standard_format(
    const xcb_render_query_pict_formats_reply_t *formats,
    xcb_pict_standard_t                          format
);
(2)xcb_render_util_find_visual_format should be "pFpu"
const xcb_render_pictvisual_t *
xcb_render_util_find_visual_format(
    const xcb_render_query_pict_formats_reply_t *formats,
    const xcb_visualid_t                         visual
);
/usr/include/xcb/xproto.h:typedef uint32_t xcb_visualid_t;

Hope the founds help you!