### PR TITLE
malloc_hack: redirect captured function pointers and direct calls

### DIFF
--- a/src/dynarec/arm64/dynarec_arm64_00.c
+++ b/src/dynarec/arm64/dynarec_arm64_00.c
@@ -3916,6 +3916,7 @@ uintptr_t dynarec64_00(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int nin
                         j64 = (uint32_t)(addr+i32);
                     else
                         j64 = addr+i32;
+                        j64 = (uintptr_t)getAlternate((void*)j64);
                     jump_to_next(dyn, j64, 0, ninst, rex.is32bits);
                     CALLRET_RET(can_continue);
                     MARK;

--- a/src/elfs/elfloader.c
+++ b/src/elfs/elfloader.c
@@ -689,7 +689,7 @@ static int RelocateElfRELA(lib_t *maplib, lib_t *local_maplib, int bindnow, int 
                 break;
             case R_X86_64_RELATIVE:
                 printf_dump(LOG_NEVER, "Apply %s R_X86_64_RELATIVE @%p (%p -> %p)\n", BindSym(bind), p, *(void**)p, (void*)(head->delta+ rela[i].r_addend));
-                *p = head->delta+ rela[i].r_addend;
+                *p = (uintptr_t)getAlternate((void*)(head->delta+ rela[i].r_addend));
                 break;
             case R_X86_64_IRELATIVE:
                 {
@@ -739,7 +739,7 @@ static int RelocateElfRELA(lib_t *maplib, lib_t *local_maplib, int bindnow, int 
                             printf_log((bind==STB_WEAK)?LOG_DEBUG:LOG_NONE, "%s: Global Symbol %s not found, cannot apply R_X86_64_GLOB_DAT @%p (%p) in %s\n", (bind==STB_WEAK)?"Warning":"Error", symname, p, *(void**)p, head->name);
                     } else {
                         printf_dump(LOG_NEVER, "Apply %s R_X86_64_GLOB_DAT @%p (%p -> %p) on sym=%s (%sver=%d/%s, elf=%s)\n", BindSym(bind), p, (void*)(p?(*p):0), (void*)(offs + rela[i].r_addend), symname, veropt?"opt":"", version, vername?vername:"(none)", sym_elf?sym_elf->name:"(native)");
-                        *p = offs + rela[i].r_addend;
+                        *p = (uintptr_t)getAlternate((void*)(offs + rela[i].r_addend));
                         if(sym_elf && sym_elf!=last_elf && sym_elf!=head) last_elf = checkElfLib(head, sym_elf->lib);
                     }
                 }
@@ -767,7 +767,7 @@ static int RelocateElfRELA(lib_t *maplib, lib_t *local_maplib, int bindnow, int 
                         if(p) {
                             printf_dump(LOG_NEVER, "Apply %s R_X86_64_JUMP_SLOT @%p with sym=%s (%p -> %p / %s (%sver=%d / %s))\n",
                                 BindSym(bind), p, symname, *(void**)p, (void*)(offs+rela[i].r_addend), sym_elf?sym_elf->name:"native", veropt?"opt":"", version, vername?vername:"(none)");
-                            *p = offs + rela[i].r_addend;
+                            *p = (uintptr_t)getAlternate((void*)(offs + rela[i].r_addend));
                             if(sym_elf && sym_elf!=last_elf && sym_elf!=head) last_elf = checkElfLib(head, sym_elf->lib);
                         } else {
                             printf_log(LOG_INFO, "Warning, Symbol %s found, but Jump Slot Offset is NULL \n", symname);
@@ -795,7 +795,7 @@ static int RelocateElfRELA(lib_t *maplib, lib_t *local_maplib, int bindnow, int 
                 } else {
                     printf_dump(LOG_NEVER, "Apply %s R_X86_64_64 @%p with sym=%s (%sver=%d/%s) addend=0x%lx (%p -> %p)\n",
                         BindSym(bind), p, symname, veropt?"opt":"", version, vername?vername:"(none)", rela[i].r_addend, *(void**)p, (void*)(offs+rela[i].r_addend/*+*(uint64_t*)p*/));
-                    *p /*+*/= offs+rela[i].r_addend;
+                    *p = (uintptr_t)getAlternate((void*)(offs+rela[i].r_addend));
                     if(sym_elf && sym_elf!=last_elf && sym_elf!=head) last_elf = checkElfLib(head, sym_elf->lib);
                 }
                 break;


### PR DESCRIPTION
`getAlternate` (how `BOX64_MALLOC_HACK` reroutes malloc/free) was only applied on some paths. When a program takes the **address** of the overridden malloc/free without a symbol call — a data relocation (`RELATIVE`/`GLOB_DAT`/`64`) or an arm64 direct `CALL` — the raw address was kept and the redirect bypassed.

Chromium/Electron (PartitionAlloc) capture `free`'s address into their allocator tables and also call it directly, so they mix box64- and app-allocated pointers under `malloc_hack` and crash in `free()`.

Apply `getAlternate` on those paths too:
- `RelocateElfRELA`: `RELATIVE`, `GLOB_DAT`, `JUMP_SLOT`, `64` — matching what `PltResolver64` already does for lazy binding.
- arm64 `0xE8 CALL` — matching rv64/la64/ppc64le, which already do this.

**Result:** an unmodified amd64 Signal Desktop (Electron) now boots under box64 on aarch64 instead of crashing in `PartitionAlloc::Free`.

Note: no unit test — the behaviour only appears with a real overriding allocator under `malloc_hack`; a synthetic override perturbs libc startup. Validated by running the app; the change only extends existing `getAlternate` coverage.
