### PR TITLE
[INTERP] Fixed 66 prefix decoding

### DIFF
--- a/src/emu/x64run.c
+++ b/src/emu/x64run.c
@@ -166,7 +166,7 @@ x64emurun:
                 goto fini;
             }
             #endif
-        } else if(rex.is66) {
+        } else if(rex.is66 && (!rex.w || opcode==0x0F)) {
             /* 16bits prefix */
             #ifdef TEST_INTERPRETER
             if(!(addr = Test66(test, rex, addr-1, &step)))


### PR DESCRIPTION
rex.w cancels "66", but not for 66 0f type of prefix. This was addressed in DynaRec, but not in the interpreter, not sure why.