### PR TITLE
[CUSTOMMEM] only track the newly added heap when brk changed

### DIFF
--- a/src/custommem.c
+++ b/src/custommem.c
@@ -2831,11 +2831,8 @@ int memExist(uintptr_t addr)
 #define MEDIUM (void*)0x40000000
 #define HIGH   (void*)0x60000000
 
-// The guest can grow its heap with brk(), which box64 doesn't see as an mmap, so
-// the new memory is tracked here instead. Only track what was actually added:
-// re-tracking the whole heap from pbrk as RW would clobber PROT_EXEC on pages the
-// guest had made executable inside the heap (JIT/hook trampolines), leaving the
-// tracking out of sync with the kernel until CheckExec faults on them.
+// only track what brk added: re-tracking the whole heap would lose PROT_EXEC on
+// pages the guest made executable in it (like hook trampolines)
 static void catchup_brk_protection(void)
 {
     if(pbrk && cur_brk && *cur_brk!=old_brk) {

--- a/src/custommem.c
+++ b/src/custommem.c
@@ -2831,13 +2831,25 @@ int memExist(uintptr_t addr)
 #define MEDIUM (void*)0x40000000
 #define HIGH   (void*)0x60000000
 
+// The guest can grow its heap with brk(), which box64 doesn't see as an mmap, so
+// the new memory is tracked here instead. Only track what was actually added:
+// re-tracking the whole heap from pbrk as RW would clobber PROT_EXEC on pages the
+// guest had made executable inside the heap (JIT/hook trampolines), leaving the
+// tracking out of sync with the kernel until CheckExec faults on them.
+static void catchup_brk_protection(void)
+{
+    if(pbrk && cur_brk && *cur_brk!=old_brk) {
+        uintptr_t prev = old_brk ? old_brk : pbrk;
+        old_brk = *cur_brk;
+        if(old_brk > prev)
+            setProtection(prev, old_brk-prev, PROT_READ|PROT_WRITE);
+    }
+}
+
 void* find31bitBlockNearHint(void* hint_, size_t size, uintptr_t mask)
 {
     // first, check if program break as changed
-    if(pbrk && cur_brk && *cur_brk!=old_brk) {
-        old_brk = *cur_brk;
-        setProtection(pbrk, old_brk-pbrk, PROT_READ|PROT_WRITE);
-    }
+    catchup_brk_protection();
     uint32_t prot;
     uintptr_t hint = (uintptr_t)hint_;
     if(hint_<LOWEST) hint = (uintptr_t)WINE_LOWEST;
@@ -2888,10 +2900,7 @@ void* find47bitBlock(size_t size)
 void* find47bitBlockNearHint(void* hint, size_t size, uintptr_t mask)
 {
     // first, check if program break as changed
-    if(pbrk && cur_brk && *cur_brk!=old_brk) {
-        old_brk = *cur_brk;
-        setProtection(pbrk, old_brk-pbrk, PROT_READ|PROT_WRITE);
-    }
+    catchup_brk_protection();
     uint32_t prot;
     if(hint<LOWEST) hint = LOWEST;
     uintptr_t bend = 0;


### PR DESCRIPTION
Proper fix for #4052, replacing the CheckExec workaround in #4053.

`find31bitBlockNearHint` / `find47bitBlockNearHint` re-tracked the whole heap from `pbrk` as RW every time the program break moved. `setProtection` only writes the tracking, not the kernel, so every page the guest had made executable inside the heap silently lost PROT_EXEC in the tracking while the kernel still mapped it rwx. `CheckExec` then saw prot=3 against a kernel 0x7 and raised 0xecec forever at that RIP.

Hit it with UE4SS on a Palworld dedicated server: it puts hook trampolines on heap pages, the heap grows, the trampolines lose their exec bit in the tracking, and the server dies in a signal storm about one boot in three.

Now only the range actually added since last time is tracked, so existing heap pages keep their protection.

Tested on ARM64 (Neoverse-N1), Palworld dedicated server + UE4SS, 8 boots: no storm. I kept the CheckExec resync from #4053 in the test binary purely as a canary that logs when tracking and kernel disagree — with the same binary before this fix it fired on 5 of 8 boots, after it never fired once.

#4053 can be closed if you take this one.