### PR TITLE
[CORE] Change mmap flag judgment in getMmapped

### DIFF
--- a/src/custommem.c
+++ b/src/custommem.c
@@ -2851,7 +2851,12 @@ uint32_t getProtection_fast(uintptr_t addr)
 
 int getMmapped(uintptr_t addr)
 {
-    return (rb_get(mapallmem, addr)&MEM_ALLOCATED); // will be ok for both MEM_ALLOCATED & MEM_MMAP
+    return (rb_get(mapallmem, addr)&MEM_MMAP) == MEM_MMAP;
+}
+
+int getMAllocated(uintptr_t addr)
+{
+    return (rb_get(mapallmem, addr)&MEM_ALLOCATED);
 }
 
 int memExist(uintptr_t addr)

--- a/src/include/custommem.h
+++ b/src/include/custommem.h
@@ -121,6 +121,7 @@ void refreshProtection(uintptr_t addr);
 uint32_t getProtection(uintptr_t addr);
 uint32_t getProtection_fast(uintptr_t addr);
 int getMmapped(uintptr_t addr);
+int getMAllocated(uintptr_t addr);
 int memExist(uintptr_t addr);
 void loadProtectionFromMap(void);
 #ifdef DYNAREC

--- a/src/libtools/signals.c
+++ b/src/libtools/signals.c
@@ -939,7 +939,7 @@ void my_box64signalhandler(int32_t sig, siginfo_t* info, void * ucntx)
     #ifdef BAD_SIGNAL
     // try to see if the si_code makes sense
     // the RK3588 tend to need a special Kernel that seems to have a weird behaviour sometimes
-    if((sig==X64_SIGSEGV) && (addr) && (info->si_code == 1) && getMmapped((uintptr_t)addr)) {
+    if((sig==X64_SIGSEGV) && (addr) && (info->si_code == 1) && getMAllocated((uintptr_t)addr)) {
         printf_log(LOG_DEBUG, "Workaround for suspicious si_code for %p / prot=0x%hhx\n", addr, prot);
         info->si_code = 2;
     }


### PR DESCRIPTION
Change `getMmapped` to strictly check `MEM_MMAP` flag instead of `MEM_ALLOCATED` bitmask.

I found that some memory allocated via native `malloc` is also registered in `mapallmem` with the` MEM_ALLOCATED` flag, and later released through custom free routines.