### PR TITLE
[CMAKE] Updated minimum cmake version to be 3.19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.19)
 
 cmake_policy(SET CMP0065 NEW)
 


### PR DESCRIPTION
Hi,

To fix `file does not recognize sub-command CHMOD`.

Please review my patch.

Thanks,
Leslie Zhai