### PR TITLE
[INTERP] Set invalid flag for FP-to-int conversions

### DIFF
--- a/src/emu/x64run0f.c
+++ b/src/emu/x64run0f.c
@@ -381,13 +381,17 @@ uintptr_t Run0F(x64emu_t *emu, rex_t rex, uintptr_t addr, int *step)
             tmp64s = EX->f[1];
             if (tmp64s==(int32_t)tmp64s && !isnanf(EX->f[1]))
                 GM->sd[1] = (int32_t)tmp64s;
-            else
+            else {
+                mxcsr_raise_invalid(emu);
                 GM->sd[1] = INT32_MIN;
+            }
             tmp64s = EX->f[0];
             if (tmp64s==(int32_t)tmp64s && !isnanf(EX->f[0]))
                 GM->sd[0] = (int32_t)tmp64s;
-            else
+            else {
+                mxcsr_raise_invalid(emu);
                 GM->sd[0] = INT32_MIN;
+            }
             break;
         case 0x2D:                      /* CVTPS2PI Gm, Ex */
             // rounding should be done; and indefinite integer should also be assigned if overflow or NaN/Inf
@@ -418,8 +422,10 @@ uintptr_t Run0F(x64emu_t *emu, rex_t rex, uintptr_t addr, int *step)
                     }
                 if (tmp64s==(int32_t)tmp64s)
                     GM->sd[i] = (int32_t)tmp64s;
-                else
+                else {
+                    mxcsr_raise_invalid(emu);
                     GM->sd[i] = INT32_MIN;
+                }
             }
             break;
         case 0x2E:                      /* UCOMISS Gx, Ex */

--- a/src/emu/x64run660f.c
+++ b/src/emu/x64run660f.c
@@ -230,13 +230,17 @@ uintptr_t Run660F(x64emu_t *emu, rex_t rex, uintptr_t addr)
         tmp64s = EX->d[0];
         if (tmp64s==(int32_t)tmp64s && !isnan(EX->d[0]))
             GM->sd[0] = (int32_t)tmp64s;
-        else
+        else {
+            mxcsr_raise_invalid(emu);
             GM->sd[0] = INT32_MIN;
+        }
         tmp64s = EX->d[1];
         if (tmp64s==(int32_t)tmp64s && !isnan(EX->d[1]))
             GM->sd[1] = (int32_t)tmp64s;
-        else
+        else {
+            mxcsr_raise_invalid(emu);
             GM->sd[1] = INT32_MIN;
+        }
         break;
     case 0x2D:                      /* CVTPD2PI Gm, Ex */
         nextop = F8;
@@ -264,11 +268,14 @@ uintptr_t Run660F(x64emu_t *emu, rex_t rex, uintptr_t addr)
                 i64[1] = EX->d[1];
                 break;
         }
-        for(int i=0; i<2; ++i)
+        for(int i=0; i<2; ++i) {
             if (i64[i]==(int32_t)i64[i] && !isnan(EX->d[i]))
                 GM->sd[i] = (int32_t)i64[i];
-            else
+            else {
+                mxcsr_raise_invalid(emu);
                 GM->sd[i] = INT32_MIN;
+            }
+        }
 
         break;
     case 0x2E:                      /* UCOMISD Gx, Ex */
@@ -1396,6 +1403,7 @@ uintptr_t Run660F(x64emu_t *emu, rex_t rex, uintptr_t addr)
             if (tmp64s==(int32_t)tmp64s) {
                 GX->sd[i] = (int32_t)tmp64s;
             } else {
+                mxcsr_raise_invalid(emu);
                 GX->sd[i] = INT32_MIN;
             }
         }
@@ -2504,13 +2512,15 @@ uintptr_t Run660F(x64emu_t *emu, rex_t rex, uintptr_t addr)
         nextop = F8;
         GETEX(0);
         GETGX;
-        if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>(double)0x7fffffff)
+        if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>(double)0x7fffffff) {
+            mxcsr_raise_invalid(emu);
             GX->ud[0] = 0x80000000;
-        else
+        } else
             GX->sd[0] = EX->d[0];
-        if(isnan(EX->d[1]) || isinf(EX->d[1]) || EX->d[1]>(double)0x7fffffff)
+        if(isnan(EX->d[1]) || isinf(EX->d[1]) || EX->d[1]>(double)0x7fffffff) {
+            mxcsr_raise_invalid(emu);
             GX->ud[1] = 0x80000000;
-        else
+        } else
             GX->sd[1] = EX->d[1];
         GX->q[1] = 0;
         break;

--- a/src/emu/x64run_private.h
+++ b/src/emu/x64run_private.h
@@ -1,6 +1,7 @@
 #ifndef __X86RUN_PRIVATE_H_
 #define __X86RUN_PRIVATE_H_
 
+#include <fenv.h>
 #include <stdint.h>
 #include "regs.h"
 #include "x64emu_private.h"
@@ -44,6 +45,19 @@ typedef struct vex_s {
     uint16_t    m:5;    // opcode map
     uint16_t    evex:1; // was decoded from an EVEX prefix
 } vex_t;
+
+static inline void box64_feraise_invalid(void)
+{
+#if !defined(_WIN32) && !defined(__MINGW32__)
+    feraiseexcept(FE_INVALID);
+#endif
+}
+
+static inline void mxcsr_raise_invalid(x64emu_t* emu)
+{
+    emu->mxcsr.f.MXCSR_IE = 1;
+    box64_feraise_invalid();
+}
 
 static inline int FillVEXFromEVEX(vex_t* vex, rex_t rex, uint8_t p0, uint8_t p1, uint8_t p2)
 {

--- a/src/emu/x64runavx660f.c
+++ b/src/emu/x64runavx660f.c
@@ -428,6 +428,7 @@ uintptr_t RunAVX_660F(x64emu_t *emu, vex_t vex, uintptr_t addr, int *step)
                 if (tmp64s==(int32_t)tmp64s) {
                     GX->sd[i] = (int32_t)tmp64s;
                 } else {
+                    mxcsr_raise_invalid(emu);
                     GX->sd[i] = INT32_MIN;
                 }
             }
@@ -458,6 +459,7 @@ uintptr_t RunAVX_660F(x64emu_t *emu, vex_t vex, uintptr_t addr, int *step)
                     if (tmp64s==(int32_t)tmp64s) {
                         GY->sd[i] = (int32_t)tmp64s;
                     } else {
+                        mxcsr_raise_invalid(emu);
                         GY->sd[i] = INT32_MIN;
                     }
                 }
@@ -1748,23 +1750,27 @@ uintptr_t RunAVX_660F(x64emu_t *emu, vex_t vex, uintptr_t addr, int *step)
             GETEX(0);
             GETGX;
             GETGY;
-            if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>(double)0x7fffffff)
+            if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>(double)0x7fffffff) {
+                mxcsr_raise_invalid(emu);
                 GX->ud[0] = 0x80000000;
-            else
+            } else
                 GX->sd[0] = EX->d[0];
-            if(isnan(EX->d[1]) || isinf(EX->d[1]) || EX->d[1]>(double)0x7fffffff)
+            if(isnan(EX->d[1]) || isinf(EX->d[1]) || EX->d[1]>(double)0x7fffffff) {
+                mxcsr_raise_invalid(emu);
                 GX->ud[1] = 0x80000000;
-            else
+            } else
                 GX->sd[1] = EX->d[1];
             if(vex.l) {
                 GETEY;
-                if(isnan(EY->d[0]) || isinf(EY->d[0]) || EY->d[0]>(double)0x7fffffff)
+                if(isnan(EY->d[0]) || isinf(EY->d[0]) || EY->d[0]>(double)0x7fffffff) {
+                    mxcsr_raise_invalid(emu);
                     GX->ud[2] = 0x80000000;
-                else
+                } else
                     GX->sd[2] = EY->d[0];
-                if(isnan(EY->d[1]) || isinf(EY->d[1]) || EY->d[1]>(double)0x7fffffff)
+                if(isnan(EY->d[1]) || isinf(EY->d[1]) || EY->d[1]>(double)0x7fffffff) {
+                    mxcsr_raise_invalid(emu);
                     GX->ud[3] = 0x80000000;
-                else
+                } else
                     GX->sd[3] = EY->d[1];
             } else
                 GX->q[1] = 0;

--- a/src/emu/x64runavxf20f.c
+++ b/src/emu/x64runavxf20f.c
@@ -117,15 +117,17 @@ uintptr_t RunAVX_F20F(x64emu_t *emu, vex_t vex, uintptr_t addr, int *step)
             nextop = F8;
             _GETEX(0);
             GETGD;
-            if(rex.w)
-                if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>=(double)0x7fffffffffffffffLL)
+            if(rex.w) {
+                if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>=(double)0x7fffffffffffffffLL) {
+                    mxcsr_raise_invalid(emu);
                     GD->q[0] = 0x8000000000000000LL;
-                else
+                } else
                     GD->sq[0] = EX->d[0];
-            else {
-                if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>(double)0x7fffffff)
+            } else {
+                if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>(double)0x7fffffff) {
+                    mxcsr_raise_invalid(emu);
                     GD->dword[0] = 0x80000000;
-                else
+                } else
                     GD->sdword[0] = EX->d[0];
                 GD->dword[1] = 0;
             }
@@ -135,9 +137,10 @@ uintptr_t RunAVX_F20F(x64emu_t *emu, vex_t vex, uintptr_t addr, int *step)
             _GETEX(0);
             GETGD;
             if(rex.w) {
-                if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>=(double)0x7fffffffffffffffLL)
+                if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>=(double)0x7fffffffffffffffLL) {
+                    mxcsr_raise_invalid(emu);
                     GD->q[0] = 0x8000000000000000LL;
-                else
+                } else
                     switch(emu->mxcsr.f.MXCSR_RC) {
                         case ROUND_Nearest: {
                             int round = fegetround();
@@ -157,9 +160,10 @@ uintptr_t RunAVX_F20F(x64emu_t *emu, vex_t vex, uintptr_t addr, int *step)
                             break;
                     }
             } else {
-                if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>(double)0x7fffffff)
+                if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>(double)0x7fffffff) {
+                    mxcsr_raise_invalid(emu);
                     GD->dword[0] = 0x80000000;
-                else
+                } else
                     switch(emu->mxcsr.f.MXCSR_RC) {
                         case ROUND_Nearest: {
                             int round = fegetround();
@@ -508,11 +512,13 @@ uintptr_t RunAVX_F20F(x64emu_t *emu, vex_t vex, uintptr_t addr, int *step)
             if (tmp64s0==(int32_t)tmp64s0 && !isnan(EX->d[0])) {
                 GX->sd[0] = (int32_t)tmp64s0;
             } else {
+                mxcsr_raise_invalid(emu);
                 GX->sd[0] = INT32_MIN;
             }
             if (tmp64s1==(int32_t)tmp64s1 && !isnan(EX->d[1])) {
                 GX->sd[1] = (int32_t)tmp64s1;
             } else {
+                mxcsr_raise_invalid(emu);
                 GX->sd[1] = INT32_MIN;
             }
             if(vex.l) {
@@ -542,11 +548,13 @@ uintptr_t RunAVX_F20F(x64emu_t *emu, vex_t vex, uintptr_t addr, int *step)
                 if (tmp64s0==(int32_t)tmp64s0 && !isnan(EY->d[0])) {
                     GX->sd[2] = (int32_t)tmp64s0;
                 } else {
+                    mxcsr_raise_invalid(emu);
                     GX->sd[2] = INT32_MIN;
                 }
                 if (tmp64s1==(int32_t)tmp64s1 && !isnan(EY->d[1])) {
                     GX->sd[3] = (int32_t)tmp64s1;
                 } else {
+                    mxcsr_raise_invalid(emu);
                     GX->sd[3] = INT32_MIN;
                 }
             } else

--- a/src/emu/x64runavxf30f.c
+++ b/src/emu/x64runavxf30f.c
@@ -136,14 +136,16 @@ uintptr_t RunAVX_F30F(x64emu_t *emu, vex_t vex, uintptr_t addr, int *step)
             GETEX(0);
             GETGD;
             if (rex.w) {
-                if(isnanf(EX->f[0]) || isinff(EX->f[0]) || EX->f[0]>=(float)0x7fffffffffffffffLL)
+                if(isnanf(EX->f[0]) || isinff(EX->f[0]) || EX->f[0]>=(float)0x7fffffffffffffffLL) {
+                    mxcsr_raise_invalid(emu);
                     GD->q[0] = 0x8000000000000000LL;
-                else
+                } else
                     GD->sq[0] = EX->f[0];
             } else {
-                if(isnanf(EX->f[0]) || isinff(EX->f[0]) || EX->f[0]>=(float)0x7fffffff)
+                if(isnanf(EX->f[0]) || isinff(EX->f[0]) || EX->f[0]>=(float)0x7fffffff) {
+                    mxcsr_raise_invalid(emu);
                     GD->dword[0] = 0x80000000;
-                else
+                } else
                     GD->sdword[0] = EX->f[0];
                 GD->dword[1] = 0;
             }
@@ -153,9 +155,10 @@ uintptr_t RunAVX_F30F(x64emu_t *emu, vex_t vex, uintptr_t addr, int *step)
             GETEX(0);
             GETGD;
             if(rex.w) {
-                if(isnanf(EX->f[0]) || isinff(EX->f[0]) || EX->f[0]>=(float)0x7fffffffffffffffLL)
+                if(isnanf(EX->f[0]) || isinff(EX->f[0]) || EX->f[0]>=(float)0x7fffffffffffffffLL) {
+                    mxcsr_raise_invalid(emu);
                     GD->q[0] = 0x8000000000000000LL;
-                else
+                } else
                     switch(emu->mxcsr.f.MXCSR_RC) {
                         case ROUND_Nearest: {
                             int round = fegetround();
@@ -198,8 +201,10 @@ uintptr_t RunAVX_F30F(x64emu_t *emu, vex_t vex, uintptr_t addr, int *step)
                     }
                 if (tmp64s==(int32_t)tmp64s)
                     GD->sdword[0] = (int32_t)tmp64s;
-                else
+                else {
+                    mxcsr_raise_invalid(emu);
                     GD->sdword[0] = INT32_MIN;
+                }
                 GD->dword[1] = 0;
             }
             break;
@@ -305,6 +310,7 @@ uintptr_t RunAVX_F30F(x64emu_t *emu, vex_t vex, uintptr_t addr, int *step)
                 if (tmp64s==(int32_t)tmp64s) {
                     GX->sd[i] = (int32_t)tmp64s;
                 } else {
+                    mxcsr_raise_invalid(emu);
                     GX->sd[i] = INT32_MIN;
                 }
             }
@@ -318,6 +324,7 @@ uintptr_t RunAVX_F30F(x64emu_t *emu, vex_t vex, uintptr_t addr, int *step)
                     if (tmp64s==(int32_t)tmp64s) {
                         GY->sd[i] = (int32_t)tmp64s;
                     } else {
+                        mxcsr_raise_invalid(emu);
                         GY->sd[i] = INT32_MIN;
                     }
                 }

--- a/src/emu/x64rundb.c
+++ b/src/emu/x64rundb.c
@@ -141,26 +141,29 @@ uintptr_t RunDB(x64emu_t *emu, rex_t rex, uintptr_t addr)
                 break;
             case 1: /* FISTTP Ed, ST0 */
                 GETE4(0);
-                if(isgreater(ST0.d, (double)0x7fffffff) || isless(ST0.d, -(double)0x80000000U) || !isfinite(ST0.d))
+                if(isgreater(ST0.d, (double)0x7fffffff) || isless(ST0.d, -(double)0x80000000U) || !isfinite(ST0.d)) {
+                    fpu_raise_invalid(emu);
                     ED->sdword[0] = 0x80000000;
-                else
+                } else
                     ED->sdword[0] = ST0.d;
                 fpu_do_pop(emu);
                 break;
             case 2: /* FIST Ed, ST0 */
                 GETE4(0);
-                if(isgreater(ST0.d, (double)0x7fffffff) || isless(ST0.d, -(double)0x80000000U) || !isfinite(ST0.d))
+                if(isgreater(ST0.d, (double)0x7fffffff) || isless(ST0.d, -(double)0x80000000U) || !isfinite(ST0.d)) {
+                    fpu_raise_invalid(emu);
                     ED->sdword[0] = 0x80000000;
-                else {
+                } else {
                     volatile int32_t tmp = fpu_round(emu, ST0.d);    // tmp to avoid BUS ERROR
                     ED->sdword[0] = tmp;
                 }
                 break;
             case 3: /* FISTP Ed, ST0 */
                 GETE4(0);
-                if(isgreater(ST0.d, (double)0x7fffffff) || isless(ST0.d, -(double)0x80000000U) || !isfinite(ST0.d))
+                if(isgreater(ST0.d, (double)0x7fffffff) || isless(ST0.d, -(double)0x80000000U) || !isfinite(ST0.d)) {
+                    fpu_raise_invalid(emu);
                     ED->sdword[0] = 0x80000000;
-                else {
+                } else {
                     volatile int32_t tmp = fpu_round(emu, ST0.d);    // tmp to avoid BUS ERROR
                     ED->sdword[0] = tmp;
                 }

--- a/src/emu/x64rundd.c
+++ b/src/emu/x64rundd.c
@@ -104,9 +104,10 @@ uintptr_t RunDD(x64emu_t *emu, rex_t rex, uintptr_t addr)
                 if(STll(0).sref==ST(0).sq)
                     ED->sq[0] = STll(0).sq;
                 else {
-                    if(isgreater(ST0.d, (double)0x7fffffffffffffffLL) || isless(ST0.d, -(double)0x8000000000000000LL) || !isfinite(ST0.d))
+                    if(isgreater(ST0.d, (double)0x7fffffffffffffffLL) || isless(ST0.d, -(double)0x8000000000000000LL) || !isfinite(ST0.d)) {
+                        fpu_raise_invalid(emu);
                         *(uint64_t*)ED = 0x8000000000000000LL;
-                    else
+                    } else
                         *(int64_t*)ED = ST0.d;
                 }
                 fpu_do_pop(emu);

--- a/src/emu/x64rundf.c
+++ b/src/emu/x64rundf.c
@@ -104,24 +104,27 @@ uintptr_t RunDF(x64emu_t *emu, rex_t rex, uintptr_t addr)
         case 1: /* FISTTP Ew, ST0 */
             GETEW(0);
             tmp16s = ST0.d;
-            if(isgreater(ST0.d, (double)(int32_t)0x7fff) || isless(ST0.d, -(double)(int32_t)0x8000) || !isfinite(ST0.d))
+            if(isgreater(ST0.d, (double)(int32_t)0x7fff) || isless(ST0.d, -(double)(int32_t)0x8000) || !isfinite(ST0.d)) {
+                fpu_raise_invalid(emu);
                 EW->sword[0] = 0x8000;
-            else
+            } else
                 EW->sword[0] = tmp16s;
             fpu_do_pop(emu);
             break;
         case 2: /* FIST Ew, ST0 */
             GETEW(0);
-            if(isgreater(ST0.d, (double)(int32_t)0x7fff) || isless(ST0.d, -(double)(int32_t)0x8000) || !isfinite(ST0.d))
+            if(isgreater(ST0.d, (double)(int32_t)0x7fff) || isless(ST0.d, -(double)(int32_t)0x8000) || !isfinite(ST0.d)) {
+                fpu_raise_invalid(emu);
                 EW->sword[0] = 0x8000;
-            else
+            } else
                 EW->sword[0] = fpu_round(emu, ST0.d);
             break;
         case 3: /* FISTP Ew, ST0 */
             GETEW(0);
-            if(isgreater(ST0.d, (double)(int32_t)0x7fff) || isless(ST0.d, -(double)(int32_t)0x8000) || !isfinite(ST0.d))
+            if(isgreater(ST0.d, (double)(int32_t)0x7fff) || isless(ST0.d, -(double)(int32_t)0x8000) || !isfinite(ST0.d)) {
+                fpu_raise_invalid(emu);
                 EW->sword[0] = 0x8000;
-            else
+            } else
                 EW->sword[0] = fpu_round(emu, ST0.d);
             fpu_do_pop(emu);
             break;
@@ -148,9 +151,10 @@ uintptr_t RunDF(x64emu_t *emu, rex_t rex, uintptr_t addr)
             if(STll(0).sref==ST(0).sq)
                 ED->sq[0] = STll(0).sq;
             else {
-                if(isgreater(ST0.d, (double)0x7fffffffffffffffLL) || isless(ST0.d, -(double)0x8000000000000000LL) || !isfinite(ST0.d))
+                if(isgreater(ST0.d, (double)0x7fffffffffffffffLL) || isless(ST0.d, -(double)0x8000000000000000LL) || !isfinite(ST0.d)) {
+                    fpu_raise_invalid(emu);
                     ED->sq[0] = 0x8000000000000000LL;
-                else
+                } else
                     ED->sq[0] = fpu_round(emu, ST0.d);
             }
             fpu_do_pop(emu);

--- a/src/emu/x64runf20f.c
+++ b/src/emu/x64runf20f.c
@@ -100,15 +100,17 @@ uintptr_t RunF20F(x64emu_t *emu, rex_t rex, uintptr_t addr, int *step)
         nextop = F8;
         _GETEX(0);
         GETGD;
-        if(rex.w)
-            if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>=(double)0x7fffffffffffffffLL)
+        if(rex.w) {
+            if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>=(double)0x7fffffffffffffffLL) {
+                mxcsr_raise_invalid(emu);
                 GD->q[0] = 0x8000000000000000LL;
-            else
+            } else
                 GD->sq[0] = EX->d[0];
-        else {
-            if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>(double)0x7fffffff)
+        } else {
+            if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>(double)0x7fffffff) {
+                mxcsr_raise_invalid(emu);
                 GD->dword[0] = 0x80000000;
-            else
+            } else
                 GD->sdword[0] = EX->d[0];
             GD->dword[1] = 0;
         }
@@ -118,9 +120,10 @@ uintptr_t RunF20F(x64emu_t *emu, rex_t rex, uintptr_t addr, int *step)
         _GETEX(0);
         GETGD;
         if(rex.w) {
-            if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>=(double)0x7fffffffffffffffLL)
+            if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>=(double)0x7fffffffffffffffLL) {
+                mxcsr_raise_invalid(emu);
                 GD->q[0] = 0x8000000000000000LL;
-            else
+            } else
                 switch(emu->mxcsr.f.MXCSR_RC) {
                     case ROUND_Nearest: {
                         int round = fegetround();
@@ -140,9 +143,10 @@ uintptr_t RunF20F(x64emu_t *emu, rex_t rex, uintptr_t addr, int *step)
                         break;
                 }
         } else {
-            if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>(double)0x7fffffff)
+            if(isnan(EX->d[0]) || isinf(EX->d[0]) || EX->d[0]>(double)0x7fffffff) {
+                mxcsr_raise_invalid(emu);
                 GD->dword[0] = 0x80000000;
-            else
+            } else
                 switch(emu->mxcsr.f.MXCSR_RC) {
                     case ROUND_Nearest: {
                         int round = fegetround();
@@ -503,11 +507,13 @@ uintptr_t RunF20F(x64emu_t *emu, rex_t rex, uintptr_t addr, int *step)
         if (tmp64s0==(int32_t)tmp64s0 && !isnan(EX->d[0])) {
             GX->sd[0] = (int32_t)tmp64s0;
         } else {
+            mxcsr_raise_invalid(emu);
             GX->sd[0] = INT32_MIN;
         }
         if (tmp64s1==(int32_t)tmp64s1 && !isnan(EX->d[1])) {
             GX->sd[1] = (int32_t)tmp64s1;
         } else {
+            mxcsr_raise_invalid(emu);
             GX->sd[1] = INT32_MIN;
         }
 

--- a/src/emu/x64runf30f.c
+++ b/src/emu/x64runf30f.c
@@ -108,14 +108,16 @@ uintptr_t RunF30F(x64emu_t *emu, rex_t rex, uintptr_t addr, int* step)
         GETEX(0);
         GETGD;
         if (rex.w) {
-            if(isnanf(EX->f[0]) || isinff(EX->f[0]) || EX->f[0]>=(float)0x7fffffffffffffffLL)
+            if(isnanf(EX->f[0]) || isinff(EX->f[0]) || EX->f[0]>=(float)0x7fffffffffffffffLL) {
+                mxcsr_raise_invalid(emu);
                 GD->q[0] = 0x8000000000000000LL;
-            else
+            } else
                 GD->sq[0] = EX->f[0];
         } else {
-            if(isnanf(EX->f[0]) || isinff(EX->f[0]) || EX->f[0]>=(float)0x7fffffff)
+            if(isnanf(EX->f[0]) || isinff(EX->f[0]) || EX->f[0]>=(float)0x7fffffff) {
+                mxcsr_raise_invalid(emu);
                 GD->dword[0] = 0x80000000;
-            else
+            } else
                 GD->sdword[0] = EX->f[0];
             GD->dword[1] = 0;
         }
@@ -125,9 +127,10 @@ uintptr_t RunF30F(x64emu_t *emu, rex_t rex, uintptr_t addr, int* step)
         GETEX(0);
         GETGD;
         if(rex.w) {
-            if(isnanf(EX->f[0]) || isinff(EX->f[0]) || EX->f[0]>=(float)0x7fffffffffffffffLL)
+            if(isnanf(EX->f[0]) || isinff(EX->f[0]) || EX->f[0]>=(float)0x7fffffffffffffffLL) {
+                mxcsr_raise_invalid(emu);
                 GD->q[0] = 0x8000000000000000LL;
-            else
+            } else
                 switch(emu->mxcsr.f.MXCSR_RC) {
                     case ROUND_Nearest: {
                         int round = fegetround();
@@ -170,8 +173,10 @@ uintptr_t RunF30F(x64emu_t *emu, rex_t rex, uintptr_t addr, int* step)
                 }
             if (tmp64s==(int32_t)tmp64s)
                 GD->sdword[0] = (int32_t)tmp64s;
-            else
+            else {
+                mxcsr_raise_invalid(emu);
                 GD->sdword[0] = INT32_MIN;
+            }
             GD->dword[1] = 0;
         }
         break;
@@ -289,6 +294,7 @@ uintptr_t RunF30F(x64emu_t *emu, rex_t rex, uintptr_t addr, int* step)
             if (tmp64s==(int32_t)tmp64s) {
                 GX->sd[i] = (int32_t)tmp64s;
             } else {
+                mxcsr_raise_invalid(emu);
                 GX->sd[i] = INT32_MIN;
             }
         }

--- a/src/emu/x87emu_private.h
+++ b/src/emu/x87emu_private.h
@@ -207,6 +207,11 @@ static inline void fpu_ftst(x64emu_t* emu) {
     emu->sw.f.F87_C0 = (ST0.ud[1]&0x80000000)?1:0;
 }
 
+static inline void fpu_raise_invalid(x64emu_t* emu) {
+    emu->sw.f.F87_IE = 1;
+    box64_feraise_invalid();
+}
+
 void fpu_fbst(x64emu_t* emu, uint8_t* d);
 void fpu_fbld(x64emu_t* emu, uint8_t* s);
 


### PR DESCRIPTION
The primary objective is to ensure the correct updating of exception status flags when floating-point to integer conversions encounter exceptional conditions within the interpreter.

Key changes cover the x87, SSE, and AVX code paths: when processing inputs that are NaN, infinity (Inf), or out of range, these paths already generate the "indefinite integer result" mandated by the x86 architecture.

Updates:
- x87 `FIST/FISTP/FISTTP`: Set `F87_IE`.
- SSE/AVX `CVT*/CVTT*` (single/double-precision float to integer): Set `MXCSR_IE`.
- Trigger the host machine's `FE_INVALID` exception so that `fetestexcept(FE_INVALID)` can detect the status.

## Reproduction Scenario

Official tests for the third-party Python library NumPy check for floating-point exception status after type conversion. Although the resulting integer is correct, the absence of the "invalid operation" flag (invalid flag) meant that the invalid type conversion failed to trigger the expected warning.