### PR TITLE
[RV64_DYNAREC] Support prefetch family inst by Zicbop

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_0f.c
+++ b/src/dynarec/rv64/dynarec_rv64_0f.c
@@ -167,10 +167,24 @@ uintptr_t dynarec64_0F(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
         case 0x0D:
             nextop = F8;
             switch ((nextop >> 3) & 7) {
-                case 1:
-                    INST_NAME("PREFETCHW");
-                    // nop without Zicbom, Zicbop, Zicboz extensions
-                    FAKEED;
+                case 0:
+                    INST_NAME("PREFETCH");
+                    if (cpuext.zicbop) {
+                        addr = geted(dyn, addr, ninst, nextop, &ed, x1, x2, &fixedaddress, rex, NULL, 0, 0);
+                        CBO_PREFETCH_R(ed, 0);
+                    } else {
+                        FAKEED;
+                    }
+                    break;
+                case 1: // PREFETCHW
+                case 2: // PREFETCHWT1
+                    INST_NAME("PREFETCHWh");
+                    if (cpuext.zicbop) {
+                        addr = geted(dyn, addr, ninst, nextop, &ed, x1, x2, &fixedaddress, rex, NULL, 0, 0);
+                        CBO_PREFETCH_W(ed, 0);
+                    } else {
+                        FAKEED;
+                    }
                     break;
                 default: //???
                     DEFAULT;
@@ -302,11 +316,19 @@ uintptr_t dynarec64_0F(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
             } else
                 switch ((nextop >> 3) & 7) {
                     case 0:
+                        INST_NAME("PREFETCHNTA Ed");
+                        FAKEED;
+                        break;
                     case 1:
                     case 2:
                     case 3:
                         INST_NAME("PREFETCHh Ed");
-                        FAKEED;
+                        if (cpuext.zicbop) {
+                            addr = geted(dyn, addr, ninst, nextop, &ed, x1, x2, &fixedaddress, rex, NULL, 0, 0);
+                            CBO_PREFETCH_R(ed, 0);
+                        } else {
+                            FAKEED;
+                        }
                         break;
                     default:
                         INST_NAME("NOP (multibyte)");

--- a/src/dynarec/rv64/rv64_emitter.h
+++ b/src/dynarec/rv64/rv64_emitter.h
@@ -522,6 +522,12 @@
 #define CBO_FLUSH(rs1) EMIT((0b000000000010 << 20) | CBOM_BASE(rs1))
 #define CBO_INVAL(rs1) EMIT((0b000000000000 << 20) | CBOM_BASE(rs1))
 
+// Zicbop
+#define CBOP_BASE(rs1, imm12) (((((imm12) >> 5) & 0x7F) << 25) | ((rs1) << 15) | (0b110 << 12) | (0b00000 << 7) | 0b0010011)
+#define CBO_PREFETCH_I(rs1, imm12) EMIT(CBOP_BASE(rs1, imm12) | (0b00000 << 20))
+#define CBO_PREFETCH_R(rs1, imm12) EMIT(CBOP_BASE(rs1, imm12) | (0b00001 << 20))
+#define CBO_PREFETCH_W(rs1, imm12) EMIT(CBOP_BASE(rs1, imm12) | (0b00011 << 20))
+
 #define EBREAK() EMIT(I_type(1, 0, 0, 0, 0b1110011))
 
 // RV64I

--- a/src/include/hostext.h
+++ b/src/include/hostext.h
@@ -37,6 +37,7 @@ typedef union cpu_ext_s {
         uint64_t xtheadmac : 1;
         uint64_t xtheadfmv : 1;
         uint64_t zicbom : 1;
+        uint64_t zicbop : 1;
 #elif defined(LA64)
         uint64_t lbt : 1; // it's important it's stay the 1st bit
         uint64_t lam_bh : 1;

--- a/src/os/hostext_common.c
+++ b/src/os/hostext_common.c
@@ -53,6 +53,7 @@ void PrintHostCpuFeatures(void)
     if (cpuext.zbc) printf_log_prefix(0, LOG_INFO, "_zbc");
     if (cpuext.zbs) printf_log_prefix(0, LOG_INFO, "_zbs");
     if (cpuext.zicbom) printf_log_prefix(0, LOG_INFO, "_zicbom");
+    if (cpuext.zicbop) printf_log_prefix(0, LOG_INFO, "_zicbop");
     if (cpuext.vector && !cpuext.xtheadvector) printf_log_prefix(0, LOG_INFO, "_zvl%d", cpuext.vlen * 8);
     if (cpuext.xtheadba) printf_log_prefix(0, LOG_INFO, "_xtheadba");
     if (cpuext.xtheadbb) printf_log_prefix(0, LOG_INFO, "_xtheadbb");

--- a/src/os/hostext_linux.c
+++ b/src/os/hostext_linux.c
@@ -117,6 +117,13 @@ void rv64Detect(void)
     BR(xRA);
     cpuext.zicbom = Check(my_block);
 
+    // Test Zicbop with PREFETCH.R
+    block = (uint32_t*)my_block;
+    CBO_PREFETCH_R(A2, 0);
+    ADDI(A0, xZR, 42);
+    BR(xRA);
+    cpuext.zicbop = Check(my_block);
+
     block = (uint32_t*)my_block;
     CSRRS(xZR, xZR, 0xc22 /* vlenb */);
     ADDI(A0, xZR, 42);
@@ -265,6 +272,7 @@ int DetectHostCpuFeatures(void)
                 if (!strcasecmp(p, "xtheadmempair")) cpuext.xtheadmempair = 0;
                 if (!strcasecmp(p, "xtheadcondmov")) cpuext.xtheadcondmov = 0;
                 if (!strcasecmp(p, "zicbom")) cpuext.zicbom = 0;
+                if (!strcasecmp(p, "zicbop")) cpuext.zicbop = 0;
                 p = strtok(NULL, ",");
             }
         }


### PR DESCRIPTION
1. Map x86-64 prefetch/prefetcht0/prefetcht1/prefetcht2 to risc-v prefetch.r
2. Map x86-64 prefetchw/prefetchwt1 to risc-v prefetch.w
3. Keep x86-64 PREFETCHNTA unchanged
