### PR TITLE
Add strict EVEX dispatch for AVX512VL forms backed by existing AVX handlers

### DIFF
--- a/src/dynarec/arm64/dynarec_arm64_00.c
+++ b/src/dynarec/arm64/dynarec_arm64_00.c
@@ -950,7 +950,26 @@ uintptr_t dynarec64_00(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int nin
             break;
         case 0x62:
             nextop = F8;
-            if(rex.is32bits && !MODREG) {
+            if(!rex.is32bits) {
+                vex_t vex = {0};
+                u8 = F8;
+                u16 = F8;
+                if(FillVEXFromEVEX(&vex, rex, nextop, u8, u16)) {
+                    INST_NAME("EVEX");
+                    addr = dynarec64_AVX(dyn, addr, ip, ninst, vex, ok, need_epilog);
+                } else {
+                    INST_NAME("Illegal 62");
+                    if(BOX64DRENV(dynarec_safeflags)>1) {
+                        READFLAGS(X_PEND);
+                    } else {
+                        SETFLAGS(X_ALL, SF_SET_NODF);    // Hack to set flags in "don't care" state
+                    }
+                    GETIP(ip);
+                    UDF(0);
+                    *need_epilog = 1;
+                    *ok = 0;
+                }
+            } else if(!MODREG) {
                 INST_NAME("BOUND Gd, Ed");
                 addr = geted(dyn, addr, ninst, nextop, &wback, x1, &fixedaddress, NULL, 0, 0, rex, NULL, 0, 0);
                 LDRxw_U12(x2, wback, 0);

--- a/src/dynarec/arm64/dynarec_arm64_avx.c
+++ b/src/dynarec/arm64/dynarec_arm64_avx.c
@@ -71,7 +71,8 @@ uintptr_t dynarec64_AVX(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int ni
 
     if((*ok==-1) && (BOX64ENV(dynarec_log)>=LOG_INFO || dyn->need_dump || BOX64ENV(dynarec_missing)))
         if(!dyn->size || BOX64ENV(dynarec_log)>LOG_INFO || dyn->need_dump) {
-            dynarec_log(LOG_NONE, "  Dynarec unimplemented VEX opcode size %d prefix %s map %s opcode %02X\n", 128<<vex.l, avx_prefix_string(vex.p), avx_map_string(vex.m), opcode);
+            dynarec_log(LOG_NONE, "  Dynarec unimplemented %s opcode size %d prefix %s map %s opcode %02X\n",
+                vex.evex ? "EVEX" : "VEX", 128<<vex.l, avx_prefix_string(vex.p), avx_map_string(vex.m), opcode);
     }
     return addr;
 }

--- a/src/emu/x64run.c
+++ b/src/emu/x64run.c
@@ -504,9 +504,29 @@ x64emurun:
                 goto fini;
             }
             break;
-        case 0x62:                  /* BOUND Gd, Ed */
+        case 0x62:                  /* EVEX prefix / BOUND Gd, Ed */
             nextop = F8;
-            if(rex.is32bits && !MODREG) {
+            if(!rex.is32bits) {
+                vex_t vex = {0};
+                tmp8u = F8;
+                tmp8u2 = F8;
+                if(!FillVEXFromEVEX(&vex, rex, nextop, tmp8u, tmp8u2)) {
+                    unimp = 1;
+                    goto fini;
+                }
+                #ifdef TEST_INTERPRETER
+                if(!(addr = TestAVX(test, vex, addr, &step)))
+                    unimp = 1;
+                #else
+                if(!(addr = RunAVX(emu, vex, addr, &step))) {
+                    unimp = 1;
+                    goto fini;
+                }
+                if(step==2) {
+                    STEP2;
+                }
+                #endif
+            } else if(!MODREG) {
                 GETGD;
                 int* bounds = (int*)GETEA(0);
                 if((GD->sdword[0]<bounds[0]) || (GD->sdword[0]>bounds[1]))

--- a/src/emu/x64run_private.h
+++ b/src/emu/x64run_private.h
@@ -42,7 +42,42 @@ typedef struct vex_s {
     uint16_t    p:2;    //0: none, 1: 0x66, 2:0xF3, 3: 0xF2
     uint16_t    v:4;    // src register
     uint16_t    m:5;    // opcode map
+    uint16_t    evex:1; // was decoded from an EVEX prefix
 } vex_t;
+
+static inline int FillVEXFromEVEX(vex_t* vex, rex_t rex, uint8_t p0, uint8_t p1, uint8_t p2)
+{
+    uint8_t m = p0 & 0x0f;
+    uint8_t l = (p2 >> 5) & 0x03;
+
+    if(rex.is32bits || rex.is66 || rex.isf0 || rex.rep)
+        return 0;
+    if(!(p1 & 0x04))    // EVEX P1 bit 2 is reserved and must be 1
+        return 0;
+    if(m != VEX_M_0F && m != VEX_M_0F38 && m != VEX_M_0F3A)
+        return 0;
+    if(l > 1)           // no ZMM state yet
+        return 0;
+    if(!(p0 & 0x10))    // no high-16 destination register state yet
+        return 0;
+    if(!(p2 & 0x08))    // no high-16 NDS/VIDX register state yet
+        return 0;
+    if(p2 & 0x97)       // z, b and aaa need opmask/broadcast/SAE handling
+        return 0;
+
+    *vex = (vex_t){0};
+    vex->rex = rex;
+    vex->rex.b = (p0 & 0x20) ? 0 : 1;
+    vex->rex.x = (p0 & 0x40) ? 0 : 1;
+    vex->rex.r = (p0 & 0x80) ? 0 : 1;
+    vex->rex.w = (p1 >> 7) & 1;
+    vex->p = p1 & 0x03;
+    vex->l = l;
+    vex->v = ((~p1) >> 3) & 0x0f;
+    vex->m = m;
+    vex->evex = 1;
+    return 1;
+}
 
 // the op code definition can be found here: http://ref.x86asm.net/geek32.html
 

--- a/src/emu/x64runavx.c
+++ b/src/emu/x64runavx.c
@@ -106,7 +106,8 @@ uintptr_t RunAVX(x64emu_t *emu, vex_t vex, uintptr_t addr, int *step)
     else addr = 0;
 
     if(!addr)
-        printf_log(LOG_INFO, "Unimplemented AVX opcode size %d prefix %s map %s opcode %02X ", 128<<vex.l, avx_prefix_string(vex.p), avx_map_string(vex.m), opcode);
+        printf_log(LOG_INFO, "Unimplemented %s opcode size %d prefix %s map %s opcode %02X ",
+            vex.evex ? "EVEX" : "AVX", 128<<vex.l, avx_prefix_string(vex.p), avx_map_string(vex.m), opcode);
 #endif
 
     return addr;


### PR DESCRIPTION
dynarec/arm64: add strict EVEX dispatch for AVX-compatible AVX512VL forms

Add a shared EVEX-to-VEX decoder for EVEX instructions that Box64 can
represent with the existing 128/256-bit AVX register model and opcode
handlers.

The decoder accepts only k0/no-mask, no-broadcast, no-SAE/rounding,
non-ZMM, non-high-register EVEX forms, then routes them through the
existing AVX interpreter and ARM64 dynarec paths. Unsupported EVEX forms
still fail cleanly instead of being misdecoded as legacy BOUND or
silently producing incorrect results.

Also improve missing-opcode diagnostics to distinguish EVEX from VEX/AVX.

Tested with:
- avx_intrinsics ctest
- ARM64 dynarec native_pass0..3 build
- manual EVEX vaddps smoke test through interpreter and ARM64 dynarec
