### PR TITLE
[RV64_DYNAREC] Fixed VHADDPD/VHSUBPD and VPSHUFB register clobbering in 256-bit path

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_avx_66_0f.c
+++ b/src/dynarec/rv64/dynarec_rv64_avx_66_0f.c
@@ -1352,6 +1352,7 @@ uintptr_t dynarec64_AVX_66_0F(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip,
             }
             d0 = fpu_get_scratch(dyn);
             d1 = fpu_get_scratch(dyn);
+            d2 = d0;
             FLD(d0, gback, vxoffset + 0);
             FLD(d1, gback, vxoffset + 8);
             if (!BOX64ENV(dynarec_fastnan)) {
@@ -1391,6 +1392,7 @@ uintptr_t dynarec64_AVX_66_0F(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip,
             }
             if (vex.l) {
                 GETEY();
+                d0 = d2;
                 if (gd == ed) {
                     FLD(v0, gback, gyoffset + 0);
                 }
@@ -1448,6 +1450,7 @@ uintptr_t dynarec64_AVX_66_0F(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip,
             }
             d0 = fpu_get_scratch(dyn);
             d1 = fpu_get_scratch(dyn);
+            d2 = d0;
             FLD(d0, gback, vxoffset + 0);
             FLD(d1, gback, vxoffset + 8);
             if (!BOX64ENV(dynarec_fastnan)) {
@@ -1487,6 +1490,7 @@ uintptr_t dynarec64_AVX_66_0F(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip,
             }
             if (vex.l) {
                 GETEY();
+                d0 = d2;
                 if (gd == ed) {
                     FLD(v0, gback, gyoffset + 0);
                 }

--- a/src/dynarec/rv64/dynarec_rv64_avx_66_0f38.c
+++ b/src/dynarec/rv64/dynarec_rv64_avx_66_0f38.c
@@ -78,8 +78,8 @@ uintptr_t dynarec64_AVX_66_0F38(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t i
             if (vex.l) {
                 GETEY();
                 if (gd == vex.v) {
-                    LD(x3, vback, vyoffset + 0);
-                    LD(x4, vback, vyoffset + 8);
+                    LD(x3, xEmu, vyoffset + 0);
+                    LD(x4, xEmu, vyoffset + 8);
                     SD(x3, x5, 0);
                     SD(x4, x5, 8);
                     vback = x5;


### PR DESCRIPTION
**Fixed two register clobbering bugs in AVX 256-bit paths on RV64 dynarec**

1. VHADDPD/VHSUBPD:

When 'gd == ed', 'd0 = v0' aliases both variables to the same FP register. This alias leaks into the 'vex.l' block, causing 'FLD(d0, ...)' to overwrite the Ey[0] value saved in v0.

Fix: save the original d0 scratch register in d2 after allocation, and restore 'd0 = d2' before the 'vex.l' block.

2. VPSHUFB:

The 128-bit 'gd == vex.v' path redirects 'vback' to scratch and resets 'vxoffset = 0', but 'vyoffset' remains relative to 'xEmu'. The 'vex.l' block then loads Vy data from the wrong base address.

Fix: use 'xEmu' directly as the base register for loading Vy data.


Validation:
- ctest: 34/34 passed on RV64 hardware.