### PR TITLE
[CMAKE] Remove the trailing '/' from INSTALL_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1526,7 +1526,7 @@ if(NOT _x86 AND NOT _x86_64)
 	  endif()
 
   endif()
-  set(INSTALL_PATH "/usr/lib/box64-x86_64-linux-gnu/")
+  set(INSTALL_PATH "/usr/lib/box64-x86_64-linux-gnu")
   if(NOT NO_LIB_INSTALL)
 	if(NOT TERMUX AND NOT ANDROID)
         install(FILES ${CMAKE_SOURCE_DIR}/x64lib/libstdc++.so.5 DESTINATION ${INSTALL_PATH})


### PR DESCRIPTION
Remove the trailing '/' from INSTALL_PATH, otherwise an extra slash will be generated when installing directories.

Just fix typo.  

BTW, I am working on supporting collaborative meeting software with screen sharing functionality, which requires **emulated** support for` libpipewire-0.3` and `libspa-0.2`. 

Would it be acceptable to upload roughly 50 libraries（`ibpipewire-0.3 and libspa-0.2`）into x64lib?  If not, what are the criteria for libraries allowed to be uploaded into` x64lib`?