### PR TITLE
[ARM64_DYNAREC] Fix NaN detection operand typo

### DIFF
--- a/src/dynarec/arm64/dynarec_arm64_avx_f3_0f.c
+++ b/src/dynarec/arm64/dynarec_arm64_avx_f3_0f.c
@@ -214,7 +214,7 @@ uintptr_t dynarec64_AVX_F3_0F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, 
                 q0 = fpu_get_scratch(dyn, ninst);
                 q1 = fpu_get_scratch(dyn, ninst);
                 // check if any input value was NAN
-                FCMEQS(q0, v1, v1);    // 0 if NAN, 1 if not NAN
+                FCMEQS(q0, d0, d0);    // 0 if NAN, 1 if not NAN
             }
             FSQRTS(d1, d0);
             if(!BOX64ENV(dynarec_fastnan)) {


### PR DESCRIPTION
The fastnan=0 path of VSQRTSS compared `v1` against itself for NaN detection, but `v1` is never assigned in this case where the input is loaded into `d0` by GETEXSS.


Before fix:
 ```  
sqrt(4.0)                        0x40000000 2
sqrt(-1.0)                       0xffc00000 -NaN
 sqrt(+QNaN)                      0xffc00000 -NaN     <-- expected 0x7fc00000 (+NaN)
 sqrt(-QNaN)                      0xffc00000 -NaN
```

After fix:

```    
sqrt(4.0)                        0x40000000 2
sqrt(-1.0)                       0xffc00000 -NaN
sqrt(+QNaN)                      0x7fc00000 +NaN
sqrt(-QNaN)                      0xffc00000 -NaN
```
   
Thanks !