### PR TITLE
[CORE] Add MallocHookRun to call startMallocHook before RunElfInit

### DIFF
--- a/src/elfs/elfloader.c
+++ b/src/elfs/elfloader.c
@@ -48,6 +48,12 @@
 #include "../tools/bridge_private.h"
 #include "x64tls.h"
 
+#ifndef STATICBUILD
+void startMallocHook();
+#else
+void startMallocHook() {}
+#endif
+
 void* my__IO_2_1_stderr_ = (void*)1;
 void* my__IO_2_1_stdin_  = (void*)2;
 void* my__IO_2_1_stdout_ = (void*)3;
@@ -1216,16 +1222,21 @@ void RefreshElfTLS(elfheader_t* h, x64emu_t* emu)
         }
     }
 }
+
+void MallocHookRun(elfheader_t* h)
+{
+    if (!h)
+        return;
+    if(h->malloc_hook_2)
+        startMallocHook();
+}
+
 void MarkElfInitDone(elfheader_t* h)
 {
     if(h)
         h->init_done = 1;
 }
-#ifndef STATICBUILD
-void startMallocHook();
-#else
-void startMallocHook() {}
-#endif
+
 void RunElfInit(elfheader_t* h, x64emu_t *emu)
 {
     if(!h || h->init_done)

--- a/src/emu/entrypoint.c
+++ b/src/emu/entrypoint.c
@@ -34,6 +34,9 @@ EXPORT int32_t my___libc_start_main(x64emu_t* emu, int (*main) (int, char * *, c
 {
     (void)argc; (void)ubp_av; (void)fini; (void)rtld_fini; (void)stack_end;
 
+    if(my_context->elfs[0])
+        MallocHookRun(my_context->elfs[0]);
+
     if(init) {
         uintptr_t old_rsp = GetRSP(emu);
         uintptr_t old_rbp = GetRBP(emu); // should not be needed, but seems to be without dynarec
@@ -110,6 +113,8 @@ int32_t EXPORT my32___libc_start_main(x64emu_t* emu, int *(main) (int, char * *,
     Push_32(emu, my_context->envv32);
     Push_32(emu, my_context->argv32);
     Push_32(emu, my_context->argc);
+    if(my_context->elfs[0])
+        MallocHookRun(my_context->elfs[0]);
     if(init) {
         PushExit_32(emu);
         R_EIP=to_ptrv(*init);

--- a/src/include/elfloader.h
+++ b/src/include/elfloader.h
@@ -61,6 +61,7 @@ void RunElfInit(elfheader_t* h, x64emu_t *emu);
 void RunElfFini(elfheader_t* h, x64emu_t *emu);
 void RunDeferredElfInit(x64emu_t *emu);
 void MarkElfInitDone(elfheader_t* h);
+void MallocHookRun(elfheader_t* h);
 void* GetBaseAddress(elfheader_t* h);
 void* GetElfDelta(elfheader_t* h);
 uint32_t GetBaseSize(elfheader_t* h);


### PR DESCRIPTION
The `startMallocHook` function is only invoked inside `RunElfInit`, and `RunElfInit` is only called for the main ELF binary within `__libc_start_main`.

In the `RunElfInit` function, `startMallocHook` is currently invoked only after all initialization routines of dynamic libraries have been executed. However, if the malloc hook is defined within a dependent library and that library’s initialization routine invokes the malloc hook interface, activation of the malloc hook will be delayed, leading to unexpected runtime exceptions.

Therefore, I add a call to `MallocHookRun` so that the malloc hook can be available before the execution of library init functions.

Before:
```
__libc_start_main
    |
    ---> RunElfInit
             |
             ----> libA.so Init
             |          |
             |          ---> _Znam
             |                 |
             |                 ---> Native actual_malloc
             ---> startMallocHook
```

After:
```
__libc_start_main
    |
    ---> MallocHookRun
    |        |
    |        ---> startMallocHook
    |
    ---> RunElfInit
             |
             ----> libA.so Init
                       |
                       ---> _Znam
                              |
                              ---> X86-64 real_malloc
```