### PR TITLE
fix clang warnings: use portable inttypes

### DIFF
--- a/src/os/sysinfo.c
+++ b/src/os/sysinfo.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <sched.h>
+#include <inttypes.h>
 
 #include "debug.h"
 #include "sysinfo.h"
@@ -170,7 +171,7 @@ fallback:
     sprintf(str, "%d", (info->ncpu) ? (int)info->ncpu : 1);
     setenv("BOX64_SYSINFO_NCPU", str, 1);
     setenv("BOX64_SYSINFO_CPUNAME", info->cpuname, 1);
-    sprintf(str, "%llu", info->frequency);
+    sprintf(str, "%" PRIu64, info->frequency);
     setenv("BOX64_SYSINFO_FREQUENCY", str, 1);
     setenv("BOX64_SYSINFO_CACHED", "1", 1);
     return;
@@ -190,7 +191,7 @@ void InitializeSystemInfo(void)
         if (box64_sysinfo.frequency > 1500000) {
             snprintf(branding, sizeof(branding), BOX64_BUILD_INFO_STRING_SHORT " on %.*s @%1.2f GHz", 28, box64_sysinfo.cpuname, box64_sysinfo.frequency / 1000000000.);
         } else {
-            snprintf(branding, sizeof(branding), BOX64_BUILD_INFO_STRING_SHORT " on %.*s @%04d MHz", 28, box64_sysinfo.cpuname, box64_sysinfo.frequency / 1000000);
+            snprintf(branding, sizeof(branding), BOX64_BUILD_INFO_STRING_SHORT " on %.*s @%04" PRIu64 " MHz", 28, box64_sysinfo.cpuname, box64_sysinfo.frequency / 1000000);
         }
     }
     box64_sysinfo.box64_cpuname = (char*)calloc(strlen(branding) + 1, 1);

--- a/src/tools/dynacache.c
+++ b/src/tools/dynacache.c
@@ -4,6 +4,7 @@
 #include <fcntl.h>
 #include <string.h>
 #include <stdint.h>
+#include <inttypes.h>
 #if defined(DYNAREC) && !defined(WIN32)
 #include <sys/types.h>
 #include <dirent.h>
@@ -168,7 +169,7 @@ char* MmaplistName(const char* filename, uint64_t dynarec_settings, const char* 
     // Where XXXXX is the hash of the full name
     // and YYYY is the Dynarec optim (in hex)
     static char mapname[4096];
-    snprintf(mapname, 4095-6, "%s-%llx-%u", filename, dynarec_settings, __ac_X31_hash_string(fullname));
+    snprintf(mapname, 4095-6, "%s-%" PRIx64 "-%u", filename, dynarec_settings, __ac_X31_hash_string(fullname));
     strcat(mapname, ".box64");
     return mapname;
 }


### PR DESCRIPTION
building using clang warns about format specifier mismatch

```
src/os/sysinfo.c:173:26: warning: format specifies type 'unsigned long long' but the argument has type 'uint64_t' (aka 'unsigned long') [-Wformat]
  173 |     sprintf(str, "%llu", info->frequency);
      |                   ~~~~   ^~~~~~~~~~~~~~~
      |                   %lu
src/os/sysinfo.c:193:129: warning: format specifies type 'int' but the argument has type 'uint64_t' (aka 'unsigned long') [-Wformat]
  193 |             snprintf(branding, sizeof(branding), BOX64_BUILD_INFO_STRING_SHORT " on %.*s @%04d MHz", 28, box64_sysinfo.cpuname, box64_sysinfo.frequency / 1000000);
      |                                                                                           ~~~~                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                           %04lu
```

use inttypes format macros instead of format specifiers directly