### PR TITLE
[RV64_DYNAREC] Change some BNEZ+ORI to SET_FLAGS_EQZ

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_660f38.c
+++ b/src/dynarec/rv64/dynarec_rv64_660f38.c
@@ -332,8 +332,7 @@ uintptr_t dynarec64_660F38(dynarec_rv64_t* dyn, uintptr_t addr, uint8_t opcode, 
                             AND(x6, x4, x2);
                             AND(x7, x5, x3);
                             OR(x6, x6, x7);
-                            BNEZ(x6, 4 + 4);
-                            ORI(xFlags, xFlags, 1 << F_ZF);
+                            SET_FLAGS_EQZ(x6, F_ZF, x7);
                         }
                         IFX (X_CF) {
                             NOT(x4, x4);
@@ -341,8 +340,7 @@ uintptr_t dynarec64_660F38(dynarec_rv64_t* dyn, uintptr_t addr, uint8_t opcode, 
                             AND(x6, x4, x2);
                             AND(x7, x5, x3);
                             OR(x6, x6, x7);
-                            BNEZ(x6, 4 + 4);
-                            ORI(xFlags, xFlags, 1 << F_CF);
+                            SET_FLAGS_EQZ(x6, F_CF, x7);
                         }
                     }
                     break;

--- a/src/dynarec/rv64/dynarec_rv64_660f_vector.c
+++ b/src/dynarec/rv64/dynarec_rv64_660f_vector.c
@@ -464,8 +464,7 @@ uintptr_t dynarec64_660F_vector(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t i
                         }
                         VMV_X_S(x4, VMASK);
                         if (!cpuext.xtheadvector) ANDI(x4, x4, 0b11);
-                        BNEZ(x4, 8);
-                        ORI(xFlags, xFlags, 1 << F_ZF);
+                        SET_FLAGS_EQZ(x4, F_ZF, x3);
                     }
                     IFX (X_CF) {
                         VXOR_VI(v0, q0, 0x1F, VECTOR_UNMASKED);
@@ -480,8 +479,7 @@ uintptr_t dynarec64_660F_vector(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t i
                         }
                         VMV_X_S(x4, VMASK);
                         if (!cpuext.xtheadvector) ANDI(x4, x4, 0b11);
-                        BNEZ(x4, 8);
-                        ORI(xFlags, xFlags, 1 << F_CF);
+                        SET_FLAGS_EQZ(x4, F_CF, x3);
                     }
                     break;
                 case 0x1C ... 0x1E:

--- a/src/dynarec/rv64/dynarec_rv64_avx_0f38.c
+++ b/src/dynarec/rv64/dynarec_rv64_avx_0f38.c
@@ -79,8 +79,7 @@ uintptr_t dynarec64_AVX_0F38(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, 
                 OR(xFlags, xFlags, x5);
             }
             IFX (X_ZF) {
-                BNEZ(gd, 8);
-                ORI(xFlags, xFlags, 1 << F_ZF);
+                SET_FLAGS_EQZ(gd, F_ZF, x5);
             }
             if (BOX64DRENV(dynarec_safeflags)) {
                 IFX (X_PF) emit_pf(dyn, ninst, gd, x2, x5);
@@ -100,15 +99,13 @@ uintptr_t dynarec64_AVX_0F38(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, 
                     }
                     CLEAR_FLAGS();
                     IFX (X_CF) {
-                        BNEZ(ed, 8);
-                        ORI(xFlags, xFlags, 1 << F_CF);
+                        SET_FLAGS_EQZ(ed, F_CF, x5);
                     }
                     ADDIxw(x3, ed, -1);
                     AND(vd, ed, x3);
                     if (!rex.w) ZEROUP(vd);
                     IFX (X_ZF) {
-                        BNEZ(vd, 8);
-                        ORI(xFlags, xFlags, 1 << F_ZF);
+                        SET_FLAGS_EQZ(vd, F_ZF, x5);
                     }
                     IFX (X_SF) {
                         SRLI(x5, vd, rex.w ? 63 : 31);
@@ -130,8 +127,7 @@ uintptr_t dynarec64_AVX_0F38(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, 
                     }
                     CLEAR_FLAGS();
                     IFX (X_CF) {
-                        BNEZ(ed, 8);
-                        ORI(xFlags, xFlags, 1 << F_CF);
+                        SET_FLAGS_EQZ(ed, F_CF, x5);
                     }
                     ADDIxw(x3, ed, -1);
                     XOR(vd, ed, x3);
@@ -156,15 +152,13 @@ uintptr_t dynarec64_AVX_0F38(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, 
                     }
                     CLEAR_FLAGS();
                     IFX (X_CF) {
-                        BEQZ(ed, 8);
-                        ORI(xFlags, xFlags, 1 << F_CF);
+                        SET_FLAGS_NEZ(ed, F_CF, x5);
                     }
                     SUBxw(x3, xZR, ed);
                     AND(vd, ed, x3);
                     if (!rex.w) ZEROUP(vd);
                     IFX (X_ZF) {
-                        BNEZ(vd, 8);
-                        ORI(xFlags, xFlags, 1 << F_ZF);
+                        SET_FLAGS_EQZ(vd, F_ZF, x5);
                     }
                     IFX (X_SF) {
                         SRLI(x5, vd, rex.w ? 63 : 31);
@@ -211,8 +205,7 @@ uintptr_t dynarec64_AVX_0F38(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, 
                 ZEROUP(gd);
             }
             IFX (X_ZF) {
-                BNEZ(gd, 8);
-                ORI(xFlags, xFlags, 1 << F_ZF);
+                SET_FLAGS_EQZ(gd, F_ZF, x5);
             }
             IFX (X_SF) {
                 SRLI(x5, gd, rex.w ? 63 : 31);
@@ -247,8 +240,7 @@ uintptr_t dynarec64_AVX_0F38(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t ip, 
             }
             CLEAR_FLAGS();
             IFX (X_ZF) {
-                BNEZ(gd, 8);
-                ORI(xFlags, xFlags, 1 << F_ZF);
+                SET_FLAGS_EQZ(gd, F_ZF, x5);
             }
             break;
         default:

--- a/src/dynarec/rv64/dynarec_rv64_avx_66_0f38.c
+++ b/src/dynarec/rv64/dynarec_rv64_avx_66_0f38.c
@@ -581,8 +581,7 @@ uintptr_t dynarec64_AVX_66_0F38(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t i
                     AND(x6, x4, x2);
                     AND(x7, x5, x3);
                     OR(x6, x6, x7);
-                    BNEZ(x6, 4 + 4);
-                    ORI(xFlags, xFlags, 1 << F_ZF);
+                    SET_FLAGS_EQZ(x6, F_ZF, x7);
                 }
                 IFX (X_CF) {
                     NOT(x4, x4);
@@ -590,8 +589,7 @@ uintptr_t dynarec64_AVX_66_0F38(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t i
                     AND(x6, x4, x2);
                     AND(x7, x5, x3);
                     OR(x6, x6, x7);
-                    BNEZ(x6, 4 + 4);
-                    ORI(xFlags, xFlags, 1 << F_CF);
+                    SET_FLAGS_EQZ(x6, F_CF, x7);
                 }
             }
             if (vex.l) {


### PR DESCRIPTION
Use SET_FLAGS_EQZ to replace  BNEZ+ORI, and so can use zicond extension.