### PR TITLE
Add null check for dynablock in arch_unaligned

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_arch.c
+++ b/src/dynarec/rv64/dynarec_rv64_arch.c
@@ -210,6 +210,8 @@ void adjust_arch(dynablock_t* db, x64emu_t* emu, ucontext_t* p, uintptr_t x64pc)
 
 int arch_unaligned(dynablock_t* db, uintptr_t x64pc)
 {
+    if（!db) 
+        return 0;
     if(!db->arch_size || !db->arch)
         return 0;
     int ninst = getX64AddressInst(db, x64pc);

--- a/src/dynarec/rv64/dynarec_rv64_arch.c
+++ b/src/dynarec/rv64/dynarec_rv64_arch.c
@@ -210,7 +210,7 @@ void adjust_arch(dynablock_t* db, x64emu_t* emu, ucontext_t* p, uintptr_t x64pc)
 
 int arch_unaligned(dynablock_t* db, uintptr_t x64pc)
 {
-    if（!db) 
+    if(!db)
         return 0;
     if(!db->arch_size || !db->arch)
         return 0;


### PR DESCRIPTION
I find a error iwhen testing examples “signal03 signal05” in LTP。
the resolution has existed in arm64 and ppc。