### PR TITLE
[SYSCALL] Fixed a bad bad bug

### DIFF
--- a/src/emu/x64syscall.c
+++ b/src/emu/x64syscall.c
@@ -50,7 +50,6 @@ typedef struct x64_stack_s x64_stack_t;
 extern int mkdir(const char *path, mode_t mode);
 extern int mknod(const char *path, mode_t mode, dev_t dev);
 extern int chmod(const char *path, mode_t mode);
-extern int fchmodat (int __fd, const char *__file, mode_t __mode, int __flag);
 
 //int32_t my_getrandom(x64emu_t* emu, void* buf, uint32_t buflen, uint32_t flags);
 int of_convert(int flag);
@@ -364,8 +363,8 @@ static const scwrap_t syscallwrap[] = {
     #ifdef __NR_io_uring_register
     [427] = {__NR_io_uring_register, 4},
     #endif
-    #ifdef __NR_fchmodat4
-    [434] = {__NR_fchmodat4, 4},
+    #ifdef __NR_pidfd_open
+    [434] = {__NR_pidfd_open, 2},
     #endif
     #ifdef __NR_close_range
     [436] = {__NR_close_range, 3},
@@ -1011,13 +1010,6 @@ void EXPORT x64Syscall_linux(x64emu_t *emu)
         case 334: // It is helpeful to run static binary
             R_RAX = -ENOSYS;
             break;
-        #ifndef __NR_fchmodat4
-        case 434:
-            S_RAX = fchmodat(S_EDI, (void*)R_RSI, (mode_t)R_RDX, S_R10d);
-            if(S_RAX==-1)
-                S_RAX = -errno;
-            break;
-        #endif
         #ifndef __NR_faccessat2
         case 439:
             S_RAX = faccessat(S_EDI, (void*)R_RSI, (mode_t)R_RDX, S_R10d);
@@ -1380,10 +1372,6 @@ long EXPORT my_syscall(x64emu_t *emu)
         #endif
         case 317:   // sys_seccomp
             return 0;  // ignoring call
-        #ifndef __NR_fchmodat4
-        case 434:
-            return fchmodat(S_ESI, (void*)R_RDX, (mode_t)R_RCX, S_R8d);
-        #endif
         #ifndef __NR_faccessat2
         case 439:
             return faccessat(S_ESI, (void*)R_RDX, (mode_t)R_RCX, S_R8d);


### PR DESCRIPTION
It seems that back in 2019, when `fchmodat4` syscall was introduced, it did get the number 434: https://lists.openwall.net/linux-kernel/2019/07/17/25, but that patch was rejected and 434 was assigned to `pidfd_open` later.