### PR TITLE
[WRAPPER] Fix missing parameter

### DIFF
--- a/src/wrapped/wrappedgtk3.c
+++ b/src/wrapped/wrappedgtk3.c
@@ -571,7 +571,7 @@ static void* findTranslateEvent(void* fct)
     static uintptr_t my_GCallback_fct_##A = 0;    \
     static void my_GCallback_##A(void* data)      \
     {                                             \
-        RunFunctionFmt(my_GCallback_fct_##A, "p"); \
+        RunFunctionFmt(my_GCallback_fct_##A, "p", data); \
     }
 SUPER()
 #undef GO

--- a/src/wrapped/wrappedlibx11.c
+++ b/src/wrapped/wrappedlibx11.c
@@ -416,7 +416,7 @@ static void* findXInternalAsyncHandlerFct(void* fct)
 static uintptr_t my_XSynchronizeProc_fct_##A = 0;                       \
 static int my_XSynchronizeProc_##A(void* dpy)                           \
 {                                                                       \
-    return (int)RunFunctionFmt(my_XSynchronizeProc_fct_##A, "p");       \
+    return (int)RunFunctionFmt(my_XSynchronizeProc_fct_##A, "p", dpy);  \
 }
 SUPER()
 #undef GO


### PR DESCRIPTION
Regardless of whether `data `or `dpy` are utilized, they must be explicitly passed for safety since they are specified in the argument list when invoking `RunFunctionFmt.`