### PR TITLE
[EMITSIGNALS] Resync tracked protection from kernel maps in CheckExec before emitting SIGSEGV

### DIFF
--- a/src/os/emit_signals_linux.c
+++ b/src/os/emit_signals_linux.c
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <signal.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
@@ -114,7 +115,35 @@ void CheckExec(x64emu_t* emu, uintptr_t addr)
 {
     if (box64_pagesize != 4096)
         return; // disabling the test, 4K pagesize simlation isn't good enough for this
+    int resynced = 0;
     while ((getProtection/*_fast*/(addr) & (PROT_EXEC | PROT_READ)) != (PROT_EXEC | PROT_READ)) {
+        if (!resynced) {
+            // the tracked protection can get out of sync with the actual mapping
+            // (seen with runtime-generated code stubs on heap pages): before
+            // emitting a signal, recheck with the kernel and resync if it says
+            // the page is actually executable
+            resynced = 1;
+            uint32_t kprot = 0;
+            uintptr_t page = addr & ~(uintptr_t)(box64_pagesize - 1);
+            FILE* f = fopen("/proc/self/maps", "r");
+            if (f) {
+                char line[512];
+                while (fgets(line, sizeof(line), f)) {
+                    uintptr_t s, e;
+                    char r, w, x;
+                    if (sscanf(line, "%lx-%lx %c%c%c", &s, &e, &r, &w, &x) == 5 && s <= addr && addr < e) {
+                        kprot = ((r == 'r') ? PROT_READ : 0) | ((w == 'w') ? PROT_WRITE : 0) | ((x == 'x') ? PROT_EXEC : 0);
+                        break;
+                    }
+                }
+                fclose(f);
+            }
+            if ((kprot & (PROT_EXEC | PROT_READ)) == (PROT_EXEC | PROT_READ)) {
+                printf_log(LOG_NONE, "%04d|CheckExec: tracked prot=0x%x but kernel prot=0x%x for %p, resyncing\n", GetTID(), getProtection(addr), kprot, (void*)addr);
+                updateProtection(page, box64_pagesize, kprot);
+                continue;
+            }
+        }
         R_RIP = addr; // incase there is a slight difference
         EmitSignal(emu, X64_SIGSEGV, (void*)addr, 0xecec);
     }

--- a/src/os/emit_signals_linux.c
+++ b/src/os/emit_signals_linux.c
@@ -139,7 +139,7 @@ void CheckExec(x64emu_t* emu, uintptr_t addr)
                 fclose(f);
             }
             if ((kprot & (PROT_EXEC | PROT_READ)) == (PROT_EXEC | PROT_READ)) {
-                printf_log(LOG_NONE, "%04d|CheckExec: tracked prot=0x%x but kernel prot=0x%x for %p, resyncing\n", GetTID(), getProtection(addr), kprot, (void*)addr);
+                printf_log(BOX64ENV(showsegv) ? LOG_NONE : LOG_INFO, "%04d|CheckExec: tracked prot=0x%x but kernel prot=0x%x for %p, resyncing\n", GetTID(), getProtection(addr), kprot, (void*)addr);
                 updateProtection(page, box64_pagesize, kprot);
                 continue;
             }


### PR DESCRIPTION
Workaround for #4052.

When a page's tracked protection loses its exec bit but the kernel mapping is still executable, CheckExec raises SIGSEGV (code=0xecec) in an endless loop at the same RIP. With a game whose crash handler re-raises, that's tens of thousands of signals per second. I hit this with runtime-generated hook trampolines on heap pages (Palworld dedicated server + UE4SS), details and captures in the issue.

This rechecks /proc/self/maps once before raising, and resyncs the tracked protection if the kernel says the page is executable after all. Error path only, so healthy execution doesn't pay for it.

Tested on ARM64 (Neoverse-N1): 6/6 clean boots where ~half stormed before, the resync log fired 4 times (tracked prot=0x3, kernel prot=0x7).

Note this doesn't fix whatever loses the exec bit in the first place — see the discussion in #4052, my current suspicion is a lost-update race between the mprotect syscall and updateProtection in my_mprotect.