### PR TITLE
[SIGNAL] Fixed my_signal not reporting sigaction failure for SIGKILL/SIGSTOP

### DIFF
--- a/src/libtools/signals.c
+++ b/src/libtools/signals.c
@@ -1385,7 +1385,8 @@ EXPORT sighandler_t my_signal(x64emu_t* emu, int signum, sighandler_t handler)
         struct sigaction oldact = {0};
         newact.sa_flags = 0x04;
         newact.sa_sigaction = MY_SIGHANDLER;
-        sigaction(signal_from_x64(signum), &newact, &oldact);
+        if(sigaction(signal_from_x64(signum), &newact, &oldact)<0)
+            return SIG_ERR;
         return oldact.sa_handler;
     } else
         return signal(signal_from_x64(signum), handler);


### PR DESCRIPTION
Problem: Test case failure for LTP signal01:
`signal01.c:54: TFAIL: (long)signal(SIGKILL, tc->sighandler) succeeded`

Reason: 'my_signal' ignored the return value of the host 'sigaction()' and always returned 'oldact.sa_handler'. For uncatchable signals (SIGKILL/SIGSTOP) the kernel rejects the handler with EINVAL, but the guest saw a non-'SIG_ERR' result and assumed success.

Now returns 'SIG_ERR' on failure. This matches the signal() contract and glibc's own implementation, which also returns SIG_ERR when sigaction fails:
```
  act.sa_flags = __sigismember (&_sigintr, sig) ? 0 : SA_RESTART;
  if (__sigaction (sig, &act, &oact) < 0)
    return SIG_ERR;

  return oact.sa_handler;
```

Validation:
- ctest: 34/34 passed on RV64 hardware.
- LTP **signal01**: 6/6 (was 5/6).