### PR TITLE
[INTERPRETER] Improve x87 long double classification

### DIFF
--- a/src/emu/x64emu.c
+++ b/src/emu/x64emu.c
@@ -448,7 +448,7 @@ const char* DumpCPURegs(x64emu_t* emu, uintptr_t ip, int is32bits)
         int stack = emu->fpu_stack;
         if(stack>8) stack = 8;
         for (int i=0; i<stack; i++) {
-            sprintf(tmp, "ST%d=%f(0x%" PRIx64 "%s)", i, ST(i).d, ST(i).q, (ST(i).q==STld(i).uref)?PrintLD(&STld(i).ld, " / "):"");
+            sprintf(tmp, "ST%d=%f(0x%" PRIx64 "%s)", i, ST(i).d, ST(i).q, fpu_ld80_raw_valid(emu, i)?PrintLD(&STld(i).ld, " / "):"");
             strcat(buff, tmp);
             int c = 20-strlen(tmp);
             if(c<1) c=1;

--- a/src/emu/x64rund9.c
+++ b/src/emu/x64rund9.c
@@ -50,10 +50,19 @@ uintptr_t RunD9(x64emu_t *emu, rex_t rex, uintptr_t addr)
         case 0xC5:
         case 0xC6:
         case 0xC7:  /* FLD STx */
-            ll = ST(nextop&7).q;
-            fpu_do_push(emu);
-            ST0.q = ll;
-            break;
+            {
+                int i = nextop&7;
+                fpu_ld_t ld = STld(i);
+                int ld_valid = fpu_ld80_raw_valid(emu, i);
+                ll = ST(i).q;
+                fpu_do_push(emu);
+                ST0.q = ll;
+                if(ld_valid)
+                    STld(0) = ld;
+                else
+                    fpu_ld80_clear(emu, 0);
+                break;
+            }
         case 0xC8:
         case 0xC9:
         case 0xCA:
@@ -62,10 +71,11 @@ uintptr_t RunD9(x64emu_t *emu, rex_t rex, uintptr_t addr)
         case 0xCD:
         case 0xCE:
         case 0xCF:  /* FXCH STx */
-            ll = ST(nextop&7).q;
-            ST(nextop&7).q = ST0.q;
-            ST0.q = ll;
-            break;
+            {
+                int i = nextop&7;
+                fpu_ld80_swap(emu, 0, i);
+                break;
+            }
 
         case 0xD0:  /* FNOP */
             break;
@@ -78,15 +88,39 @@ uintptr_t RunD9(x64emu_t *emu, rex_t rex, uintptr_t addr)
         case 0xDD:
         case 0xDE:
         case 0xDF:
-            ST(nextop&7).q = ST0.q;
+            fpu_ld80_copy(emu, nextop&7, 0);
             fpu_do_pop(emu);
             break;
         case 0xE0:  /* FCHS */
-            ST0.d = -ST0.d;
-            break;
+            {
+                int i = fpu_ld80_raw_valid(emu, 0);
+                ST0.d = -ST0.d;
+                if(i) {
+#ifdef HAVE_LD80BITS
+                    STld(0).ld = -STld(0).ld;
+#else
+                    STld(0).ld.l.upper ^= 0x8000;
+#endif
+                    STld(0).uref = ST0.q;
+                } else
+                    fpu_ld80_clear(emu, 0);
+                break;
+            }
         case 0xE1:  /* FABS */
-            ST0.d = fabs(ST0.d);
-            break;
+            {
+                int i = fpu_ld80_raw_valid(emu, 0);
+                ST0.d = fabs(ST0.d);
+                if(i) {
+#ifdef HAVE_LD80BITS
+                    STld(0).ld = fabsl(STld(0).ld);
+#else
+                    STld(0).ld.l.upper &= 0x7fff;
+#endif
+                    STld(0).uref = ST0.q;
+                } else
+                    fpu_ld80_clear(emu, 0);
+                break;
+            }
         
         case 0xE4:  /* FTST */
             fpu_ftst(emu);
@@ -206,7 +240,7 @@ uintptr_t RunD9(x64emu_t *emu, rex_t rex, uintptr_t addr)
         case 0xF8:  /* FPREM */
             {
                 int go = 1;
-                if(STld(0).uref==ST0.q && STld(1).uref==ST1.q) {
+                if(fpu_ld80_raw_valid(emu, 0) && fpu_ld80_raw_valid(emu, 1)) {
                     // try a full precision fpre alternative
                     if(full_ld_fprem(emu))
                         go = 0;

--- a/src/emu/x64runda.c
+++ b/src/emu/x64runda.c
@@ -48,7 +48,7 @@ uintptr_t RunDA(x64emu_t *emu, rex_t rex, uintptr_t addr)
     case 0xC7:
         CHECK_FLAGS(emu);
         if(ACCESS_FLAG(F_CF))
-            ST0.q = ST(nextop&7).q;
+            fpu_ld80_copy(emu, 0, nextop&7);
         break;
     case 0xC8:      /* FCMOVE ST(0), ST(i) */
     case 0xC9:
@@ -60,7 +60,7 @@ uintptr_t RunDA(x64emu_t *emu, rex_t rex, uintptr_t addr)
     case 0xCF:
         CHECK_FLAGS(emu);
         if(ACCESS_FLAG(F_ZF))
-            ST0.q = ST(nextop&7).q;
+            fpu_ld80_copy(emu, 0, nextop&7);
         break;
     case 0xD0:      /* FCMOVBE ST(0), ST(i) */
     case 0xD1:
@@ -72,7 +72,7 @@ uintptr_t RunDA(x64emu_t *emu, rex_t rex, uintptr_t addr)
     case 0xD7:
         CHECK_FLAGS(emu);
         if(ACCESS_FLAG(F_CF) || ACCESS_FLAG(F_ZF))
-            ST0.q = ST(nextop&7).q;
+            fpu_ld80_copy(emu, 0, nextop&7);
         break;
     case 0xD8:      /* FCMOVU ST(0), ST(i) */
     case 0xD9:
@@ -84,7 +84,7 @@ uintptr_t RunDA(x64emu_t *emu, rex_t rex, uintptr_t addr)
     case 0xDF:
         CHECK_FLAGS(emu);
         if(ACCESS_FLAG(F_PF))
-            ST0.q = ST(nextop&7).q;
+            fpu_ld80_copy(emu, 0, nextop&7);
         break;
     
     case 0xE9:      /* FUCOMPP */

--- a/src/emu/x64rundb.c
+++ b/src/emu/x64rundb.c
@@ -50,7 +50,7 @@ uintptr_t RunDB(x64emu_t *emu, rex_t rex, uintptr_t addr)
     case 0xC7:
         CHECK_FLAGS(emu);
         if(!ACCESS_FLAG(F_CF))
-            ST0.q = ST(nextop&7).q;
+            fpu_ld80_copy(emu, 0, nextop&7);
         break;
     case 0xC8:      /* FCMOVNE ST(0), ST(i) */
     case 0xC9:
@@ -62,7 +62,7 @@ uintptr_t RunDB(x64emu_t *emu, rex_t rex, uintptr_t addr)
     case 0xCF:
         CHECK_FLAGS(emu);
         if(!ACCESS_FLAG(F_ZF))
-            ST0.q = ST(nextop&7).q;
+            fpu_ld80_copy(emu, 0, nextop&7);
         break;
     case 0xD0:      /* FCMOVNBE ST(0), ST(i) */
     case 0xD1:
@@ -74,7 +74,7 @@ uintptr_t RunDB(x64emu_t *emu, rex_t rex, uintptr_t addr)
     case 0xD7:
         CHECK_FLAGS(emu);
         if(!(ACCESS_FLAG(F_CF) || ACCESS_FLAG(F_ZF)))
-            ST0.q = ST(nextop&7).q;
+            fpu_ld80_copy(emu, 0, nextop&7);
         break;
     case 0xD8:      /* FCMOVNU ST(0), ST(i) */
     case 0xD9:
@@ -86,7 +86,7 @@ uintptr_t RunDB(x64emu_t *emu, rex_t rex, uintptr_t addr)
     case 0xDF:
         CHECK_FLAGS(emu);
         if(!ACCESS_FLAG(F_PF))
-            ST0.q = ST(nextop&7).q;
+            fpu_ld80_copy(emu, 0, nextop&7);
         break;
 
     case 0xE1:      /* FDISI8087_NOP */
@@ -115,7 +115,10 @@ uintptr_t RunDB(x64emu_t *emu, rex_t rex, uintptr_t addr)
     case 0xED:
     case 0xEE:
     case 0xEF:
-        fpu_fcomi(emu, ST(nextop&7).d);   // bad, should handle QNaN and IA interrupt
+    #ifndef HAVE_LD80BITS
+        if (!fpu_fcomi_ld80(emu, nextop&7))
+    #endif
+            fpu_fcomi(emu, ST(nextop&7).d);   // bad, should handle QNaN and IA interrupt
         break;
 
     case 0xF0:  /* FCOMI ST0, STx */
@@ -126,7 +129,10 @@ uintptr_t RunDB(x64emu_t *emu, rex_t rex, uintptr_t addr)
     case 0xF5:
     case 0xF6:
     case 0xF7:
-        fpu_fcomi(emu, ST(nextop&7).d);
+    #ifndef HAVE_LD80BITS
+        if (!fpu_fcomi_ld80(emu, nextop&7))
+    #endif
+            fpu_fcomi(emu, ST(nextop&7).d);
         break;
 
     default:
@@ -178,7 +184,7 @@ uintptr_t RunDB(x64emu_t *emu, rex_t rex, uintptr_t addr)
                 break;
             case 7: /* FSTP tbyte */
                 GETET(0);
-                if(STld(0).uref && (ST0.q==STld(0).uref))
+                if(fpu_ld80_raw_valid(emu, 0))
                     memcpy(ED, &STld(0).ld, 10);
                 else
                     D2LD(&ST0.d, ED);

--- a/src/emu/x64rundd.c
+++ b/src/emu/x64rundd.c
@@ -55,7 +55,7 @@ uintptr_t RunDD(x64emu_t *emu, rex_t rex, uintptr_t addr)
         case 0xD5:
         case 0xD6:
         case 0xD7:
-            ST(nextop&7).q = ST0.q;
+            fpu_ld80_copy(emu, nextop&7, 0);
             break;
         case 0xD8:  /* FSTP ST0, STx */
         case 0xD9:
@@ -65,7 +65,7 @@ uintptr_t RunDD(x64emu_t *emu, rex_t rex, uintptr_t addr)
         case 0xDD:
         case 0xDE:
         case 0xDF:
-            ST(nextop&7).q = ST0.q;
+            fpu_ld80_copy(emu, nextop&7, 0);
             fpu_do_pop(emu);
             break;
         case 0xE0:  /* FUCOM ST0, STx */

--- a/src/emu/x64rundf.c
+++ b/src/emu/x64rundf.c
@@ -58,7 +58,7 @@ uintptr_t RunDF(x64emu_t *emu, rex_t rex, uintptr_t addr)
         case 0xD5:
         case 0xD6:
         case 0xD7:
-            ST(nextop&7).q = ST0.q;
+            fpu_ld80_copy(emu, nextop&7, 0);
             fpu_do_pop(emu);
             break;
 
@@ -75,7 +75,10 @@ uintptr_t RunDF(x64emu_t *emu, rex_t rex, uintptr_t addr)
         case 0xED:
         case 0xEE:
         case 0xEF:
-            fpu_fcomi(emu, ST(nextop&7).d);   // bad, should handle QNaN and IA interrupt
+        #ifndef HAVE_LD80BITS
+            if (!fpu_fcomi_ld80(emu, nextop&7))
+        #endif
+                fpu_fcomi(emu, ST(nextop&7).d);   // bad, should handle QNaN and IA interrupt
             fpu_do_pop(emu);
             break;
 

--- a/src/emu/x87emu_private.c
+++ b/src/emu/x87emu_private.c
@@ -13,6 +13,7 @@
 
 void fpu_do_free(x64emu_t* emu, int i)
 {
+    fpu_ld80_clear(emu, i);
     emu->fpu_tags |= 0b11 << (i*2);   // empty
     // check if all empty
     if(emu->fpu_tags != TAGS_EMPTY)
@@ -24,9 +25,11 @@ void reset_fpu(x64emu_t* emu)
 {
     memset(emu->x87, 0, sizeof(emu->x87));
     memset(emu->fpu_ld, 0, sizeof(emu->fpu_ld));
+    emu->top = 0;
+    for(int i=0; i<8; ++i)
+        fpu_ld80_clear(emu, i);
     emu->cw.x16 = 0x37F;
     emu->sw.x16 = 0x0000;
-    emu->top = 0;
     emu->fpu_stack = 0;
     emu->fpu_tags = TAGS_EMPTY;
 }

--- a/src/emu/x87emu_private.h
+++ b/src/emu/x87emu_private.h
@@ -24,6 +24,37 @@ typedef struct x64emu_s x64emu_t;
 #define STld(a)  emu->fpu_ld[(emu->top+(a))&7]
 #define STll(a)  emu->fpu_ll[(emu->top+(a))&7]
 
+// Use a NaN payload as invalid marker so a valid +0.0 reference stays usable.
+#define FPU_LD80_INVALID_REF UINT64_C(0x7ff8deadbeefc0de)
+static inline void fpu_ld80_clear(x64emu_t* emu, int i)
+{
+    STld(i).uref = FPU_LD80_INVALID_REF;
+}
+
+static inline int fpu_ld80_raw_valid(x64emu_t* emu, int i)
+{
+    return STld(i).uref != FPU_LD80_INVALID_REF && ST(i).q==STld(i).uref;
+}
+
+static inline void fpu_ld80_copy(x64emu_t* emu, int dst, int src)
+{
+    ST(dst).q = ST(src).q;
+    if(fpu_ld80_raw_valid(emu, src))
+        STld(dst) = STld(src);
+    else
+        fpu_ld80_clear(emu, dst);
+}
+
+static inline void fpu_ld80_swap(x64emu_t* emu, int a, int b)
+{
+    uint64_t q = ST(a).q;
+    fpu_ld_t tmp = STld(a);
+    ST(a).q = ST(b).q;
+    ST(b).q = q;
+    STld(a) = STld(b);
+    STld(b) = tmp;
+}
+
 static inline void fpu_do_push(x64emu_t* emu)
 {
     int newtop = (emu->top-1)&7;
@@ -37,6 +68,7 @@ static inline void fpu_do_push(x64emu_t* emu)
     emu->fpu_tags<<=2;  // st0 full
     emu->fpu_tags &= TAGS_EMPTY;
     emu->top = newtop;
+    fpu_ld80_clear(emu, 0);
 }
 
 static inline void fpu_do_pop(x64emu_t* emu)
@@ -52,6 +84,7 @@ static inline void fpu_do_pop(x64emu_t* emu)
     
     emu->fpu_tags>>=2;
     emu->fpu_tags |= 0b1100000000000000;    // top empty
+    fpu_ld80_clear(emu, 0);
     emu->top = (emu->top+1)&7;
     // check tags
     /*while((emu->fpu_tags&0b11) && emu->fpu_stack) {
@@ -88,6 +121,79 @@ static inline void fpu_fcom(x64emu_t* emu, double b)
         emu->sw.f.F87_C3 = 1;
     }
 }
+
+#ifndef HAVE_LD80BITS
+// 1 => a > b
+// 0 => a == b
+// -1 => a < b
+// 2 => unordered
+static inline int fpu_ld80_raw_cmp(const longdouble_t* a, const longdouble_t* b)
+{
+    uint16_t a_upper = a->l.upper, b_upper = b->l.upper;
+    uint64_t a_lower = a->l.lower, b_lower = b->l.lower;
+
+    int a_sign = a_upper >> 15, b_sign = b_upper >> 15;
+    int a_exponent = a_upper & 0x7fff, b_exponent = b_upper & 0x7fff;
+
+    int a_zero = (a_exponent == 0 && a_lower == 0);
+    int b_zero = (b_exponent == 0 && b_lower == 0);
+
+    int a_nan = (a_exponent == 0x7fff && a_lower != 0x8000000000000000ULL);
+    int b_nan = (b_exponent == 0x7fff && b_lower != 0x8000000000000000ULL);
+
+    if (a_nan || b_nan)
+        return 2;   /* unordered */
+
+    if (a_zero && b_zero)
+        return 0;
+
+    if (a_sign != b_sign)
+        return a_sign ? -1 : 1;
+
+    int mag;
+    if (a_exponent != b_exponent)
+        mag = (a_exponent > b_exponent) ? 1 : -1;
+    else if (a_lower != b_lower)
+        mag = (a_lower > b_lower) ? 1 : -1;
+    else
+        mag = 0;
+
+    return a_sign ? -mag : mag;
+}
+
+static inline int fpu_fcomi_ld80(x64emu_t* emu, int i)
+{
+    if (!fpu_ld80_raw_valid(emu, i) || !fpu_ld80_raw_valid(emu, 0))
+        return 0;
+
+    int cmp = fpu_ld80_raw_cmp(&STld(0).ld, &STld(i).ld);
+
+    RESET_FLAGS(emu);
+    CLEAR_FLAG(F_AF);
+    CLEAR_FLAG(F_OF);
+    CLEAR_FLAG(F_SF);
+    emu->sw.f.F87_C1 = 0;
+
+    if (cmp == 2) {
+        SET_FLAG(F_CF);
+        SET_FLAG(F_PF);
+        SET_FLAG(F_ZF);
+    } else if (cmp > 0) {
+        CLEAR_FLAG(F_CF);
+        CLEAR_FLAG(F_PF);
+        CLEAR_FLAG(F_ZF);
+    } else if (cmp < 0) {
+        SET_FLAG(F_CF);
+        CLEAR_FLAG(F_PF);
+        CLEAR_FLAG(F_ZF);
+    } else {
+        CLEAR_FLAG(F_CF);
+        CLEAR_FLAG(F_PF);
+        SET_FLAG(F_ZF);
+    }
+    return 1;
+}
+#endif
 
 static inline void fpu_fcomi(x64emu_t* emu, double b)
 {


### PR DESCRIPTION
Keep the existing raw 80-bit x87 shadow aligned through FLD ST(i), FXCH, FST/FSTP, FCMOV, FABS, and FCHS, and use it for FCOMI/FUCOMI/FUCOMIP when the shadow is still valid.

This avoids falling back to the double representation for long double classification, where large finite values such as LDBL_MAX may collapse to inf and break isinf/isnan/isfinite-style checks.

# Reproduce

```
@aosc-de793919 [ ChatTTS@main ] ! 
  BOX64_DYNAREC=0 BOX64_LOG=0 PYTHONFAULTHANDLER=1 \
  box64 python3 -X faulthandler - <<'PY'
import numpy as np
                  
for name, val in [
    ("+inf", np.inf),
    ("-inf", -np.inf),
    ("nan", np.nan),
]:                                   
    v = np.array([val], dtype="g")[0]
    print(name, v.tobytes().hex(),
          "isinf=", bool(np.isinf(v)),
          "isfinite=", bool(np.isfinite(v)),
          "isnan=", bool(np.isnan(v)),
          flush=True)
PY
done
===== BOX64_DYNAREC=0 =====
[BOX64] Box64 loongarch64 v0.4.3 9c0214dd3 with Dynarec built on Jul 22 2026 21:37:10
+inf 0000000000000080ff7f1600ff7f0000 isinf= False isfinite= True isnan= False
-inf 0000000000000080ffff1600ff7f0000 isinf= False isfinite= True isnan= False
nan 00000000000000c0ff7f1600ff7f0000 isinf= False isfinite= False isnan= True
@aosc-de793919 [ ChatTTS@main ] $ BOX64_DYNAREC=0 BOX64_LOG=0 PYTHONFAULTHANDLER=1   box64 python3 -X faulthandler - <<'PY'
import numpy as np

for name, val in [
    ("+inf", np.inf),
    ("-inf", -np.inf),
    ("nan", np.nan),
]:
    v = np.array([val], dtype="g")[0]
    print(name, v.tobytes().hex(),
          "isinf=", bool(np.isinf(v)),
          "isfinite=", bool(np.isfinite(v)),
          "isnan=", bool(np.isnan(v)),
          flush=True)
PY
 done
===== BOX64_DYNAREC=0 =====
[BOX64] Box64 loongarch64 v0.4.3 40a841df8 with Dynarec built on Jul 23 2026 21:41:27
+inf 0000000000000080ff7f1600ff7f0000 isinf= True isfinite= False isnan= False
-inf 0000000000000080ffff1600ff7f0000 isinf= True isfinite= False isnan= False
nan 00000000000000c0ff7f1600ff7f0000 isinf= False isfinite= False isnan= True

```