### PR TITLE
[DYNAREC][ENV] Disabled SEP by default

### DIFF
--- a/docs/COMPILE.md
+++ b/docs/COMPILE.md
@@ -3,7 +3,7 @@ Compiling/Installing
 
 If you don't want to compile box64 yourself and prefer to use third-party pre-build version, go to the [end of the document](#pre-built-packages) for alternatives.
 
-You can also generate your own package using the [instructions below](https://github.com/ptitSeb/box64/blob/main/docs/COMPILE.md#debian-packaging). 
+You can also generate your own package using the [instructions below](https://github.com/ptitSeb/box64/blob/main/docs/COMPILE.md#debian-packaging).
 
 Additional installation steps may be necessary when copying only the box64 executable file without running make install in cross-build environments. See [Cross-Compiling](https://github.com/ptitSeb/box64/blob/main/docs/COMPILE.md#Cross-Compiling)
 
@@ -15,7 +15,7 @@ Additional installation steps may be necessary when copying only the box64 execu
 git clone https://github.com/ptitSeb/box64
 cd box64
 mkdir build; cd build; cmake .. ${OPTIONS}
-make -j4  
+make -j4
 sudo make install
 ```
 If it's the first install, you also need:
@@ -288,13 +288,13 @@ To have a trace enabled build (***the interpreter will be slightly slower***), a
 
 #### Build DynaRec
 
-Add `-D ARM_DYNAREC=ON` option to enable DynaRec on ARM machines.  
-Add `-D RV64_DYNAREC=ON` option to enable DynaRec on RV64 machines.  
-Add `-D LARCH64_DYNAREC=ON` option to enable DynaRec on LARCH64 machines.  
+Add `-D ARM_DYNAREC=ON` option to enable DynaRec on ARM machines.
+Add `-D RV64_DYNAREC=ON` option to enable DynaRec on RV64 machines.
+Add `-D LARCH64_DYNAREC=ON` option to enable DynaRec on LARCH64 machines.
 
 #### Save memory at run time
 
-You can use `-DSAVE_MEM` to have a build that will try to save some memory. For now, it only increases the jumptable from 4 levels to 5. The added granularity avoids wasting space, but adds one more read from memory when jumping between blocks.
+You can use `-DSAVE_MEM=ON` to build Box64 with memory-saving optimizations. This uses a five-level jump table to reduce unused address-space allocations and enables secondary entry points (BOX64_DYNAREC_SEP=1) by default to reduce duplicate DynaRec blocks. These optimizations may reduce memory usage at the cost of additional memory accesses and lower performance on some workloads.
 
 #### Build outside of a git repo
 
@@ -326,9 +326,9 @@ Box64 can also be packaged into a .deb file ***using the source code zip from th
 
 ## Pre-built packages
 
-### Debian-based Linux 
+### Debian-based Linux
 
-You can use the [Pi-Apps-Coders apt repository](https://github.com/Pi-Apps-Coders/box64-debs) to install precompiled box64 debs, updated every 24 hours. 
+You can use the [Pi-Apps-Coders apt repository](https://github.com/Pi-Apps-Coders/box64-debs) to install precompiled box64 debs, updated every 24 hours.
 
 ```
 # check if .list file already exists
@@ -358,12 +358,12 @@ sudo apt update
 sudo apt install box64-generic-arm -y
 ```
 
-## Cross-Compiling 
+## Cross-Compiling
 ----
 ### Set Up the Cross-Compiler
-For example, to compile Box64 for RISC-V on an x86 machine, you can get prebuilt GNU toolchain from the [riscv-gnu-toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain/releases) 
+For example, to compile Box64 for RISC-V on an x86 machine, you can get prebuilt GNU toolchain from the [riscv-gnu-toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain/releases)
 
-### Run CMake with Cross-Compilation Options 
+### Run CMake with Cross-Compilation Options
 Follow the per-platform compilation instructions to configure the CMake options for your target architecture.
 In particular, you must specify the cross-compiler. For example:
 ```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -85,8 +85,8 @@ Optimize CALL/RET opcodes. Available in WowBox64.
 
 Optimize CALL/RET further with Secondary Entry Points (SEP). Has no effect if CALLRET is not enabled Available in WowBox64.
 
- * 0: Do not add SEP at CALLRET return
- * 1: Add SEP at CALLRET return, on memory that are from known binary files [Default]
+ * 0: Do not add SEP at CALLRET return [Default]
+ * 1: Add SEP at CALLRET return, on memory that are from known binary files
  * 2: Add SEP at CALLRET return for all type of memory.
 
 ### BOX64_DYNAREC_DF

--- a/docs/USAGE_CN.md
+++ b/docs/USAGE_CN.md
@@ -85,8 +85,8 @@ BOX64_DYNAREC_CALLRET=1
 
 使用二级入口点（SEP）进一步优化 CALL/RET。如果 CALLRET 未启用则无效。 在 WowBox64 中可用。
 
- * 0: 不在 CALLRET 返回时添加 SEP。
- * 1: 在 CALLRET 返回时添加 SEP，仅针对来自已知二进制文件的内存。 [默认值]
+ * 0: 不在 CALLRET 返回时添加 SEP。 [默认值]
+ * 1: 在 CALLRET 返回时添加 SEP，仅针对来自已知二进制文件的内存。
  * 2: 在 CALLRET 返回时添加 SEP，适用于所有类型的内存。
 
 ### BOX64_DYNAREC_DF

--- a/docs/box64.pod
+++ b/docs/box64.pod
@@ -189,8 +189,8 @@ Optimize CALL/RET opcodes. Available in WowBox64.
 
 Optimize CALL/RET further with Secondary Entry Points (SEP). Has no effect if CALLRET is not enabled Available in WowBox64.
 
- * 0 : Do not add SEP at CALLRET return 
- * 1 : Add SEP at CALLRET return, on memory that are from known binary files [Default]
+ * 0 : Do not add SEP at CALLRET return [Default]
+ * 1 : Add SEP at CALLRET return, on memory that are from known binary files 
  * 2 : Add SEP at CALLRET return for all type of memory. 
 
 

--- a/docs/gen/usage.json
+++ b/docs/gen/usage.json
@@ -338,12 +338,12 @@
       {
         "key": "0",
         "description": "Do not add SEP at CALLRET return",
-        "default": false
+        "default": true
       },
       {
         "key": "1",
         "description": "Add SEP at CALLRET return, on memory that are from known binary files",
-        "default": true
+        "default": false
       },
       {
         "key": "2",

--- a/src/include/env.h
+++ b/src/include/env.h
@@ -51,7 +51,7 @@ extern char* ftrace_name;
     BOOLEAN(BOX64_DYNAREC_ALIGNED_ATOMICS, dynarec_aligned_atomics, 0, 1, 1)     \
     INTEGER(BOX64_DYNAREC_BIGBLOCK, dynarec_bigblock, 2, 0, 3, 1, 2)             \
     BOOLEAN(BOX64_DYNAREC_BLEEDING_EDGE, dynarec_bleeding_edge, 1, 0, 0)         \
-    INTEGER(BOX64_DYNAREC_SEP, dynarec_sep, 1, 0, 2, 1, 2)                       \
+    INTEGER(BOX64_DYNAREC_SEP, dynarec_sep, 0, 0, 2, 1, 2)                       \
     BOOLEAN(BOX64_DYNAREC_DF, dynarec_df, 1, 1, 1)                               \
     INTEGER(BOX64_DYNAREC_DIRTY, dynarec_dirty, 0, 0, 2, 0, 2)                   \
     BOOLEAN(BOX64_DYNAREC_NOHOTPAGE, dynarec_nohotpage, 0, 0, 1)                 \

--- a/src/include/env.h
+++ b/src/include/env.h
@@ -51,7 +51,6 @@ extern char* ftrace_name;
     BOOLEAN(BOX64_DYNAREC_ALIGNED_ATOMICS, dynarec_aligned_atomics, 0, 1, 1)     \
     INTEGER(BOX64_DYNAREC_BIGBLOCK, dynarec_bigblock, 2, 0, 3, 1, 2)             \
     BOOLEAN(BOX64_DYNAREC_BLEEDING_EDGE, dynarec_bleeding_edge, 1, 0, 0)         \
-    INTEGER(BOX64_DYNAREC_SEP, dynarec_sep, 0, 0, 2, 1, 2)                       \
     BOOLEAN(BOX64_DYNAREC_DF, dynarec_df, 1, 1, 1)                               \
     INTEGER(BOX64_DYNAREC_DIRTY, dynarec_dirty, 0, 0, 2, 0, 2)                   \
     BOOLEAN(BOX64_DYNAREC_NOHOTPAGE, dynarec_nohotpage, 0, 0, 1)                 \
@@ -188,12 +187,21 @@ extern char* ftrace_name;
     INTEGER(BOX64_DYNAREC_CALLRET, dynarec_callret, 0, 0, 2, 1, 2)
 #endif
 
+#ifdef SAVE_MEM
+#define ENVSUPER6() \
+    INTEGER(BOX64_DYNAREC_SEP, dynarec_sep, 1, 0, 2, 1, 2)
+#else
+#define ENVSUPER6() \
+    INTEGER(BOX64_DYNAREC_SEP, dynarec_sep, 0, 0, 2, 1, 2)
+#endif
+
 #define ENVSUPER() \
     ENVSUPER1()    \
     ENVSUPER2()    \
     ENVSUPER3()    \
     ENVSUPER4()    \
-    ENVSUPER5()
+    ENVSUPER5()    \
+    ENVSUPER6()
 
 typedef struct box64env_s {
 #define INTEGER(NAME, name, default, min, max, wine, dynacache) int name;


### PR DESCRIPTION
Now that we have callret enabled by default, I noticed SEP causes the branch misprediction by an order of magnitude in coremark, while the memory-saving effect is almost imperceptible.

```
ksco@steel [ coremark@main ] $ BOX64_LOG=0 BOX64_NOBANNER=1 BOX64_DYNACACHE=0 BOX64_DYNAREC_SEP=0 perf stat -e task-clock,cycles,instructions,branches,branch-misses -- taskset -c 2 box64 ./coremark.exe_x64 0 0 0x66 200000 7 1 >/dev/null

 Performance counter stats for 'taskset -c 2 box64 ./coremark.exe_x64 0 0 0x66 200000 7 1':

         16,339.65 msec task-clock:u
    35,828,022,082      cycles:u
   118,528,644,489      instructions:u
    12,994,274,457      branches:u
        36,068,961      branch-misses:u

      16.348269274 seconds time elapsed

      16.331188000 seconds user
       0.009995000 seconds sys

ksco@steel [ coremark@main ] $ BOX64_LOG=0 BOX64_NOBANNER=1 BOX64_DYNACACHE=0 BOX64_DYNAREC_SEP=1 perf stat -e task-clock,cycles,instructions,branches,branch-misses -- taskset -c 2 box64 ./coremark.exe_x64 0 0 0x66 200000 7 1 >/dev/null

 Performance counter stats for 'taskset -c 2 box64 ./coremark.exe_x64 0 0 0x66 200000 7 1':

         18,571.57 msec task-clock:u
    40,721,222,650      cycles:u
   118,523,943,716      instructions:u
    12,993,208,645      branches:u
       383,363,320      branch-misses:u

      18.581470637 seconds time elapsed

      18.564061000 seconds user
       0.008996000 seconds sys

ksco@steel [ coremark@main ] $ perf stat -e task-clock,cycles,instructions,branches,branch-misses -- taskset -c 2 ./coremark.exe 0 0 0x66 200000 7 1 >/dev/null

 Performance counter stats for 'taskset -c 2 ./coremark.exe 0 0 0x66 200000 7 1':

          9,757.79 msec task-clock:u
    21,407,080,976      cycles:u
    62,785,977,365      instructions:u
    11,852,476,157      branches:u
        18,851,352      branch-misses:u

       9.762550998 seconds time elapsed

       9.757495000 seconds user
       0.000999000 seconds sys

```