### PR TITLE
[SIGNAL] Preserve TF handling when resuming signals with Dynarec

### DIFF
--- a/src/libtools/signal32.c
+++ b/src/libtools/signal32.c
@@ -745,7 +745,9 @@ int my_sigactionhandler_oldcode_32(x64emu_t* emu, int32_t sig, int simple, sigin
             #undef GO
             // flags
             emu->eflags.x64=sigcontext->uc_mcontext.gregs[I386_EFL];
-            if((skip==1) && (emu->ip.q[0]!=sigcontext->uc_mcontext.gregs[I386_EIP]) && !ACCESS_FLAG(F_TF))
+            if(ACCESS_FLAG(F_TF))
+                skip = 1;   // no_tf may not be consumed in dynarec, force to use interpreter
+            else if((skip==1) && (emu->ip.q[0]!=sigcontext->uc_mcontext.gregs[I386_EIP]))
                 skip = 3;   // if it jumps elsewhere, it can resume with dynarec...
             emu->ip.q[0]=sigcontext->uc_mcontext.gregs[I386_EIP];
             if (ACCESS_FLAG(F_TF) && skip == 1) emu->flags.no_tf = 1;

--- a/src/libtools/signals.c
+++ b/src/libtools/signals.c
@@ -581,7 +581,9 @@ int my_sigactionhandler_oldcode_64(x64emu_t* emu, int32_t sig, int simple, sigin
             #ifndef DYNAREC
             mctx2emu(emu, &sigcontext->uc_mcontext);
             #endif
-            if((skip==1) && (emu->ip.q[0]!=sigcontext->uc_mcontext.gregs[X64_RIP]) && !ACCESS_FLAG(F_TF))
+            if(ACCESS_FLAG(F_TF))
+                skip = 1;   // no_tf may not be consumed in dynarec, force to use interpreter
+            else if((skip==1) && (emu->ip.q[0]!=sigcontext->uc_mcontext.gregs[X64_RIP]))
                 skip = 3;   // if it jumps elsewhere, it can resume with dynarec...
             if (ACCESS_FLAG(F_TF) && skip == 1) emu->flags.no_tf = 1;
             printf_log((sig==10)?LOG_DEBUG:log_minimum, "Context has been changed in Sigactionhanlder, doing siglongjmp to resume emu at %p, RSP=%p (resume with %s)\n", (void*)R_RIP, (void*)R_RSP, (skip==3)?"Dynarec":"Interp");


### PR DESCRIPTION
When a signal handler restores a context with TF set, resume through the interpreter for one instruction so no_tf can suppress the initial spurious SIGTRAP.

This fixes the issue exposed after commit 38d64ba when running Syringe.exe from the Ares expansion platform.