### PR TITLE
fix clang warnings that are bugs

### DIFF
--- a/src/tools/env.c
+++ b/src/tools/env.c
@@ -783,8 +783,9 @@ void RecordEnvMappings(uintptr_t addr, size_t length, int fd)
     if(strstr(lowercase_filename, "/memfd:")==lowercase_filename) {
         // memfd, first remove the (deleted) at the end
         char* p = strstr(lowercase_filename, " (deleted)");
-        if(p=lowercase_filename+strlen(lowercase_filename)-strlen(" (deleted)"))
-            *p = 0;
+        if(p == lowercase_filename+strlen(lowercase_filename)-strlen(" (deleted)")) {
+            *p = '\0';
+        }
         // add the "/fd" at the end to differenciate between memfd
         char* new_name = box_calloc(1, strlen(lowercase_filename)+100);
         sprintf(new_name, "%s/%d", lowercase_filename, fd);

--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -2043,8 +2043,8 @@ static int isProcAny(const char *path, const char* w)
     if(strncmp(path, "/proc/", 6)==0) {
         int pid;
         char p[4096] ={0};
-        if(sscanf(path, "/proc/%d/%s", &pid, &p)==2)
-            if(p && !strcmp(p, w))
+        if(sscanf(path, "/proc/%d/%s", &pid, p)==2)
+            if(strcmp(p, w) == 0)
                 return pid;
     }
     return -1;

--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -2125,7 +2125,7 @@ EXPORT ssize_t my_readlink(x64emu_t* emu, void* path, void* buf, size_t sz)
                 if(filename[0]=='.') {
                     // relative path, need to grap cwd and cannonicalise the path
                     char cwd_name[strlen(path)+4];
-                    sprintf(cwd_name, "/proc/%d/cwd");
+                    sprintf(cwd_name, "/proc/%d/cwd", pid);
                     char cwd[MAX_PATH] = {0};
                     if(readlink(cwd_name, cwd, MAX_PATH)>0 && strlen(cwd)+strlen(path)+1<MAX_PATH) {
                         strcat(cwd, "/");


### PR DESCRIPTION
I split this PR from the previous, because these are not just fixes to warnings, but to behaviour, because the warning is caused by bugs (see also https://github.com/ptitSeb/box64/issues/3916)

- **remove suffix only if present**
the suffix is always removed, not only when present due to an assignment
that should be a comparison
- **fix isProcAny check**
the pid should only be returned, when the path matches w, but is always
returned. Pass p as is (is already a pointer)
- **add missing parameter**
pid is missing in path construction