### PR TITLE
[RV64_DYNAREC] Fixed ANDNPS/ANDNPD/PANDN register reuse conflict in vector path

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_0f_vector.c
+++ b/src/dynarec/rv64/dynarec_rv64_0f_vector.c
@@ -569,6 +569,10 @@ uintptr_t dynarec64_0F_vector(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip,
             SET_ELEMENT_WIDTH(x1, VECTOR_SEW32, 1);
             GETEX_vector(q0, 0, 0, VECTOR_SEW32);
             GETGX_vector(v0, 1, VECTOR_SEW32);
+            if (v0 == q0) {
+                q0 = fpu_get_scratch(dyn);
+                VMV_V_V(q0, v0);
+            }
             VXOR_VI(v0, v0, 0x1f, VECTOR_UNMASKED);
             VAND_VV(v0, v0, q0, VECTOR_UNMASKED);
             break;

--- a/src/dynarec/rv64/dynarec_rv64_660f_vector.c
+++ b/src/dynarec/rv64/dynarec_rv64_660f_vector.c
@@ -1119,6 +1119,10 @@ uintptr_t dynarec64_660F_vector(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t i
             SET_ELEMENT_WIDTH(x1, VECTOR_SEWANY, 1);
             GETGX_vector(q0, 1, dyn->vector_eew);
             GETEX_vector(q1, 0, 0, dyn->vector_eew);
+            if (q0 == q1) {
+                q1 = fpu_get_scratch(dyn);
+                VMV_V_V(q1, q0);
+            }
             VXOR_VI(q0, q0, 0x1F, VECTOR_UNMASKED);
             VAND_VV(q0, q1, q0, VECTOR_UNMASKED);
             break;
@@ -2034,6 +2038,10 @@ uintptr_t dynarec64_660F_vector(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t i
             SET_ELEMENT_WIDTH(x1, VECTOR_SEWANY, 1);
             GETGX_vector(q0, 1, dyn->vector_eew);
             GETEX_vector(q1, 0, 0, dyn->vector_eew);
+            if (q0 == q1) {
+                q1 = fpu_get_scratch(dyn);
+                VMV_V_V(q1, q0);
+            }
             VXOR_VI(q0, q0, 0x1F, VECTOR_UNMASKED);
             VAND_VV(q0, q1, q0, VECTOR_UNMASKED);
             break;


### PR DESCRIPTION
Fix register reuse conflict in SSE ANDNPS/ANDNPD/PANDN for RV64 vector dynarec.

When Gx and Ex refer to the same register, VXOR_VI clobbers the source value while computing the NOT, causing VAND_VV to operate on incorrect data.

This patch detects the aliasing case and copies the source to a scratch register before applying NOT.

Affected instructions:
- ANDNPS in dynarec_rv64_0f_vector.c
- ANDNPD in dynarec_rv64_660f_vector.c
- PANDN in dynarec_rv64_660f_vector.c

Validation:
- ctest: 34/34 passed on RV64 hardware.