### PR TITLE
[CORE] Fix unexpected modification of GetNativeName's return value

### DIFF
--- a/src/os/os_linux.c
+++ b/src/os/os_linux.c
@@ -106,9 +106,10 @@ const char* GetBridgeName(void* p)
     return getBridgeName(p);
 }
 
+static __thread char native_name[500] = { 0 };
+
 const char* GetNativeName(void* p, int lib)
 {
-    static char buff[500] = { 0 };
     {
         const char* n = GetBridgeName(p);
         if (n)
@@ -119,22 +120,22 @@ const char* GetNativeName(void* p, int lib)
         const char* ret = GetNameOffset(my_context->maplib, p);
         if (ret)
             return ret;
-        sprintf(buff, "%s(%p)", "???", p);
-        return buff;
+        sprintf(native_name, "%s(%p)", "???", p);
+        return native_name;
     } else {
         if (info.dli_sname) {
-            strcpy(buff, info.dli_sname);
+            strcpy(native_name, info.dli_sname);
             if (lib && info.dli_fname) {
-                strcat(buff, "(");
-                strcat(buff, info.dli_fname);
-                strcat(buff, ")");
+                strcat(native_name, "(");
+                strcat(native_name, info.dli_fname);
+                strcat(native_name, ")");
             }
         } else {
-            sprintf(buff, "%s(%s+%p)", "???", info.dli_fname, (void*)(p - info.dli_fbase));
-            return buff;
+            sprintf(native_name, "%s(%s+%p)", "???", info.dli_fname, (void*)(p - info.dli_fbase));
+            return native_name;
         }
     }
-    return buff;
+    return native_name;
 }
 
 

--- a/src/wrapped/wrappedlibdl.c
+++ b/src/wrapped/wrappedlibdl.c
@@ -523,6 +523,7 @@ int my_dladdr1(x64emu_t* emu, void *addr, void *i, void** extra_info, int flags)
     library_t* lib = NULL;
     info->dli_saddr = NULL;
     info->dli_fname = NULL;
+    // TODO: If dli_sname points to native_name, how do I avoid data tampering during usage?
     info->dli_sname = FindSymbolName(my_context->maplib, addr, &info->dli_saddr, NULL, &info->dli_fname, &info->dli_fbase, &lib);
     printf_log(LOG_DEBUG, "     dladdr return saddr=%p, fname=\"%s\", sname=\"%s\"\n", info->dli_saddr, info->dli_sname?info->dli_sname:"", info->dli_fname?info->dli_fname:"");
     if(flags==RTLD_DL_SYMENT) {

--- a/src/wrapped32/wrappedlibdl.c
+++ b/src/wrapped32/wrappedlibdl.c
@@ -77,6 +77,7 @@ int my32_dladdr1(x64emu_t* emu, void *addr, void *i, void** extra_info, int flag
     info->dli_saddr = to_ptrv(start);
     info->dli_fname = to_ptrv((void*)fname);
     info->dli_fbase = to_ptrv(base);
+    // TODO: If dli_sname points to native_name, how do I avoid data tampering during usage?
     info->dli_sname = to_ptrv((void*)sname);
     printf_log(LOG_DEBUG, "     dladdr return saddr=%p, fname=\"%s\", sname=\"%s\"\n", start, sname?sname:"", fname?fname:"");
     if(flags==RTLD_DL_SYMENT) {


### PR DESCRIPTION
When I enable `BOX64_ROLLING_LOG`, I observe an error that triggers a software exception in `x64Int3`. The direct cause of the error is that the value of `R_RSI` or `R_RDI` is passed to the `snprintf` function as a string pointer (e.g., line 183 in src/emu/x64int3.c), but the value of `R_RSI` or `R_RDI` at this time is not a valid string pointer.

Initially, I thought the values of `R_RSI` or `R_RDI` were incorrect, but after analysis, I found that when the error occurs, the actual function pointer, `a` is `my___tls_get_addr` instead of `fopen`, so the values of `R_RSI` and `R_RDI` are correct, and the symbol name is wrong.

Furthermore, I discovered that the value of the symbol name changes during the execution of the `x64Int3` function: it shifts from `__tls_get_addr` to `fopen` or other values. The root cause of this change is that a static array is used to store the symbol name in `GetNativeName`, leading to data tampering in a multi-threaded environment.

I changed the `static char buff` to `static __thread char native_name` to avoid multi-threaded data tampering.