### PR TITLE
fix clang warnings: use proper type in function signature

### DIFF
--- a/src/wrapped/generated/wrappedgmptypes.h
+++ b/src/wrapped/generated/wrappedgmptypes.h
@@ -12,10 +12,10 @@
 #endif
 
 typedef void (*vFppp_t)(void*, void*, void*);
-typedef int32_t (*iFppV_t)(void*, void*, ...);
-typedef int32_t (*iFppA_t)(void*, void*, va_list);
-typedef int32_t (*iFSpV_t)(void*, void*, ...);
-typedef int32_t (*iFSpA_t)(void*, void*, va_list);
+typedef int32_t (*iFppV_t)(void*, const char *, ...);
+typedef int32_t (*iFppA_t)(void*, const char *, va_list);
+typedef int32_t (*iFSpV_t)(void*, const char *, ...);
+typedef int32_t (*iFSpA_t)(void*, const char *, va_list);
 
 #define SUPER() ADDED_FUNCTIONS() \
 	GO(__gmp_get_memory_functions, vFppp_t) \


### PR DESCRIPTION
building on clang warns about type mismatch:

```
src/wrapped/wrappedgmp.c:158:38: warning: passing 'const char *' to parameter of type 'void *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
  158 |     return my->__gmp_vasprintf(strp, fmt, VARARGS);
      |                                      ^~~
  165 |     return my->__gmp_vfprintf(stream, fmt, VARARGS);
      |                                       ^~~
  176 |     return my->__gmp_vasprintf(strp, fmt, VARARGS);
      |                                      ^~~
  187 |     return my->__gmp_vfprintf(stream, fmt, VARARGS);
      |                                       ^~~
```

modifiy definition to use actual type instead of void.