### PR TITLE
[RV64_DYNAREC] Remove redundant SMREAD

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_0f.c
+++ b/src/dynarec/rv64/dynarec_rv64_0f.c
@@ -292,7 +292,6 @@ uintptr_t dynarec64_0F(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, int ni
                 INST_NAME("MOVLHPS Gx,Ex");
             } else {
                 INST_NAME("MOVHPS Gx,Ex");
-                SMREAD();
             }
             GETGX();
             GETEX(x2, 0, 1);


### PR DESCRIPTION
Frankly, I am not sure whether this` SMREAD` should be removed. 

Based on my understanding, `GETEX` already performs `SMREAD` in the` !MODREG` block, while `GETGX` only contains store operations. So I think it can be removed.