### PR TITLE
Support libpipewire bundle

### DIFF
--- a/box64-bundle-x86-libs.csv
+++ b/box64-bundle-x86-libs.csv
@@ -2,6 +2,12 @@ https://archive.debian.org/debian/pool/main/c/curl/libcurl3-gnutls_7.74.0-1.3+de
 https://archive.debian.org/debian/pool/main/c/curl/libcurl3-gnutls_7.74.0-1.3+deb11u7~bpo11+1_i386.deb,625e5189304d4d3bfb27cb821e257816c5ce761b1696b5da5ca4fa1035c48463
 https://archive.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.2l-1~bpo8+1_amd64.deb,6e85968afe1a6643f4e82e1cc168f848c5967a131bb1c7392f11974953db0e67
 https://archive.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.2l-1~bpo8+1_i386.deb,4e8b924286a064c257ca50b8ecd44fe71226443daef62b6836010590e2157329
+https://archive.debian.org/debian/pool/main/p/pipewire/libpipewire-0.3-0_0.3.65-2~bpo11+1_amd64.deb,b49a24743eb2b6d1198c7cf014ee791bccd5d3223ed8a1e4769d899e1f894a5b
+https://archive.debian.org/debian/pool/main/p/pipewire/libpipewire-0.3-0_0.3.65-2~bpo11+1_i386.deb,1d032b638081704393bc847e2e1f7a00c6894fa262ed0272fb7282962e8915a9
+https://archive.debian.org/debian/pool/main/p/pipewire/libpipewire-0.3-modules_0.3.65-2~bpo11+1_amd64.deb,6a4c2d7b127ed18c8c2a558e4d63fcd56de4a154bb9db5fafa7e497f4771dc4a
+https://archive.debian.org/debian/pool/main/p/pipewire/libpipewire-0.3-modules_0.3.65-2~bpo11+1_i386.deb,4585064f220490562c132e6fe6a2c46a66d319f6862f60f26e21bccbaadcbd90
+https://archive.debian.org/debian/pool/main/p/pipewire/libspa-0.2-modules_0.3.65-2~bpo11+1_amd64.deb,833a024051fcfa79208462486c2761b6e1c464676da96e0d3664f4a189449e34
+https://archive.debian.org/debian/pool/main/p/pipewire/libspa-0.2-modules_0.3.65-2~bpo11+1_i386.deb,5cbd85ab559d99dc5907898488c87b8cf0e117412e0d7981ca7e69e35fbc3f84
 https://archives.fedoraproject.org/pub/archive/epel/9.5/Everything/x86_64/Packages/m/mbedtls-2.28.8-1.el9.x86_64.rpm,54cb7e43e902a7378e912ecfec470ee30fe69af323d3812cbc39ddebd64790ff
 https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/34/Everything/x86_64/os/Packages/l/libpng12-1.2.57-13.fc34.i686.rpm,5e4f525f44d538e3467dd13c66010d54f3d12ec4a319829e15a23ff2d0195b5b
 https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/34/Everything/x86_64/os/Packages/l/libpng12-1.2.57-13.fc34.x86_64.rpm,49f956ad143399c29f5ddf6da6b6fc108ce130d1ed598b4ec5a68b1ff26091de

--- a/box64-bundle-x86-libs.sh
+++ b/box64-bundle-x86-libs.sh
@@ -77,10 +77,10 @@ done
 # reorganize the files
 cd "${dir_tmp}"/bundle-libs
 mkdir -p "${dir_tmp}"/bundle-libs/box64-i386-linux-gnu
-mv lib/*.so* usr/lib/*.so* usr/lib/i386-linux-gnu/*.so* usr/lib32/*.so* \
+mv lib/*.so* usr/lib/*.so* usr/lib/i386-linux-gnu/* usr/lib32/*.so* \
     "${dir_tmp}"/bundle-libs/box64-i386-linux-gnu
 mkdir -p "${dir_tmp}"/bundle-libs/box64-x86_64-linux-gnu
-mv lib64/*.so* usr/lib/x86_64-linux-gnu/*.so* usr/lib64/*.so* \
+mv lib64/*.so* usr/lib/x86_64-linux-gnu/* usr/lib64/*.so* \
     "${dir_tmp}"/bundle-libs/box64-x86_64-linux-gnu
 rm -f ./*.tar.* debian-binary files.xml metadata.xml
 rm -rf ./lib* etc run sbin usr var


### PR DESCRIPTION
I add   3 libraries for bundle,

- libpipewire-0.3-0_0.3.65-2~bpo11+1
- libpipewire-0.3-modules_0.3.65-2~bpo11+1
- libspa-0.2-modules_0.3.65-2~bpo11+1

and change ` box64-bundle-x86-libs.sh` to support the *.so in sub-directories as follow.
```
.
`-- x86_64-linux-gnu
    `-- spa-0.2
        |-- aec
        |   |-- libspa-aec-null.so
        |   `-- libspa-aec-webrtc.so
        |-- alsa
        |   `-- libspa-alsa.so
        |-- audioconvert
        |   `-- libspa-audioconvert.so
        |-- audiomixer
        |   `-- libspa-audiomixer.so
        |-- audiotestsrc
        |   `-- libspa-audiotestsrc.so
        |-- control
        |   `-- libspa-control.so
        |-- support
        |   |-- libspa-dbus.so
        |   |-- libspa-journal.so
        |   `-- libspa-support.so
        |-- test
        |   `-- libspa-test.so
        |-- v4l2
        |   `-- libspa-v4l2.so
        |-- videoconvert
        |   `-- libspa-videoconvert.so
        |-- videotestsrc
        |   `-- libspa-videotestsrc.so
        `-- volume
            `-- libspa-volume.so
```

And need to add env variables when use box64 to run share-screen apps.
```
SPA_PLUGIN_DIR=/usr/lib/box64-x86_64-linux-gnu/spa-0.2 PIPEWIRE_MODULE_DIR=/usr/lib/box64-x86_64-linux-gnu/pipewire-0.3
```
