### PR TITLE
[CORE] Eliminate compile warnings

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -355,10 +355,10 @@ void KillAllInstances()
     struct dirent* entry;
     ssize_t len;
     char proc_path[PATH_MAX];
-    char exe_path[PATH_MAX];
+    char exe_path[PATH_MAX+8];
     char exe_target[PATH_MAX];
     char self_name[PATH_MAX];
-    char self_name_with_deleted[PATH_MAX];
+    char self_name_with_deleted[PATH_MAX+16];
 
     DIR* proc_dir = opendir("/proc");
     if (proc_dir == NULL) {

--- a/src/dynarec/dynarec_native_functions.c
+++ b/src/dynarec/dynarec_native_functions.c
@@ -945,7 +945,7 @@ void x64disas_add_register_mapping_annotations(char* buf, const char* disas, con
     tmp[0] = '\0';
     int len = 0;
     // skip the mnemonic
-    char* p = strchr(disas, ' ');
+    const char* p = strchr(disas, ' ');
     if (!p) {
         sprintf(buf, "%s", disas);
         return;

--- a/src/dynarec/rv64/dynarec_rv64_functions.c
+++ b/src/dynarec/rv64/dynarec_rv64_functions.c
@@ -752,9 +752,9 @@ void inst_name_pass3(dynarec_native_t* dyn, int ninst, const char* name, rex_t r
             (void*)(dyn->native_start + dyn->insts[ninst].address), dyn->insts[ninst].size / 4, ninst, buf, (dyn->need_dump > 1) ? "\e[m" : "");
     }
     if (BOX64ENV(dynarec_gdbjit)) {
-        static char buf2[512];
+        static char buf2[4096+64];
         if (BOX64ENV(dynarec_gdbjit) > 1) {
-            sprintf(buf2, "; %d: %d opcodes, %s", ninst, dyn->insts[ninst].size / 4, buf);
+            snprintf(buf2, sizeof(buf2), "; %d: %d opcodes, %s", ninst, dyn->insts[ninst].size / 4, buf);
             dyn->gdbjit_block = GdbJITBlockAddLine(dyn->gdbjit_block, (dyn->native_start + dyn->insts[ninst].address), buf2);
         }
         zydis_dec_t* dec = rex.is32bits ? my_context->dec32 : my_context->dec;

--- a/src/emu/x87emu_private.c
+++ b/src/emu/x87emu_private.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <math.h>
 #include <fenv.h>
+#include <inttypes.h>
 
 #include "debug.h"
 #include "x64emu_private.h"
@@ -259,7 +260,7 @@ const char* PrintLD(void* ld, const char* prefix)
     #pragma pack(pop)
     memcpy(&val, ld, 10);
     static char buf[64];
-    snprintf(buf, sizeof(buf), "%s%04x %016llx", prefix?prefix:"", val.b, val.f.q);
+    snprintf(buf, sizeof(buf), "%s%04x %016" PRIx64 "", prefix?prefix:"", val.b, val.f.q);
     return buf;
 }
 

--- a/src/librarian/library.c
+++ b/src/librarian/library.c
@@ -83,7 +83,7 @@ KHASH_MAP_IMPL_STR(datamap, uint64_t)
 char* Path2Name(const char* path)
 {
     char* name = (char*)box_calloc(1, MAX_PATH);
-    char* p = strrchr(path, '/');
+    char* p = (char *)strrchr(path, '/');
     strcpy(name, (p)?(p+1):path);
     // name should be libXXX.so.A(.BB.CCCC)
     // so keep only 2 dot after ".so" (if any)
@@ -98,7 +98,7 @@ char* Path2Name(const char* path)
 }
 int NbDot(const char* name)
 {
-    char *p = strstr(name, ".so");
+    const char *p = strstr(name, ".so");
     if(!p)
         return -1;
     int ret = 0;

--- a/src/libtools/vulkanoverlay.c
+++ b/src/libtools/vulkanoverlay.c
@@ -923,7 +923,7 @@ void* LoadVulkanOverlay(const char* path, int flags)
         globfree(&pglob);
         int whitelist = 0;
         if(!json) {
-            char* p = strrchr(path, '/');
+            const char* p = strrchr(path, '/');
             if(!p) p = (char*)path; else ++p;
             if(!strcmp(p, "libvk_swiftshader.so"))
                 whitelist = 1;

--- a/src/os/os_linux.c
+++ b/src/os/os_linux.c
@@ -225,14 +225,16 @@ void PrintfFtrace(int prefix, const char* fmt, ...)
         } else {
             sprintf(tmp, "[%s] ", names[box64_is32bits]);
         }
-        write(trace_fd, tmp, strlen(tmp));
+        int w = write(trace_fd, tmp, strlen(tmp));
+        (void)w;
     }
     va_list args;
     va_start(args, fmt);
     vsprintf(tmp, fmt, args);
     fflush(ftrace);
     va_end(args);
-    write(trace_fd, tmp, strlen(tmp));
+    int w = write(trace_fd, tmp, strlen(tmp));
+    (void)w;
 }
 
 void* GetEnv(const char* name)

--- a/src/os/sysinfo.c
+++ b/src/os/sysinfo.c
@@ -187,12 +187,12 @@ void InitializeSystemInfo(void)
 
     char branding[3 * 4 * 4 + 1] = {0};
     if (strstr(box64_sysinfo.cpuname, "MHz") || strstr(box64_sysinfo.cpuname, "GHz")) {
-        snprintf(branding, sizeof(branding)-1, BOX64_BUILD_INFO_STRING_SHORT " on %.*s", 32, box64_sysinfo.cpuname);
+        snprintf(branding, sizeof(branding)-1, BOX64_BUILD_INFO_STRING_SHORT " on %.*s", 31, box64_sysinfo.cpuname);
     } else {
         if (box64_sysinfo.frequency > 1500000) {
-            snprintf(branding, sizeof(branding)-1, BOX64_BUILD_INFO_STRING_SHORT " on %.*s @%1.2f GHz", 28, box64_sysinfo.cpuname, box64_sysinfo.frequency / 1000000000.);
+            snprintf(branding, sizeof(branding)-1, BOX64_BUILD_INFO_STRING_SHORT " on %.*s @%1.2f GHz", 21, box64_sysinfo.cpuname, box64_sysinfo.frequency / 1000000000.);
         } else {
-            snprintf(branding, sizeof(branding)-1, BOX64_BUILD_INFO_STRING_SHORT " on %.*s @%04" PRIu64 " MHz", 28, box64_sysinfo.cpuname, box64_sysinfo.frequency / 1000000);
+            snprintf(branding, sizeof(branding)-1, BOX64_BUILD_INFO_STRING_SHORT " on %.*s @%04" PRIu64 " MHz", 21, box64_sysinfo.cpuname, box64_sysinfo.frequency / 1000000);
         }
     }
     box64_sysinfo.box64_cpuname = (char*)calloc(strlen(branding) + 1, 1);

--- a/src/steam.c
+++ b/src/steam.c
@@ -32,7 +32,8 @@ static void create_lib_symlink(const char* lib)
     if(FileExist(tmp, IS_FILE)) return; // already there
     strcpy(file, strrchr(lib, '/')+1);
     printf_log(LOG_DEBUG, "Creating symlinks %s -> %s\n", tmp, file);
-    symlink(file, tmp);
+    int ret = symlink(file, tmp);
+    (void)ret;
 }
 
 static void create_libs_symlink(const char* folder)

--- a/src/tools/dynacache.c
+++ b/src/tools/dynacache.c
@@ -875,9 +875,9 @@ int ReadDynaCache(const char* folder, const char* name, mapping_t* mapping, int 
             n += snprintf(buf+n, sizeof(buf)-n, " and %s non-canceled blocks\n", NicePrintSize(total_code));
             n += snprintf(buf+n, sizeof(buf)-n, "\tMapped at %p-%p, with %zu lock and %zu unaligned addresses",
                 (void*)file_header->map_addr, (void*)file_header->map_addr+file_header->map_len,
-                file_header->nLockAddresses, file_header->nUnalignedAddresses);
+                (size_t)file_header->nLockAddresses, (size_t)file_header->nUnalignedAddresses);
             if(total_compressed && n>0 && n<(int)sizeof(buf)) {
-                n += snprintf(buf+n, sizeof(buf)-n, "\n\tCompression: %d%% / %s compressed", 100ULL-total_compressed*100ULL/total_blocks ,NicePrintSize(total_compressed));
+                n += snprintf(buf+n, sizeof(buf)-n, "\n\tCompression: %llu%% / %s compressed", 100ULL-total_compressed*100ULL/total_blocks ,NicePrintSize(total_compressed));
                 if(total_uncompressed && n>0 && n<(int)sizeof(buf))
                     n += snprintf(buf+n, sizeof(buf)-n, ", %s uncompressed", NicePrintSize(total_uncompressed));
             }

--- a/src/wrapped/wrappeddbus.c
+++ b/src/wrapped/wrappeddbus.c
@@ -682,7 +682,9 @@ EXPORT void* my_dbus_message_new_error_printf(x64emu_t* emu, void* to, void* nam
     myStackAlign(emu, (const char*)fmt, b, emu->scratch, R_EAX, 1);
     PREPARE_VALIST;
     char* buff = NULL;
-    vasprintf(&buff, (char*)fmt, VARARGS);
+    int va = vasprintf(&buff, (char*)fmt, VARARGS);
+    if ((va < 0) || !buff)
+        return NULL;
     void* ret = my->dbus_message_new_error(to, name, buff);
     free(buff);
     return ret;

--- a/src/wrapped/wrappedgmp.c
+++ b/src/wrapped/wrappedgmp.c
@@ -155,14 +155,14 @@ EXPORT int my___gmp_asprintf(x64emu_t* emu, char** strp, const char* fmt, void* 
 {
     myStackAlign(emu, fmt, b, emu->scratch, R_EAX, 2);
     PREPARE_VALIST;
-    return my->__gmp_vasprintf(strp, fmt, VARARGS);
+    return my->__gmp_vasprintf(strp, (void *)fmt, VARARGS);
 }
 
 EXPORT int my___gmp_fprintf(x64emu_t* emu, void* stream, const char* fmt, void* b)
 {
     myStackAlign(emu, fmt, b, emu->scratch, R_EAX, 2);
     PREPARE_VALIST;
-    return my->__gmp_vfprintf(stream, fmt, VARARGS);
+    return my->__gmp_vfprintf(stream, (void *)fmt, VARARGS);
 }
 
 EXPORT int my___gmp_vasprintf(x64emu_t* emu, char** strp, const char* fmt, x64_va_list_t b)
@@ -173,7 +173,7 @@ EXPORT int my___gmp_vasprintf(x64emu_t* emu, char** strp, const char* fmt, x64_v
     myStackAlignValist(emu, fmt, emu->scratch, b);
     PREPARE_VALIST;
 #endif
-    return my->__gmp_vasprintf(strp, fmt, VARARGS);
+    return my->__gmp_vasprintf(strp, (void *)fmt, VARARGS);
 }
 
 EXPORT int my___gmp_vfprintf(x64emu_t* emu, void* stream, const char* fmt, x64_va_list_t b)
@@ -184,7 +184,7 @@ EXPORT int my___gmp_vfprintf(x64emu_t* emu, void* stream, const char* fmt, x64_v
     myStackAlignValist(emu, fmt, emu->scratch, b);
     PREPARE_VALIST;
 #endif
-    return my->__gmp_vfprintf(stream, fmt, VARARGS);
+    return my->__gmp_vfprintf(stream, (void *)fmt, VARARGS);
 }
 
 #include "wrappedlib_init.h"

--- a/src/wrapped/wrappedlibavutil56.c
+++ b/src/wrapped/wrappedlibavutil56.c
@@ -210,7 +210,9 @@ EXPORT void* my_av_asprintf(x64emu_t* emu, void * fmt, uint64_t * b) {
     myStackAlign(emu, (const char*)fmt, b, emu->scratch, R_EAX, 1);
     PREPARE_VALIST;
     char* buff = NULL;
-    vasprintf(&buff, (char*)fmt, VARARGS);
+    int va = vasprintf(&buff, (char*)fmt, VARARGS);
+    if ((va < 0) || !buff)
+        return NULL;
     void* ret = my->av_asprintf("%s", buff);
     free(buff);
     return ret;
@@ -257,7 +259,9 @@ EXPORT void my_av_log(x64emu_t* emu, void* avcl, int lvl, void* fmt, uint64_t* b
     myStackAlign(emu, (const char*)fmt, b, emu->scratch, R_EAX, 3);
     PREPARE_VALIST;
     char* buff = NULL;
-    vasprintf(&buff, (char*)fmt, VARARGS);
+    int va = vasprintf(&buff, (char*)fmt, VARARGS);
+    if((va < 0) || !buff)
+        return;
     my->av_log(avcl, lvl, "%s", buff);
     free(buff);
 }
@@ -282,7 +286,9 @@ EXPORT size_t my_av_strlcatf(x64emu_t* emu, void* dst, size_t size, void* fmt, u
     myStackAlign(emu, (const char*)fmt, b, emu->scratch, R_EAX, 3);
     PREPARE_VALIST;
     char* buff = NULL;
-    vasprintf(&buff, (char*)fmt, VARARGS);
+    int va = vasprintf(&buff, (char*)fmt, VARARGS);
+    if ((va < 0) || !buff)
+        return 0;
     size_t ret = my->av_strlcatf(dst, size, "%s", buff);
     free(buff);
     return ret;

--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -2625,8 +2625,8 @@ EXPORT int32_t my_epoll_wait(x64emu_t* emu, int32_t epfd, void* events, int32_t 
 {
     struct epoll_event _events[maxevents];
     //AlignEpollEvent(_events, events, maxevents);
-    int32_t ret = epoll_wait(epfd, events?_events:NULL, maxevents, timeout);
-    if(ret>0)
+    int32_t ret = epoll_wait(epfd, _events, maxevents, timeout);
+    if((ret > 0) && events)
         UnalignEpollEvent(events, _events, ret);
     return ret;
 }
@@ -2634,8 +2634,8 @@ EXPORT int32_t my_epoll_pwait(x64emu_t* emu, int32_t epfd, void* events, int32_t
 {
     struct epoll_event _events[maxevents];
     //AlignEpollEvent(_events, events, maxevents);
-    int32_t ret = epoll_pwait(epfd, events?_events:NULL, maxevents, timeout, sigmask);
-    if(ret>0)
+    int32_t ret = epoll_pwait(epfd, _events, maxevents, timeout, sigmask);
+    if((ret > 0) && events)
         UnalignEpollEvent(events, _events, ret);
     return ret;
 }
@@ -2652,10 +2652,10 @@ EXPORT int32_t my_epoll_pwait2(x64emu_t* emu, int epfd, void* events, int maxeve
             if(tmp>1<<31) tmp = 1<<31;
             tout = tmp;
         }
-        ret = epoll_pwait(epfd, events?_events:NULL, maxevents, tout, sigmask);
+        ret = epoll_pwait(epfd, _events, maxevents, tout, sigmask);
     } else
-        ret = my->epoll_pwait2(epfd, events?_events:NULL, maxevents, timeout, sigmask);
-    if(ret>0)
+        ret = my->epoll_pwait2(epfd, _events, maxevents, timeout, sigmask);
+    if((ret > 0) && events)
         UnalignEpollEvent(events, _events, ret);
     return ret;
 }


### PR DESCRIPTION
As per ptitSeb's requirements, patches addressing compiler warnings may only be merged after the 0.4.4 release. This PR is solely for pre‑review at this stage.

1. `vasprintf` can return a negative value and `buff` may be NULL.

2. The `events` argument in `epoll_pwait` must not be NULL.

3. The size of `val.f.q` is 64 bits.