### PR TITLE
[RV64_DYNAREC] Use risc-v zicond to eliminate some branchs for setting flag

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_helper.h
+++ b/src/dynarec/rv64/dynarec_rv64_helper.h
@@ -903,6 +903,10 @@
         if (cpuext.xtheadcondmov) {         \
             ORI(scratch, xFlags, 1 << F);   \
             TH_MVNEZ(xFlags, scratch, reg); \
+        } else if (cpuext.zicond) {         \
+            ADDI(scratch, xZR, 1 << F);     \
+            CZERO_EQZ(scratch, scratch, reg); \
+            OR(xFlags, xFlags, scratch);    \
         } else {                            \
             BEQZ(reg, 8);                   \
             ORI(xFlags, xFlags, 1 << F);    \
@@ -914,6 +918,10 @@
         if (cpuext.xtheadcondmov) {         \
             ORI(scratch, xFlags, 1 << F);   \
             TH_MVEQZ(xFlags, scratch, reg); \
+        } else if (cpuext.zicond) {         \
+            ADDI(scratch, xZR, 1 << F);     \
+            CZERO_NEZ(scratch, scratch, reg); \
+            OR(xFlags, xFlags, scratch);    \
         } else {                            \
             BNEZ(reg, 8);                   \
             ORI(xFlags, xFlags, 1 << F);    \
@@ -926,6 +934,11 @@
             SLT(scratch1, reg, xZR);              \
             ORI(scratch2, xFlags, 1 << F);        \
             TH_MVNEZ(xFlags, scratch2, scratch1); \
+        } else if (cpuext.zicond) {               \
+            SLT(scratch1, reg, xZR);              \
+            ADDI(scratch2, xZR, 1 << F);          \
+            CZERO_EQZ(scratch2, scratch2, scratch1); \
+            OR(xFlags, xFlags, scratch2);         \
         } else {                                  \
             BGE(reg, xZR, 8);                     \
             ORI(xFlags, xFlags, 1 << F);          \

--- a/src/dynarec/rv64/rv64_emitter.h
+++ b/src/dynarec/rv64/rv64_emitter.h
@@ -277,6 +277,11 @@
 #define MVEQ(rd, rs1, rs2, rs3)                               \
     if (cpuext.xtheadcondmov && (rs2 == xZR || rs3 == xZR)) { \
         TH_MVEQZ(rd, rs1, ((rs2 == xZR) ? rs3 : rs2));        \
+    } else if (cpuext.zicond && (rs2 == xZR || rs3 == xZR)) { \
+        int cond_ = (rs2 == xZR) ? rs3 : rs2;                 \
+        CZERO_EQZ(rd, rd, cond_);                             \
+        CZERO_NEZ(cond_, rs1, cond_);                         \
+        OR(rd, rd, cond_);                                    \
     } else {                                                  \
         BNE(rs2, rs3, 8);                                     \
         MV(rd, rs1);                                          \
@@ -284,6 +289,11 @@
 #define MVNE(rd, rs1, rs2, rs3)                               \
     if (cpuext.xtheadcondmov && (rs2 == xZR || rs3 == xZR)) { \
         TH_MVNEZ(rd, rs1, ((rs2 == xZR) ? rs3 : rs2));        \
+    } else if (cpuext.zicond && (rs2 == xZR || rs3 == xZR)) { \
+        int cond_ = (rs2 == xZR) ? rs3 : rs2;                 \
+        CZERO_NEZ(rd, rd, cond_);                             \
+        CZERO_EQZ(cond_, rs1, cond_);                         \
+        OR(rd, rd, cond_);                                    \
     } else {                                                  \
         BEQ(rs2, rs3, 8);                                     \
         MV(rd, rs1);                                          \

--- a/src/dynarec/rv64/rv64_emitter.h
+++ b/src/dynarec/rv64/rv64_emitter.h
@@ -1219,6 +1219,12 @@
         ANDI(rd, rd, 1);      \
     }
 
+// Zicond
+// rd = (rs2 == 0) ? 0 : rs1
+#define CZERO_EQZ(rd, rs1, rs2) EMIT(R_type(0b0000111, rs2, rs1, 0b101, rd, 0b0110011))
+// rd = (rs2 != 0) ? 0 : rs1
+#define CZERO_NEZ(rd, rs1, rs2) EMIT(R_type(0b0000111, rs2, rs1, 0b111, rd, 0b0110011))
+
 /// THead vendor extension
 /// https://github.com/T-head-Semi/thead-extension-spec/releases
 

--- a/src/dynarec/rv64/rv64_printer.c
+++ b/src/dynarec/rv64/rv64_printer.c
@@ -2602,6 +2602,25 @@ const char* rv64_print(uint32_t opcode, uintptr_t addr)
         return buff;
     }
 
+    if (cpuext.zicond) {
+        // CZERO.EQZ rd, rs1, rs2
+        if ((opcode & 0xfe00707f) == 0x0e005033) {
+            a.rd = FX(opcode, 11, 7);
+            a.rs1 = FX(opcode, 19, 15);
+            a.rs2 = FX(opcode, 24, 20);
+            snprintf(buff, sizeof(buff), "%-15s %s, %s, %s", "CZERO.EQZ", gpr[a.rd], gpr[a.rs1], gpr[a.rs2]);
+            return buff;
+        }
+        // CZERO.NEZ rd, rs1, rs2
+        if ((opcode & 0xfe00707f) == 0x0e007033) {
+            a.rd = FX(opcode, 11, 7);
+            a.rs1 = FX(opcode, 19, 15);
+            a.rs2 = FX(opcode, 24, 20);
+            snprintf(buff, sizeof(buff), "%-15s %s, %s, %s", "CZERO.NEZ", gpr[a.rd], gpr[a.rs1], gpr[a.rs2]);
+            return buff;
+        }
+    }
+
     //  rv_zbb, ORC.B
     if ((opcode & 0xfff0707f) == 0x28705013) {
         a.rd = FX(opcode, 11, 7);

--- a/src/include/hostext.h
+++ b/src/include/hostext.h
@@ -38,6 +38,7 @@ typedef union cpu_ext_s {
         uint64_t xtheadfmv : 1;
         uint64_t zicbom : 1;
         uint64_t zicbop : 1;
+        uint64_t zicond : 1;
 #elif defined(LA64)
         uint64_t lbt : 1; // it's important it's stay the 1st bit
         uint64_t lam_bh : 1;

--- a/src/os/hostext_common.c
+++ b/src/os/hostext_common.c
@@ -54,6 +54,7 @@ void PrintHostCpuFeatures(void)
     if (cpuext.zbs) printf_log_prefix(0, LOG_INFO, "_zbs");
     if (cpuext.zicbom) printf_log_prefix(0, LOG_INFO, "_zicbom");
     if (cpuext.zicbop) printf_log_prefix(0, LOG_INFO, "_zicbop");
+    if (cpuext.zicond) printf_log_prefix(0, LOG_INFO, "_zicond");
     if (cpuext.vector && !cpuext.xtheadvector) printf_log_prefix(0, LOG_INFO, "_zvl%d", cpuext.vlen * 8);
     if (cpuext.xtheadba) printf_log_prefix(0, LOG_INFO, "_xtheadba");
     if (cpuext.xtheadbb) printf_log_prefix(0, LOG_INFO, "_xtheadbb");

--- a/src/os/hostext_linux.c
+++ b/src/os/hostext_linux.c
@@ -124,6 +124,13 @@ void rv64Detect(void)
     BR(xRA);
     cpuext.zicbop = Check(my_block);
 
+    // Test Zicond with CZERO.EQZ
+    block = (uint32_t*)my_block;
+    CZERO_EQZ(A0, A0, A1);
+    ADDI(A0, xZR, 42);
+    BR(xRA);
+    cpuext.zicond = Check(my_block);
+
     block = (uint32_t*)my_block;
     CSRRS(xZR, xZR, 0xc22 /* vlenb */);
     ADDI(A0, xZR, 42);
@@ -273,6 +280,7 @@ int DetectHostCpuFeatures(void)
                 if (!strcasecmp(p, "xtheadcondmov")) cpuext.xtheadcondmov = 0;
                 if (!strcasecmp(p, "zicbom")) cpuext.zicbom = 0;
                 if (!strcasecmp(p, "zicbop")) cpuext.zicbop = 0;
+                if (!strcasecmp(p, "zicond")) cpuext.zicond = 0;
                 p = strtok(NULL, ",");
             }
         }


### PR DESCRIPTION
When setting flags, using `Zicond `eliminates the branch at the cost of one extra instruction.