### PR TITLE
[SIGNAL] Set no_tf when resuming from a signal for Syringe.exe

### DIFF
--- a/src/libtools/signal32.c
+++ b/src/libtools/signal32.c
@@ -743,11 +743,12 @@ int my_sigactionhandler_oldcode_32(x64emu_t* emu, int32_t sig, int simple, sigin
             GO(SP);
             GO(BX);
             #undef GO
-            if((skip==1) && (emu->ip.q[0]!=sigcontext->uc_mcontext.gregs[I386_EIP]))
-                skip = 3;   // if it jumps elsewhere, it can resume with dynarec...
-            emu->ip.q[0]=sigcontext->uc_mcontext.gregs[I386_EIP];
             // flags
             emu->eflags.x64=sigcontext->uc_mcontext.gregs[I386_EFL];
+            if((skip==1) && (emu->ip.q[0]!=sigcontext->uc_mcontext.gregs[I386_EIP]) && !ACCESS_FLAG(F_TF))
+                skip = 3;   // if it jumps elsewhere, it can resume with dynarec...
+            emu->ip.q[0]=sigcontext->uc_mcontext.gregs[I386_EIP];
+            if (ACCESS_FLAG(F_TF) && skip == 1) emu->flags.no_tf = 1;
             // get segments
             #define GO(S) if(emu->segs[_##S]!=sigcontext->uc_mcontext.gregs[I386_##S])  emu->segs[_##S]=sigcontext->uc_mcontext.gregs[I386_##S]
             GO(CS);
@@ -792,6 +793,7 @@ int my_sigactionhandler_oldcode_32(x64emu_t* emu, int32_t sig, int simple, sigin
     GO(EBX);
     #undef GO
     emu->eflags.x64=sigcontext->uc_mcontext.gregs[I386_EFL];
+    if(ACCESS_FLAG(F_TF)) emu->flags.no_tf = 1;
     #define GO(R)   R_##R=sigcontext->uc_mcontext.gregs[I386_##R]
     GO(CS);
     GO(DS);

--- a/src/libtools/signals.c
+++ b/src/libtools/signals.c
@@ -565,7 +565,9 @@ int my_sigactionhandler_oldcode_64(x64emu_t* emu, int32_t sig, int simple, sigin
 
     if(memcmp(sigcontext, &sigcontext_copy, sizeof(x64_ucontext_t))) {
         #if defined(DYNAREC)
-        if(db) {
+        if(db || emu->jmpbuf)
+            mctx2emu(emu, &sigcontext->uc_mcontext);
+        if(db && !ACCESS_FLAG(F_TF)) {
             // if signal was inside a dynablock, just mirror all the new regs in the right place to simple run native_next
             mctx2emu(emu, &sigcontext->uc_mcontext);
             copyEmu2USignalCTXreg(p, emu, native_next);
@@ -574,9 +576,9 @@ int my_sigactionhandler_oldcode_64(x64emu_t* emu, int32_t sig, int simple, sigin
         }
         #endif
         if(emu->jmpbuf) {
-            if((skip==1) && (emu->ip.q[0]!=sigcontext->uc_mcontext.gregs[X64_RIP]))
+            if((skip==1) && (emu->ip.q[0]!=sigcontext->uc_mcontext.gregs[X64_RIP]) && !ACCESS_FLAG(F_TF))
                 skip = 3;   // if it jumps elsewhere, it can resume with dynarec...
-            mctx2emu(emu, &sigcontext->uc_mcontext);
+            if (ACCESS_FLAG(F_TF) && skip == 1) emu->flags.no_tf = 1;
             printf_log((sig==10)?LOG_DEBUG:log_minimum, "Context has been changed in Sigactionhanlder, doing siglongjmp to resume emu at %p, RSP=%p (resume with %s)\n", (void*)R_RIP, (void*)R_RSP, (skip==3)?"Dynarec":"Interp");
             if(old_code)
                 *old_code = -1;    // re-init the value to allow another segfault at the same place
@@ -621,6 +623,7 @@ int my_sigactionhandler_oldcode_64(x64emu_t* emu, int32_t sig, int simple, sigin
     GO(RIP);
     #undef GO
     emu->eflags.x64=sigcontext->uc_mcontext.gregs[X64_EFL];
+    if (ACCESS_FLAG(F_TF)) emu->flags.no_tf = 1;
     uint16_t seg;
     seg = (sigcontext->uc_mcontext.gregs[X64_CSGSFS] >> 0)&0xffff;
     #define GO(S) emu->segs[_##S]=seg;

--- a/src/libtools/signals.c
+++ b/src/libtools/signals.c
@@ -576,6 +576,9 @@ int my_sigactionhandler_oldcode_64(x64emu_t* emu, int32_t sig, int simple, sigin
         }
         #endif
         if(emu->jmpbuf) {
+            #ifndef DYNAREC
+            mctx2emu(emu, &sigcontext->uc_mcontext);
+            #endif
             if((skip==1) && (emu->ip.q[0]!=sigcontext->uc_mcontext.gregs[X64_RIP]) && !ACCESS_FLAG(F_TF))
                 skip = 3;   // if it jumps elsewhere, it can resume with dynarec...
             if (ACCESS_FLAG(F_TF) && skip == 1) emu->flags.no_tf = 1;


### PR DESCRIPTION
Wine implements NtSetContextThread by send SIGUSR1 to child and resume it after -- where TF might be set, we need to skip the first SIGTRAP.