### PR TITLE
[RV64_DYNAREC] Fixed SBB16/SBB32 scratch register clobbering in flag calculation

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_emit_math.c
+++ b/src/dynarec/rv64/dynarec_rv64_emit_math.c
@@ -1040,7 +1040,7 @@ void emit_sbb16(dynarec_rv64_t* dyn, int ninst, int s1, int s2, int s3, int s4, 
     CLEAR_FLAGS();
     SLLIW(s1, s1, 16);
     IFX (X_SF) {
-        SET_FLAGS_LTZ(s1, F_SF, s4, s5);
+        SET_FLAGS_LTZ(s1, F_SF, s3, s4);
     }
     SRLIW(s1, s1, 16);
 
@@ -1080,7 +1080,7 @@ void emit_sbb32(dynarec_rv64_t* dyn, int ninst, rex_t rex, int s1, int s2, int s
 
     CLEAR_FLAGS();
     IFX (X_SF) {
-        SET_FLAGS_LTZ(s1, F_SF, s4, s5);
+        SET_FLAGS_LTZ(s1, F_SF, s3, s4);
     }
     if (!rex.w && (IS_GPR(s1) || dyn->insts[ninst].nat_flags_fusion)) {
         ZEROUP(s1);


### PR DESCRIPTION
Fixed SBB16/SBB32 SET_FLAGS_LTZ clobbering ~op1 in RV64 dynarec.

In emit_sbb16 and emit_sbb32, SET_FLAGS_LTZ used s5 as a scratch register, but s5 holds ~op1 which is needed later by CALC_SUB_FLAGS for borrow chain calculation. This caused CF and AF to be computed incorrectly.

Changed SET_FLAGS_LTZ scratch parameters from (s4, s5) to (s3, s4) to avoid clobbering ~op1.

Validation:
- ctest: 34/34 passed on RV64 hardware.
- Targeted SBB16/SBB32 test cases now produce correct CF and AF flags.