### PR TITLE
[WRAPPER] Fix strlcat and strcpy corn cases

### DIFF
--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -4824,15 +4824,19 @@ EXPORT void my___cxa_pure_virtual(x64emu_t* emu)
 
 EXPORT size_t my_strlcpy(x64emu_t* emu, void* dst, void* src, size_t l)
 {
-    strncpy(dst, src, l-1);
-    ((char*)dst)[l-1] = '\0';
+    if (l > 0) {
+        strncpy(dst, src, l-1);
+        ((char*)dst)[l-1] = '\0';
+    }
     return strlen(src);
 }
 EXPORT size_t my_strlcat(x64emu_t* emu, void* dst, void* src, size_t l)
 {
+    if (l == 0)
+        return strlen(src);
     size_t s = strlen(dst);
     if(s>=l)
-        return l;
+        return s + strlen(src);
     strncat(dst, src, l-s-1);
     ((char*)dst)[l-1] = '\0';
     return s+strlen(src);


### PR DESCRIPTION
There are several boundary conditions for strlcat and strlcpy that need to be added.

Test:  gcc test.c -o test -lbsd
```
#include <stdio.h>
#include <assert.h>
#include <string.h>
#include <stdlib.h>

#define _BSD_SOURCE
#include <string.h>

static void test_strlcpy(void)
{
    char buf[64];
    char backup[64];
    size_t ret;

    memset(buf, 0xCC, sizeof(buf));
    ret = strlcpy(buf, "hello", sizeof(buf));
    assert(ret == 5);
    assert(strcmp(buf, "hello") == 0);
    printf("[strlcpy] Case1 完整拷贝 OK\n");

    memset(buf, 0xCC, sizeof(buf));
    ret = strlcpy(buf, "123456789", 6);
    assert(ret == 9);
    assert(strcmp(buf, "12345") == 0);
    printf("[strlcpy] Case2 截断拷贝 OK\n");

    memset(buf, '#', sizeof(buf));
    strcpy(buf, "old_buffer_data");
    memcpy(backup, buf, sizeof(buf));

    ret = strlcpy(buf, "test_input", 0);
    assert(ret == strlen("test_input"));
    assert(memcmp(buf, backup, sizeof(buf)) == 0);
    printf("[strlcpy] Case3 size=0 不修改dst OK\n");

    memset(buf, 0xCC, sizeof(buf));
    ret = strlcpy(buf, "abcxyz", 1);
    assert(ret == 6);
    assert(buf[0] == '\0');
    printf("[strlcpy] Case4 size=1 边界 OK\n");

    memset(buf, 0xCC, sizeof(buf));
    strcpy(buf, "garbage");
    ret = strlcpy(buf, "", sizeof(buf));
    assert(ret == 0);
    assert(buf[0] == '\0');
    printf("[strlcpy] Case5 空源字符串 OK\n");

    const char *s = "null_test_string";
    size_t need = strlcpy(NULL, s, 0);
    assert(need == strlen(s));
    printf("[strlcpy] Case6 NULL dst 长度探测 OK\n");
}

static void test_strlcat(void)
{
    char buf[64];
    char backup[64];
    size_t ret;

    memset(buf, 0xDD, sizeof(buf));
    strcpy(buf, "hello");
    ret = strlcat(buf, "world", sizeof(buf));
    assert(ret == 10);
    assert(strcmp(buf, "helloworld") == 0);
    printf("[strlcat] Case1 完整拼接 OK\n");

    memset(buf, 0xDD, sizeof(buf));
    strcpy(buf, "hello");
    ret = strlcat(buf, "123456789", 8);
    assert(ret == 14);
    assert(strcmp(buf, "hello12") == 0);
    printf("[strlcat] Case2 截断拼接 OK\n");

    memset(buf, 0xDD, sizeof(buf));
    strcpy(buf, "hello");
    ret = strlcat(buf, "test", 6);
    assert(ret == 9);
    assert(strcmp(buf, "hello") == 0);
    printf("[strlcat] Case3 无剩余空间 OK\n");

    memset(buf, 'x', sizeof(buf));
    strcpy(buf, "abc_origin_data");
    memcpy(backup, buf, sizeof(buf));

    ret = strlcat(buf, "123456", 0);
    assert(ret == 6);
    assert(memcmp(buf, backup, sizeof(buf)) == 0);
    printf("[strlcat] Case4 size=0 不修改dst OK\n");

    memset(buf, 0xDD, sizeof(buf));
    buf[0] = '\0';
    ret = strlcat(buf, "empty_dst_test", sizeof(buf));
    assert(ret == strlen("empty_dst_test"));
    assert(strcmp(buf, "empty_dst_test") == 0);
    printf("[strlcat] Case5 空dst等价拷贝 OK\n");

    memset(buf, 0xDD, sizeof(buf));
    strcpy(buf, "A");
    ret = strlcat(buf, "xyz", 1);
    assert(ret == 4);
    assert(strcmp(buf, "A") == 0);
    printf("[strlcat] Case6 size=1 边界 OK\n");

    memset(buf, 0xDD, sizeof(buf));
    strcpy(buf, "demo_str");
    ret = strlcat(buf, "", sizeof(buf));
    assert(ret == 8);
    assert(strcmp(buf, "demo_str") == 0);
    printf("[strlcat] Case7 空src OK\n");
}

int main(void)
{
    test_strlcpy();
    test_strlcat();

    return 0;
}
```
