### PR TITLE
[ARM64_DYNAREC] Skip dead scalar SSE upper-lane preserve

### DIFF
--- a/src/dynarec/arm64/dynarec_arm64_f20f.c
+++ b/src/dynarec/arm64/dynarec_arm64_f20f.c
@@ -68,6 +68,7 @@ uintptr_t dynarec64_F20F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
             nextop = F8;
             GETG;
             v0 = sse_get_reg(dyn, ninst, x1, gd, 0);
+            MARK_XMM_SCALAR(gd);
             if(MODREG) {
                 ed = (nextop&7)+ (rex.b<<3);
                 d0 = sse_get_reg(dyn, ninst, x1, ed, 1);
@@ -237,6 +238,8 @@ uintptr_t dynarec64_F20F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
             GETGX(q0, 1);
             d1 = fpu_get_scratch(dyn, ninst);
             GETEXSD(d0, 0, 0);
+            MARK_XMM_SCALAR(gd);
+            if(MODREG) MARK_XMM_SCALAR((nextop&7)+(rex.b<<3));
             if(!BOX64ENV(dynarec_fastnan)) {
                 v0 = fpu_get_scratch(dyn, ninst);
                 v1 = fpu_get_scratch(dyn, ninst);
@@ -247,10 +250,13 @@ uintptr_t dynarec64_F20F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
                 VBIC(v1, v0, v1);      // forget it in any input was a NAN already
                 SHL_64(v1, v1, 63);   // only keep the sign bit
                 VORR(d1, d1, v1);      // NAN -> -NAN
+                VMOVeD(q0, 0, d1, 0);
+            } else if(XMMH_UNNEEDED(gd)) {
+                FSQRTD(q0, d0);  // upper 64 dead: compute in place, skip preserve
             } else {
                 FSQRTD(d1, d0);
+                VMOVeD(q0, 0, d1, 0);
             }
-            VMOVeD(q0, 0, d1, 0);
             break;
 
         case 0x58:
@@ -259,6 +265,8 @@ uintptr_t dynarec64_F20F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
             GETGX(d1, 1);
             v1 = fpu_get_scratch(dyn, ninst);
             GETEXSD(d0, 0, 0);
+            MARK_XMM_SCALAR(gd);
+            if(MODREG) MARK_XMM_SCALAR((nextop&7)+(rex.b<<3));
             if(!BOX64ENV(dynarec_fastnan)) {
                 v0 = fpu_get_scratch(dyn, ninst);
                 q0 = fpu_get_scratch(dyn, ninst);
@@ -277,10 +285,13 @@ uintptr_t dynarec64_F20F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
                 VMOVQDfrom(q0, 0, x5);
                 VORR(v2, v2, q0); // quiet any SNaN in src1
                 VBIF(v1, v2, v0); // where src1 was NaN, use QNaN(src1)
+                VMOVeD(d1, 0, v1, 0);
+            } else if(XMMH_UNNEEDED(gd)) {
+                FADDD(d1, d1, d0);  // upper 64 dead: compute in place, skip preserve
             } else {
                 FADDD(v1, d1, d0);  // the high part of the vector is erased...
+                VMOVeD(d1, 0, v1, 0);
             }
-            VMOVeD(d1, 0, v1, 0);
             break;
         case 0x59:
             INST_NAME("MULSD Gx, Ex");
@@ -288,6 +299,8 @@ uintptr_t dynarec64_F20F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
             GETGX(d1, 1);
             v1 = fpu_get_scratch(dyn, ninst);
             GETEXSD(d0, 0, 0);
+            MARK_XMM_SCALAR(gd);
+            if(MODREG) MARK_XMM_SCALAR((nextop&7)+(rex.b<<3));
             if(!BOX64ENV(dynarec_fastnan)) {
                 v0 = fpu_get_scratch(dyn, ninst);
                 q0 = fpu_get_scratch(dyn, ninst);
@@ -306,10 +319,13 @@ uintptr_t dynarec64_F20F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
                 VMOVQDfrom(q0, 0, x5);
                 VORR(v2, v2, q0); // quiet any SNaN in src1
                 VBIF(v1, v2, v0); // where src1 was NaN, use QNaN(src1)
+                VMOVeD(d1, 0, v1, 0);
+            } else if(XMMH_UNNEEDED(gd)) {
+                FMULD(d1, d1, d0);  // upper 64 dead: compute in place, skip preserve
             } else {
                 FMULD(v1, d1, d0);
+                VMOVeD(d1, 0, v1, 0);
             }
-            VMOVeD(d1, 0, v1, 0);
             break;
         case 0x5A:
             INST_NAME("CVTSD2SS Gx, Ex");
@@ -333,6 +349,8 @@ uintptr_t dynarec64_F20F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
             GETGX(d1, 1);
             v1 = fpu_get_scratch(dyn, ninst);
             GETEXSD(d0, 0, 0);
+            MARK_XMM_SCALAR(gd);
+            if(MODREG) MARK_XMM_SCALAR((nextop&7)+(rex.b<<3));
             if(!BOX64ENV(dynarec_fastnan)) {
                 v0 = fpu_get_scratch(dyn, ninst);
                 q0 = fpu_get_scratch(dyn, ninst);
@@ -351,10 +369,13 @@ uintptr_t dynarec64_F20F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
                 VMOVQDfrom(q0, 0, x5);
                 VORR(v2, v2, q0); // quiet any SNaN in src1
                 VBIF(v1, v2, v0); // where src1 was NaN, use QNaN(src1)
+                VMOVeD(d1, 0, v1, 0);
+            } else if(XMMH_UNNEEDED(gd)) {
+                FSUBD(d1, d1, d0);  // upper 64 dead: compute in place, skip preserve
             } else {
                 FSUBD(v1, d1, d0);
+                VMOVeD(d1, 0, v1, 0);
             }
-            VMOVeD(d1, 0, v1, 0);
             break;
         case 0x5D:
             INST_NAME("MINSD Gx, Ex");
@@ -372,6 +393,8 @@ uintptr_t dynarec64_F20F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
             GETGX(v0, 1);
             d1 = fpu_get_scratch(dyn, ninst);
             GETEXSD(v1, 0, 0);
+            MARK_XMM_SCALAR(gd);
+            if(MODREG) MARK_XMM_SCALAR((nextop&7)+(rex.b<<3));
             if(!BOX64ENV(dynarec_fastnan)) {
                 d0 = fpu_get_scratch(dyn, ninst);
                 q0 = fpu_get_scratch(dyn, ninst);
@@ -390,10 +413,13 @@ uintptr_t dynarec64_F20F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
                 VMOVQDfrom(q0, 0, x5);
                 VORR(v2, v2, q0); // quiet any SNaN in src1
                 VBIF(d1, v2, d0); // where src1 was NaN, use QNaN(src1)
+                VMOVeD(v0, 0, d1, 0);
+            } else if(XMMH_UNNEEDED(gd)) {
+                FDIVD(v0, v0, v1);  // upper 64 dead: compute in place, skip preserve
             } else {
                 FDIVD(d1, v0, v1);
+                VMOVeD(v0, 0, d1, 0);
             }
-            VMOVeD(v0, 0, d1, 0);
             break;
         case 0x5F:
             INST_NAME("MAXSD Gx, Ex");

--- a/src/dynarec/arm64/dynarec_arm64_f30f.c
+++ b/src/dynarec/arm64/dynarec_arm64_f30f.c
@@ -52,6 +52,7 @@ uintptr_t dynarec64_F30F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
             if(MODREG) {
                 v0 = sse_get_reg(dyn, ninst, x1, gd, 1);
                 q0 = sse_get_reg(dyn, ninst, x1, (nextop&7) + (rex.b<<3), 0);
+                MARK_XMM_SCALAR_SINGLE((nextop&7)+(rex.b<<3));   // reg-reg move reads only low-32 of src
                 VMOVeS(v0, 0, q0, 0);
             } else {
                 v0 = sse_get_reg_empty(dyn, ninst, x1, gd);
@@ -65,6 +66,7 @@ uintptr_t dynarec64_F30F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
             nextop = F8;
             GETG;
             v0 = sse_get_reg(dyn, ninst, x1, gd, 0);
+            MARK_XMM_SCALAR_SINGLE(gd);   // store reads only low-32 of Gx, upper-96 untouched
             if(MODREG) {
                 q0 = sse_get_reg(dyn, ninst, x1, (nextop&7) + (rex.b<<3), 1);
                 VMOVeS(q0, 0, v0, 0);
@@ -236,6 +238,8 @@ uintptr_t dynarec64_F30F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
             GETGX(q0, 1);
             d1 = fpu_get_scratch(dyn, ninst);
             GETEXSS(d0, 0, 0);
+            MARK_XMM_SCALAR_SINGLE(gd);
+            if(MODREG) MARK_XMM_SCALAR_SINGLE((nextop&7)+(rex.b<<3));
             if(!BOX64ENV(dynarec_fastnan)) {
                 v0 = fpu_get_scratch(dyn, ninst);
                 v1 = fpu_get_scratch(dyn, ninst);
@@ -246,16 +250,21 @@ uintptr_t dynarec64_F30F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
                 VBIC(v1, v0, v1);      // forget it in any input was a NAN already
                 VSHL_32(v1, v1, 31);   // only keep the sign bit
                 VORR(d1, d1, v1);      // NAN -> -NAN
+                VMOVeS(q0, 0, d1, 0);
+            } else if(XMMS_UNNEEDED(gd)) {
+                FSQRTS(q0, d0);  // upper 96 dead: compute in place, skip preserve
             } else {
                 FSQRTS(d1, d0);
+                VMOVeS(q0, 0, d1, 0);
             }
-            VMOVeS(q0, 0, d1, 0);
             break;
         case 0x52:
             INST_NAME("RSQRTSS Gx, Ex");
             nextop = F8;
             GETGX(v0, 1);
             GETEXSS(v1, 0, 0);
+            MARK_XMM_SCALAR_SINGLE(gd);
+            if(MODREG) MARK_XMM_SCALAR_SINGLE((nextop&7)+(rex.b<<3));
             d0 = fpu_get_scratch(dyn, ninst);
             d1 = fpu_get_scratch(dyn, ninst);
             // so here: F32: Imm8 = abcd efgh that gives => aBbbbbbc defgh000 00000000 00000000
@@ -273,6 +282,8 @@ uintptr_t dynarec64_F30F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
             nextop = F8;
             GETGX(v0, 1);
             GETEXSS(v1, 0, 0);
+            MARK_XMM_SCALAR_SINGLE(gd);
+            if(MODREG) MARK_XMM_SCALAR_SINGLE((nextop&7)+(rex.b<<3));
             d0 = fpu_get_scratch(dyn, ninst);
             FMOVS_8(d0, 0b01110000);    //1.0f
             FDIVS(d0, d0, v1);
@@ -285,6 +296,8 @@ uintptr_t dynarec64_F30F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
             GETGX(d1, 1);
             v1 = fpu_get_scratch(dyn, ninst);
             GETEXSS(d0, 0, 0);
+            MARK_XMM_SCALAR_SINGLE(gd);
+            if(MODREG) MARK_XMM_SCALAR_SINGLE((nextop&7)+(rex.b<<3));
             if(!BOX64ENV(dynarec_fastnan)) {
                 v0 = fpu_get_scratch(dyn, ninst);
                 q0 = fpu_get_scratch(dyn, ninst);
@@ -304,10 +317,13 @@ uintptr_t dynarec64_F30F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
                 VMOVQSfrom(q0, 0, x5);
                 VORR(v2, v2, q0);      // quiet any SNaN in src1
                 VBIF(v1, v2, v0);      // where src1 was NaN, use QNaN(src1)
+                VMOVeS(d1, 0, v1, 0);
+            } else if(XMMS_UNNEEDED(gd)) {
+                FADDS(d1, d1, d0);  // upper 96 dead: compute in place, skip preserve
             } else {
                 FADDS(v1, d1, d0);  // the high part of the vector is erased...
+                VMOVeS(d1, 0, v1, 0);
             }
-            VMOVeS(d1, 0, v1, 0);
             break;
         case 0x59:
             INST_NAME("MULSS Gx, Ex");
@@ -315,6 +331,8 @@ uintptr_t dynarec64_F30F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
             GETGX(d1, 1);
             v1 = fpu_get_scratch(dyn, ninst);
             GETEXSS(d0, 0, 0);
+            MARK_XMM_SCALAR_SINGLE(gd);
+            if(MODREG) MARK_XMM_SCALAR_SINGLE((nextop&7)+(rex.b<<3));
             if(!BOX64ENV(dynarec_fastnan)) {
                 v0 = fpu_get_scratch(dyn, ninst);
                 q0 = fpu_get_scratch(dyn, ninst);
@@ -334,10 +352,13 @@ uintptr_t dynarec64_F30F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
                 VMOVQSfrom(q0, 0, x5);
                 VORR(v2, v2, q0);      // quiet any SNaN in src1
                 VBIF(v1, v2, v0);      // where src1 was NaN, use QNaN(src1)
+                VMOVeS(d1, 0, v1, 0);
+            } else if(XMMS_UNNEEDED(gd)) {
+                FMULS(d1, d1, d0);  // upper 96 dead: compute in place, skip preserve
             } else {
                 FMULS(v1, d1, d0);  // the high part of the vector is erased...
+                VMOVeS(d1, 0, v1, 0);
             }
-            VMOVeS(d1, 0, v1, 0);
             break;
         case 0x5A:
             INST_NAME("CVTSS2SD Gx, Ex");
@@ -399,6 +420,8 @@ uintptr_t dynarec64_F30F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
             GETGX(d1, 1);
             v1 = fpu_get_scratch(dyn, ninst);
             GETEXSS(d0, 0, 0);
+            MARK_XMM_SCALAR_SINGLE(gd);
+            if(MODREG) MARK_XMM_SCALAR_SINGLE((nextop&7)+(rex.b<<3));
             if(!BOX64ENV(dynarec_fastnan)) {
                 v0 = fpu_get_scratch(dyn, ninst);
                 q0 = fpu_get_scratch(dyn, ninst);
@@ -418,16 +441,21 @@ uintptr_t dynarec64_F30F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
                 VMOVQSfrom(q0, 0, x5);
                 VORR(v2, v2, q0);      // quiet any SNaN in src1
                 VBIF(v1, v2, v0);      // where src1 was NaN, use QNaN(src1)
+                VMOVeS(d1, 0, v1, 0);
+            } else if(XMMS_UNNEEDED(gd)) {
+                FSUBS(d1, d1, d0);  // upper 96 dead: compute in place, skip preserve
             } else {
                 FSUBS(v1, d1, d0);  // the high part of the vector is erased...
+                VMOVeS(d1, 0, v1, 0);
             }
-            VMOVeS(d1, 0, v1, 0);
             break;
         case 0x5D:
             INST_NAME("MINSS Gx, Ex");
             nextop = F8;
             GETGX(v0, 1);
             GETEXSS(v1, 0, 0);
+            MARK_XMM_SCALAR_SINGLE(gd);
+            if(MODREG) MARK_XMM_SCALAR_SINGLE((nextop&7)+(rex.b<<3));
             // MINSS: if any input is NaN, or Ex[0]<Gx[0], copy Ex[0] -> Gx[0]
             FCMPS(v0, v1);
             B_NEXT(cCC);    //CC invert of CS: NAN or == or Gx > Ex
@@ -439,6 +467,8 @@ uintptr_t dynarec64_F30F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
             GETGX(d1, 1);
             v1 = fpu_get_scratch(dyn, ninst);
             GETEXSS(d0, 0, 0);
+            MARK_XMM_SCALAR_SINGLE(gd);
+            if(MODREG) MARK_XMM_SCALAR_SINGLE((nextop&7)+(rex.b<<3));
             if(!BOX64ENV(dynarec_fastnan)) {
                 v0 = fpu_get_scratch(dyn, ninst);
                 q0 = fpu_get_scratch(dyn, ninst);
@@ -458,16 +488,21 @@ uintptr_t dynarec64_F30F(dynarec_arm_t* dyn, uintptr_t addr, uintptr_t ip, int n
                 VMOVQSfrom(q0, 0, x5);
                 VORR(v2, v2, q0);      // quiet any SNaN in src1
                 VBIF(v1, v2, v0);      // where src1 was NaN, use QNaN(src1)
+                VMOVeS(d1, 0, v1, 0);
+            } else if(XMMS_UNNEEDED(gd)) {
+                FDIVS(d1, d1, d0);  // upper 96 dead: compute in place, skip preserve
             } else {
                 FDIVS(v1, d1, d0);  // the high part of the vector is erased...
+                VMOVeS(d1, 0, v1, 0);
             }
-            VMOVeS(d1, 0, v1, 0);
             break;
         case 0x5F:
             INST_NAME("MAXSS Gx, Ex");
             nextop = F8;
             GETGX(v0, 1);
             GETEXSS(v1, 0, 0);
+            MARK_XMM_SCALAR_SINGLE(gd);
+            if(MODREG) MARK_XMM_SCALAR_SINGLE((nextop&7)+(rex.b<<3));
             // MAXSS: if any input is NaN, or Ex[0]>Gx[0], copy Ex[0] -> Gx[0]
             FCMPS(v1, v0);
             B_NEXT(cCC);    //CC: invert of CS: NAN or == or Ex > Gx

--- a/src/dynarec/arm64/dynarec_arm64_functions.c
+++ b/src/dynarec/arm64/dynarec_arm64_functions.c
@@ -76,6 +76,8 @@ void fpu_reset_scratch(dynarec_arm_t* dyn)
     dyn->n.xmm_unneeded = 0;
     dyn->n.ymm_unneeded = 0;
     dyn->n.xmm_removed = 0;
+    dyn->n.xmm_scalar = 0;
+    dyn->n.xmm_scalar_single = 0;
 }
 // Get a x87 double reg
 int fpu_get_reg_x87(dynarec_arm_t* dyn, int ninst, int t, int n)
@@ -867,6 +869,12 @@ void inst_name_pass3(dynarec_native_t* dyn, int ninst, const char* name, rex_t r
     if (dyn->insts[ninst].n.xmm_used || dyn->insts[ninst].n.xmm_unneeded || dyn->insts[ninst].n.xmm_needed) {
         length += sprintf(buf + length, " xmmUsed=%04x/needed=%04x/unneeded=%04x", dyn->insts[ninst].n.xmm_used, dyn->insts[ninst].n.xmm_needed, dyn->insts[ninst].n.xmm_unneeded);
     }
+    if (dyn->insts[ninst].n.xmmh_used || dyn->insts[ninst].n.xmmh_needed || dyn->insts[ninst].n.xmmh_unneeded) {
+        length += sprintf(buf + length, " xmmHused=%04x/needed=%04x/unneeded=%04x", dyn->insts[ninst].n.xmmh_used, dyn->insts[ninst].n.xmmh_needed, dyn->insts[ninst].n.xmmh_unneeded);
+    }
+    if (dyn->insts[ninst].n.xmms_used || dyn->insts[ninst].n.xmms_needed || dyn->insts[ninst].n.xmms_unneeded) {
+        length += sprintf(buf + length, " xmmSused=%04x/needed=%04x/unneeded=%04x", dyn->insts[ninst].n.xmms_used, dyn->insts[ninst].n.xmms_needed, dyn->insts[ninst].n.xmms_unneeded);
+    }
     if (dyn->insts[ninst].n.ymm_used || dyn->insts[ninst].n.ymm_unneeded || dyn->insts[ninst].n.ymm_needed) {
         length += sprintf(buf + length, " ymmUsed=%04x/needed=%04x/unneeded=%04x", dyn->insts[ninst].n.ymm_used, dyn->insts[ninst].n.ymm_needed, dyn->insts[ninst].n.ymm_unneeded);
     }
@@ -1233,26 +1241,32 @@ static uint32_t getXYMMMask(dynarec_arm_t* dyn, int ninst)
     return ret;
 }
 
-static void propagateXYMMNeeded(dynarec_arm_t* dyn, int ninst, uint16_t mask_x, uint16_t mask_y)
+static void propagateXYMMNeeded(dynarec_arm_t* dyn, int ninst, uint16_t mask_x, uint16_t mask_y, uint16_t mask_xh, uint16_t mask_xs)
 {
     while(ninst>=0) {
         // removed unneeded regs
         mask_x &= ~dyn->insts[ninst].n.xmm_unneeded;
         mask_y &= ~dyn->insts[ninst].n.ymm_unneeded;
+        mask_xh &= ~dyn->insts[ninst].n.xmmh_unneeded;
+        mask_xs &= ~dyn->insts[ninst].n.xmms_unneeded;
         // removed already needed from mask
         mask_x &= ~dyn->insts[ninst].n.xmm_needed;
         mask_y &= ~dyn->insts[ninst].n.ymm_needed;
+        mask_xh &= ~dyn->insts[ninst].n.xmmh_needed;
+        mask_xs &= ~dyn->insts[ninst].n.xmms_needed;
         // already handled
-        if(!mask_x && !mask_y) return;
+        if(!mask_x && !mask_y && !mask_xh && !mask_xs) return;
         // added the unneeded value
         dyn->insts[ninst].n.xmm_needed |= mask_x;
         dyn->insts[ninst].n.ymm_needed |= mask_y;
+        dyn->insts[ninst].n.xmmh_needed |= mask_xh;
+        dyn->insts[ninst].n.xmms_needed |= mask_xs;
         for(int i=1; i<dyn->insts[ninst].pred_sz; ++i) {
             int j = dyn->insts[ninst].pred[i];
             // barrier or callret, value is needed
             if(!(dyn->insts[j].x64.barrier&BARRIER_FLOAT)
               && !(dyn->insts[j].x64.has_callret))
-                propagateXYMMNeeded(dyn, j, mask_x, mask_y);
+                propagateXYMMNeeded(dyn, j, mask_x, mask_y, mask_xh, mask_xs);
         }
         if(dyn->insts[ninst].pred_sz)
             ninst = dyn->insts[ninst].pred[0];
@@ -1265,25 +1279,31 @@ static void propagateXYMMNeeded(dynarec_arm_t* dyn, int ninst, uint16_t mask_x, 
     }
 }
 
-static void propagateXYMMUneeded(dynarec_arm_t* dyn, int ninst, uint16_t mask_x, uint16_t mask_y)
+static void propagateXYMMUneeded(dynarec_arm_t* dyn, int ninst, uint16_t mask_x, uint16_t mask_y, uint16_t mask_xh, uint16_t mask_xs)
 {
     while(ninst>=0) {
         // removed needed regs
         mask_x &= ~dyn->insts[ninst].n.xmm_needed;
         mask_y &= ~dyn->insts[ninst].n.ymm_needed;
+        mask_xh &= ~dyn->insts[ninst].n.xmmh_needed;
+        mask_xs &= ~dyn->insts[ninst].n.xmms_needed;
         // removed already unneeded from mask
         mask_x &= ~dyn->insts[ninst].n.xmm_unneeded;
         mask_y &= ~dyn->insts[ninst].n.ymm_unneeded;
+        mask_xh &= ~dyn->insts[ninst].n.xmmh_unneeded;
+        mask_xs &= ~dyn->insts[ninst].n.xmms_unneeded;
         // already handled
-        if(!mask_x && !mask_y) return;
+        if(!mask_x && !mask_y && !mask_xh && !mask_xs) return;
         // barrier or callret, value is needed
         if(dyn->insts[ninst].x64.barrier&BARRIER_FLOAT) return;
         if(dyn->insts[ninst].x64.has_callret) return;
         // added the unneeded value
         dyn->insts[ninst].n.xmm_unneeded |= mask_x;
         dyn->insts[ninst].n.ymm_unneeded |= mask_y;
+        dyn->insts[ninst].n.xmmh_unneeded |= mask_xh;
+        dyn->insts[ninst].n.xmms_unneeded |= mask_xs;
         for(int i=1; i<dyn->insts[ninst].pred_sz; ++i)
-            propagateXYMMUneeded(dyn, dyn->insts[ninst].pred[i], mask_x, mask_y);
+            propagateXYMMUneeded(dyn, dyn->insts[ninst].pred[i], mask_x, mask_y, mask_xh, mask_xs);
         if(dyn->insts[ninst].pred_sz)
             ninst = dyn->insts[ninst].pred[0];
         else
@@ -1297,24 +1317,46 @@ void updateUneeded(dynarec_arm_t* dyn)
 
     if(!dyn->use_xmm && !dyn->use_ymm)
         return;
+    // Upper-64 liveness of the low 16 XMM, seeded here and propagated by the same
+    // needed/unneeded passes below used for whole-xmm and the ymm upper-128 lanes.
+    // A scalar SD op touches only the low 64, so it sits in xmm_scalar and is masked
+    // out of xmmh_used; every full-width reader keeps its bit and pins the upper lane
+    // live. An op may zero the upper in place (skipping the x86 upper-preserve) only
+    // where xmmh_unneeded proves the lane dead.
+    // xmms is the same, one dword lower: the upper-96 [127:32] used by scalar-single ops.
+    // A scalar SD op still reads [63:32], so only scalar-single ops (xmm_scalar_single) are
+    // masked out of xmms_used. An SS op may zero the upper-96 in place only where xmms_unneeded
+    // proves it dead.
+    for(int ninst=0; ninst<dyn->size; ++ninst) {
+        dyn->insts[ninst].n.xmmh_used = dyn->insts[ninst].n.xmm_used & ~dyn->insts[ninst].n.xmm_scalar;
+        dyn->insts[ninst].n.xmmh_unneeded = dyn->insts[ninst].n.xmm_unneeded;
+        dyn->insts[ninst].n.xmms_used = dyn->insts[ninst].n.xmm_used & ~dyn->insts[ninst].n.xmm_scalar_single;
+        dyn->insts[ninst].n.xmms_unneeded = dyn->insts[ninst].n.xmm_unneeded;
+    }
     // first propagate the needed regs: those which are used and are not unneeded
     for(int ninst=dyn->size-1; ninst>=0; --ninst) {
         uint16_t xmm_needed = dyn->insts[ninst].n.xmm_used&~dyn->insts[ninst].n.xmm_unneeded;
         uint16_t ymm_needed = dyn->insts[ninst].n.ymm_used&~dyn->insts[ninst].n.ymm_unneeded;
+        uint16_t xmmh_needed = dyn->insts[ninst].n.xmmh_used&~dyn->insts[ninst].n.xmmh_unneeded;
+        uint16_t xmms_needed = dyn->insts[ninst].n.xmms_used&~dyn->insts[ninst].n.xmms_unneeded;
+        // an unresolved exit (float barrier or jump out of the block) can reach code
+        // that reads the full registers, so pin every lane live there, upper-64/96 included
         if((dyn->insts[ninst].x64.barrier&BARRIER_FLOAT) || (dyn->insts[ninst].x64.jmp && (dyn->insts[ninst].x64.jmp_insts==-1)))
         {
             if(dyn->use_xmm) xmm_needed = 0xffff;
             if(dyn->use_ymm) ymm_needed = 0xffff;
+            if(dyn->use_xmm) xmmh_needed = 0xffff;
+            if(dyn->use_xmm) xmms_needed = 0xffff;
         }
-        if(xmm_needed || ymm_needed)
-            propagateXYMMNeeded(dyn, ninst, xmm_needed, ymm_needed);
+        if(xmm_needed || ymm_needed || xmmh_needed || xmms_needed)
+            propagateXYMMNeeded(dyn, ninst, xmm_needed, ymm_needed, xmmh_needed, xmms_needed);
 
     }
     // then proagate the unneeded one: those which are not needed (not used anymore and will be overwritten)
     for(int ninst=dyn->size-1; ninst>=0; --ninst) {
-        if(dyn->insts[ninst].n.xmm_unneeded || dyn->insts[ninst].n.ymm_unneeded) {
+        if(dyn->insts[ninst].n.xmm_unneeded || dyn->insts[ninst].n.ymm_unneeded || dyn->insts[ninst].n.xmmh_unneeded || dyn->insts[ninst].n.xmms_unneeded) {
             for(int i=0; i<dyn->insts[ninst].pred_sz; ++i)
-                propagateXYMMUneeded(dyn, dyn->insts[ninst].pred[i], dyn->insts[ninst].n.xmm_unneeded, dyn->insts[ninst].n.ymm_unneeded);
+                propagateXYMMUneeded(dyn, dyn->insts[ninst].pred[i], dyn->insts[ninst].n.xmm_unneeded, dyn->insts[ninst].n.ymm_unneeded, dyn->insts[ninst].n.xmmh_unneeded, dyn->insts[ninst].n.xmms_unneeded);
         }
     }
     // try to add some preload of XYMM on jump were it would make sense

--- a/src/dynarec/arm64/dynarec_arm64_helper.h
+++ b/src/dynarec/arm64/dynarec_arm64_helper.h
@@ -334,6 +334,14 @@
 #define GETG        gd = ((nextop&0x38)>>3)+(rex.r<<3)
 
 // Get GX as a quad (might use x1)
+// mark an XMM reg as accessed scalar-only (upper-64 untouched) in this opcode
+#define MARK_XMM_SCALAR(a)  dyn->n.xmm_scalar |= (1 << (a))
+// test if the upper-64 of an XMM reg is proven dead in this opcode
+#define XMMH_UNNEEDED(a)    (dyn->insts[ninst].n.xmmh_unneeded & (1 << (a)))
+// mark an XMM reg as accessed scalar-single (only low-32 touched, upper-96 untouched)
+#define MARK_XMM_SCALAR_SINGLE(a)  ((dyn->n.xmm_scalar |= (1 << (a))), (dyn->n.xmm_scalar_single |= (1 << (a))))
+// test if the upper-96 of an XMM reg is proven dead in this opcode
+#define XMMS_UNNEEDED(a)    (dyn->insts[ninst].n.xmms_unneeded & (1 << (a)))
 #define GETGX(a, w)                     \
     gd = ((nextop&0x38)>>3)+(rex.r<<3); \
     a = sse_get_reg(dyn, ninst, x1, gd, w)

--- a/src/dynarec/arm64/dynarec_arm64_private.h
+++ b/src/dynarec/arm64/dynarec_arm64_private.h
@@ -86,6 +86,14 @@ typedef struct neoncache_s {
     uint16_t            ymm_needed;     // 1bit for ymmXX were value is needed 
     uint16_t            xmm_unneeded;   // 1bit for xmmXX were value is not needed
     uint16_t            ymm_unneeded;   // 1bit for ymmXX were value is not needed 
+    uint16_t            xmmh_used;      // [127:64] of low-128 used (scalar-vs-packed liveness)
+    uint16_t            xmmh_needed;    // 1bit if XMM upper-64 needed
+    uint16_t            xmmh_unneeded;  // 1bit if XMM upper-64 not needed
+    uint16_t            xmms_used;      // [127:32] of low-128 used (scalar-single-vs-wider liveness)
+    uint16_t            xmms_needed;    // 1bit if XMM upper-96 needed
+    uint16_t            xmms_unneeded;  // 1bit if XMM upper-96 not needed
+    uint16_t            xmm_scalar;     // regs accessed scalar-only (upper-64 untouched) this op
+    uint16_t            xmm_scalar_single; // regs accessed scalar-single-only (upper-96 untouched) this op
     uint64_t            ymm_regs;       // 4bits (0-15) position of 16 ymmXX regs removed
 } neoncache_t;
 


### PR DESCRIPTION
This tracks liveness for the dead upper lanes of the low XMM registers separately from whole-register XMM liveness: an upper-64 lane for the scalar-double ops and an upper-96 lane for the scalar-single ops. Scalar operations mark their operands as not genuinely reading those upper bits, while barriers and unknown exits keep the conservative all-needed behavior.

Use that liveness in the ARM64 F2 0F scalar-double lowering to compute SQRTSD, ADDSD, MULSD, SUBSD, and DIVSD directly in the destination when the destination upper-64 is proven dead, and in the F3 0F scalar-single lowering for SQRTSS, ADDSS, MULSS, SUBSS, and DIVSS when the destination upper-96 is proven dead. The existing preserve path remains the fallback for live or unknown upper lanes and for FASTNAN-disabled paths. MOVSS store and the other scalar-single ops mark their low-32 operands so a stored scalar result does not pin the upper lane live (mirroring MOVSD store, which was the difference that let the scalar-double path fire while the scalar-single one did not).

Benchmark: static x86 benchfloat (LINPACK) on an Ampere eMag, n=9 core-pinned runs, BOX64_DYNACACHE=0 to defeat the on-disk dynarec cache, parent e3161999c built as the "before". Median KFLOPS:
```
double -O2 (scalar-double path)
  SAFEFLAGS=1 : 637,631.540 -> 700,135.472   +9.8%   (MAD 226.468)
  SAFEFLAGS=0 : 765,920.767 -> 853,745.312   +11.5%  (MAD 936.058)
single -O2 (scalar-single path)
  SAFEFLAGS=1 : 513,127.344 -> 611,984.438   +19.3%  (MAD 264.312)
  SAFEFLAGS=0 : 566,161.312 -> 696,077.312   +23.0%  (MAD  65.313)
```

Host: [Ampere eMag 8180](https://connect-admin.amperecomputing.com/api/secure-file-download/download-regular?file=new-private-files/94/tech/eMAG8180_PB_v0.55_20200211.pdf&type=technical-document&doc_id=415); 1 socket x 32 cores x 1 thread; up to 3.0 GHz; Arm64 Linux v6.8.0.
