### PR TITLE
[RV64_DYNAREC] Fixed GETEW delta parameter for ROL/ROR/RCL/RCR

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_66.c
+++ b/src/dynarec/rv64/dynarec_rv64_66.c
@@ -1294,7 +1294,7 @@ uintptr_t dynarec64_66(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
                     INST_NAME("ROR Ew, 1");
                     // removed PENDING on purpose
                     SETFLAGS(X_OF | X_CF, SF_SUBSET, NAT_FLAGS_FUSION);
-                    GETEW(x1, 1);
+                    GETEW(x1, 0);
                     emit_ror16c(dyn, ninst, x1, 1, x5, x4);
                     EWBACK;
                     break;
@@ -1350,7 +1350,7 @@ uintptr_t dynarec64_66(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
                     MESSAGE(LOG_DUMP, "Need Optimization\n");
                     SETFLAGS(X_OF | X_CF, SF_SET_DF, NAT_FLAGS_NOFUSION);
                     if (BOX64DRENV(dynarec_safeflags) > 1) MAYSETFLAGS();
-                    GETEW(x1, 1);
+                    GETEW(x1, 0);
                     CALL_(const_rol16, x1, x3, x1, x2);
                     EWBACK;
                     break;
@@ -1360,7 +1360,7 @@ uintptr_t dynarec64_66(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
                     MESSAGE(LOG_DUMP, "Need Optimization\n");
                     SETFLAGS(X_OF | X_CF, SF_SET_DF, NAT_FLAGS_NOFUSION);
                     if (BOX64DRENV(dynarec_safeflags) > 1) MAYSETFLAGS();
-                    GETEW(x1, 1);
+                    GETEW(x1, 0);
                     CALL_(const_ror16, x1, x3, x1, x2);
                     EWBACK;
                     break;
@@ -1371,7 +1371,7 @@ uintptr_t dynarec64_66(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
                     READFLAGS(X_CF);
                     SETFLAGS(X_OF | X_CF, SF_SET_DF, NAT_FLAGS_NOFUSION);
                     if (BOX64DRENV(dynarec_safeflags) > 1) MAYSETFLAGS();
-                    GETEW(x1, 1);
+                    GETEW(x1, 0);
                     CALL_(const_rcl16, x1, x3, x1, x2);
                     EWBACK;
                     break;
@@ -1382,7 +1382,7 @@ uintptr_t dynarec64_66(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
                     READFLAGS(X_CF);
                     SETFLAGS(X_OF | X_CF, SF_SET_DF, NAT_FLAGS_NOFUSION);
                     if (BOX64DRENV(dynarec_safeflags) > 1) MAYSETFLAGS();
-                    GETEW(x1, 1);
+                    GETEW(x1, 0);
                     CALL_(const_rcr16, x1, x3, x1, x2);
                     EWBACK;
                     break;


### PR DESCRIPTION
Problem: Incorrect address calculation for some rotate instructions with RIP-relative memory operands on RV64 dynarec.

Reason: The GETEW macro's delta parameter was incorrectly set to 1 instead of 0 for five 16-bit rotate opcodes in the 0xD1 and 0xD3 groups (ROR Ew,1; ROL Ew,CL; ROR Ew,CL; RCL Ew,CL; RCR Ew,CL). These instructions have no immediate operand, so delta must be 0. The wrong delta caused geted() to compute an off-by-one xRIP value, leading to incorrect effective addresses for RIP-relative memory operands. 

Fix: Changed GETEW(x1, 1) → GETEW(x1, 0) for the five affected cases in dynarec_rv64_66.c.

Validation:
- ctest: 34/34 passed on RV64 hardware.