### PR TITLE
[SYSCALL] Fix mmap for io_uring

### DIFF
--- a/src/custommem.c
+++ b/src/custommem.c
@@ -3333,6 +3333,12 @@ EXPORT void* box_mmap(void *addr, size_t length, int prot, int flags, int fd, ss
     }
     #endif
     void* ret = InternalMmap(addr, length, prot, new_flags, fd, offset);
+    // io_uring doesn't support non-NULL address.
+    // The optimal approach is to detect whether an fd is an io_uring instance,
+    // but this is overly complex. So we simply retry the mmap call with the
+    // original address here.
+    if (ret == MAP_FAILED && old_addr == NULL && fd >= 0)
+        ret = InternalMmap(old_addr, length, prot, new_flags, fd, offset);
 #if !defined(NOALIGN)
     if((ret!=MAP_FAILED) && (flags&MAP_32BIT) &&
       (((uintptr_t)ret>0xffffffffLL) || ((box64_wine) && ((uintptr_t)ret&0xffff) && (ret!=addr)))) {


### PR DESCRIPTION
The pr is try to fix the issue which introduced by mmap for io_uring fd. Now mmap doesn't support non-NULL address for io_uring fd in linux-6.18. For example, the box64 will run the following code fail.

```
#include <stdio.h>
#include <stdlib.h>
#include <unistd.h>
#include <sys/syscall.h>
#include <sys/mman.h>
#include <fcntl.h>
#include <string.h>
#include <stdint.h>
#include <errno.h>
#include <linux/io_uring.h>

int main() {
    struct io_uring_params params = {0};
    int ring_fd;

    ring_fd = syscall(__NR_io_uring_setup, 32, &params);
    if (ring_fd < 0) {
        perror("io_uring_setup failed");
        return 1;
    }

    size_t total_size = params.sq_off.array + params.sq_entries * sizeof(uint32_t) +
                        params.cq_off.cqes + params.cq_entries * sizeof(struct io_uring_cqe);

    total_size = (total_size + 4095) & ~4095;

    void *ring_ptr = mmap(NULL, total_size,
                          PROT_READ|PROT_WRITE, MAP_SHARED,
                          ring_fd, 0);
    if (ring_ptr == MAP_FAILED) {
        perror("ring mmap failed");
        close(ring_fd);
        return 1;
    }

    munmap(ring_ptr, total_size);
    close(ring_fd);
    return 0;
}

```