### PR TITLE
[DRAFT] custommem: probe for 48-bit address space when the maps scan finds none

### DIFF
--- a/src/custommem.c
+++ b/src/custommem.c
@@ -2766,6 +2766,15 @@ void loadProtectionFromMap()
                 have48bits = 1;
         }
     }
+    if(!have48bits && !box64_is32bits) {
+        void* probe = InternalMmap((void*)0x7fff00000000LL, box64_pagesize, PROT_NONE,
+                                   MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE, -1, 0);
+        if(probe!=MAP_FAILED) {
+            if((uintptr_t)probe>=0x7fff00000000LL)
+                have48bits = 1;
+            InternalMunmap(probe, box64_pagesize);
+        }
+    }
     static int shown48bits = 0;
     if(!shown48bits) {
         shown48bits = 1;


### PR DESCRIPTION
Fixes #4084.

`loadProtectionFromMap()` only set `have48bits` when `/proc/self/maps` already had a mapping above `0x7fff00000000`. In fresh processes / containers there is none yet even on a 48-bit-capable kernel, so box64 wrongly assumed 39-bit and packed allocations low.

Instead, probe: if the scan found nothing high, try to reserve a page at `0x7fff00000000`. If the kernel places it there we have 48-bit; on a real 39-bit system it lands low and `have48bits` stays 0 (unchanged).
