### PR TITLE
Fix some UAF errors report in #4214

### DIFF
--- a/src/libtools/threads.c
+++ b/src/libtools/threads.c
@@ -1287,6 +1287,7 @@ EXPORT int my_pthread_cond_destroy_old(x64emu_t* emu, pthread_cond_old_t* cond)
 	pthread_cond_t * c = get_cond(cond);
 	int ret = pthread_cond_destroy(c);
 	box_free(cond->cond);
+	cond->cond = NULL;
 	return ret;
 }
 EXPORT int my_pthread_cond_init_old(x64emu_t* emu, pthread_cond_old_t* cond, void* attr)

--- a/src/libtools/threads32.c
+++ b/src/libtools/threads32.c
@@ -576,6 +576,7 @@ EXPORT int my32_pthread_cond_destroy_old(x64emu_t* emu, pthread_cond_2_0_t* cond
     pthread_cond_t * c = get_cond_old(cond);
     int ret = pthread_cond_destroy(c);
     box_free(from_ptrv(cond->cond));
+    cond->cond = 0;
     return ret;
 }
 

--- a/src/wrapped/generated/functions_list.txt
+++ b/src/wrapped/generated/functions_list.txt
@@ -5401,6 +5401,8 @@ wrappedkrb5:
 - iFppppppipp:
   - krb5_get_init_creds_password
 wrappedlber:
+- iFppi:
+  - ber_sockbuf_remove_io
 - iFppip:
   - ber_sockbuf_add_io
 wrappedlcms2:

--- a/src/wrapped/generated/wrappedlbertypes.h
+++ b/src/wrapped/generated/wrappedlbertypes.h
@@ -11,9 +11,11 @@
 #define ADDED_FUNCTIONS() 
 #endif
 
+typedef int32_t (*iFppi_t)(void*, void*, int32_t);
 typedef int32_t (*iFppip_t)(void*, void*, int32_t, void*);
 
 #define SUPER() ADDED_FUNCTIONS() \
+	GO(ber_sockbuf_remove_io, iFppi_t) \
 	GO(ber_sockbuf_add_io, iFppip_t)
 
 #endif // __wrappedlberTYPES_H_

--- a/src/wrapped/wrappedlber.c
+++ b/src/wrapped/wrappedlber.c
@@ -178,21 +178,54 @@ static void* find_sbi_close_Fct(void* fct)
 
 #undef SUPER
 
+// sockbuf_io
+#define SUPER() \
+GO(0)           \
+GO(1)           \
+GO(2)           \
+GO(3)           \
+GO(4)
+
+#define GO(A)                                           \
+static my_sockbuf_io_t* my_sockbuf_io_ref_##A = NULL;   \
+static my_sockbuf_io_t my_sockbuf_io_struct_##A = {0};
+SUPER()
+#undef GO
+
+static void wrap_sockbuf_io(my_sockbuf_io_t* dst, my_sockbuf_io_t* src)
+{
+    #define GO(A) dst->A = find_##A##_Fct(src->A)
+    GO(sbi_setup);
+    GO(sbi_remove);
+    GO(sbi_ctrl);
+    GO(sbi_read);
+    GO(sbi_write);
+    GO(sbi_close);
+    #undef GO
+}
+
+static my_sockbuf_io_t* find_sockbuf_io_Struct(my_sockbuf_io_t* io)
+{
+    if(!io) return NULL;
+    #define GO(A) if(my_sockbuf_io_ref_##A == io) return &my_sockbuf_io_struct_##A;
+    SUPER()
+    #undef GO
+    #define GO(A) if(!my_sockbuf_io_ref_##A) {              \
+        wrap_sockbuf_io(&my_sockbuf_io_struct_##A, io);     \
+        my_sockbuf_io_ref_##A = io;                         \
+        return &my_sockbuf_io_struct_##A;                   \
+    }
+    SUPER()
+    #undef GO
+    printf_log(LOG_NONE, "Warning, no more slot for liblber sockbuf_io\n");
+    return NULL;
+}
+
+#undef SUPER
+
 EXPORT int my_ber_sockbuf_add_io(x64emu_t* emu, void* sb, my_sockbuf_io_t* io, int layer, void* arg)
 {
-    my_sockbuf_io_t my_io = {0};
-    if(io) {
-        #define GO(A) my_io.A = find_##A##_Fct(io->A)
-        GO(sbi_setup);
-        GO(sbi_remove);
-        GO(sbi_ctrl);
-        GO(sbi_read);
-        GO(sbi_write);
-        GO(sbi_close);
-        #undef GO
-    }
-    return my->ber_sockbuf_add_io(sb, io?&my_io:NULL, layer, arg);
+    return my->ber_sockbuf_add_io(sb, find_sockbuf_io_Struct(io), layer, arg);
 }
 
 #include "wrappedlib_init.h"
-

--- a/src/wrapped/wrappedlber.c
+++ b/src/wrapped/wrappedlber.c
@@ -204,7 +204,7 @@ static void wrap_sockbuf_io(my_sockbuf_io_t* dst, my_sockbuf_io_t* src)
     #undef GO
 }
 
-static my_sockbuf_io_t* find_sockbuf_io_Struct(my_sockbuf_io_t* io)
+static my_sockbuf_io_t* allocate_sockbuf_io_Struct(my_sockbuf_io_t* io)
 {
     if(!io) return NULL;
     #define GO(A) if(my_sockbuf_io_ref_##A == io) return &my_sockbuf_io_struct_##A;
@@ -221,11 +221,41 @@ static my_sockbuf_io_t* find_sockbuf_io_Struct(my_sockbuf_io_t* io)
     return NULL;
 }
 
+static my_sockbuf_io_t* find_sockbuf_io_Struct(my_sockbuf_io_t* io)
+{
+    if(!io) return NULL;
+    #define GO(A) if(my_sockbuf_io_ref_##A == io) return &my_sockbuf_io_struct_##A;
+    SUPER()
+    #undef GO
+    printf_log(LOG_NONE, "Warning, No available liblber sockbuf_io slot found.\n");
+    return NULL;
+}
+
+static void reset_sockbuf_io_Struct(my_sockbuf_io_t* io)
+{
+    if(!io) return;
+    #define GO(A) if(my_sockbuf_io_ref_##A == io) {         \
+        my_sockbuf_io_ref_##A = NULL;                       \
+        memset(&my_sockbuf_io_struct_##A, 0, sizeof(*io));  \
+        return;                                             \
+    }
+    SUPER()
+    #undef GO
+    printf_log(LOG_NONE, "Warning, No available liblber sockbuf_io slot found.\n");
+}
+
 #undef SUPER
 
 EXPORT int my_ber_sockbuf_add_io(x64emu_t* emu, void* sb, my_sockbuf_io_t* io, int layer, void* arg)
 {
-    return my->ber_sockbuf_add_io(sb, find_sockbuf_io_Struct(io), layer, arg);
+    return my->ber_sockbuf_add_io(sb, allocate_sockbuf_io_Struct(io), layer, arg);
+}
+
+EXPORT int my_ber_sockbuf_remove_io(x64emu_t* emu, void* sb, my_sockbuf_io_t* io, int layer)
+{
+    int ret = my->ber_sockbuf_remove_io(sb, find_sockbuf_io_Struct(io), layer);
+    reset_sockbuf_io_Struct(io);
+    return ret;
 }
 
 #include "wrappedlib_init.h"

--- a/src/wrapped/wrappedlber.c
+++ b/src/wrapped/wrappedlber.c
@@ -188,6 +188,7 @@ GO(4)
 
 #define GO(A)                                           \
 static my_sockbuf_io_t* my_sockbuf_io_ref_##A = NULL;   \
+static uint32_t my_sockbuf_io_ref_count_##A = 0;        \
 static my_sockbuf_io_t my_sockbuf_io_struct_##A = {0};
 SUPER()
 #undef GO
@@ -204,15 +205,20 @@ static void wrap_sockbuf_io(my_sockbuf_io_t* dst, my_sockbuf_io_t* src)
     #undef GO
 }
 
-static my_sockbuf_io_t* allocate_sockbuf_io_Struct(my_sockbuf_io_t* io)
+static my_sockbuf_io_t* find_sockbuf_io_Struct(my_sockbuf_io_t* io, int alloc)
 {
     if(!io) return NULL;
-    #define GO(A) if(my_sockbuf_io_ref_##A == io) return &my_sockbuf_io_struct_##A;
+    #define GO(A) if(my_sockbuf_io_ref_##A == io) {        \
+        if (alloc) my_sockbuf_io_ref_count_##A++;          \
+        return &my_sockbuf_io_struct_##A;                  \
+    }
     SUPER()
     #undef GO
+    if (!alloc) return io;
     #define GO(A) if(!my_sockbuf_io_ref_##A) {              \
         wrap_sockbuf_io(&my_sockbuf_io_struct_##A, io);     \
         my_sockbuf_io_ref_##A = io;                         \
+        my_sockbuf_io_ref_count_##A = 1;                    \
         return &my_sockbuf_io_struct_##A;                   \
     }
     SUPER()
@@ -221,40 +227,33 @@ static my_sockbuf_io_t* allocate_sockbuf_io_Struct(my_sockbuf_io_t* io)
     return NULL;
 }
 
-static my_sockbuf_io_t* find_sockbuf_io_Struct(my_sockbuf_io_t* io)
-{
-    if(!io) return NULL;
-    #define GO(A) if(my_sockbuf_io_ref_##A == io) return &my_sockbuf_io_struct_##A;
-    SUPER()
-    #undef GO
-    printf_log(LOG_NONE, "Warning, No available liblber sockbuf_io slot found.\n");
-    return NULL;
-}
-
-static void reset_sockbuf_io_Struct(my_sockbuf_io_t* io)
+static void deallocate_sockbuf_io_Struct(my_sockbuf_io_t* io)
 {
     if(!io) return;
     #define GO(A) if(my_sockbuf_io_ref_##A == io) {         \
-        my_sockbuf_io_ref_##A = NULL;                       \
-        memset(&my_sockbuf_io_struct_##A, 0, sizeof(*io));  \
+        my_sockbuf_io_ref_count_##A--;                      \
+        if (my_sockbuf_io_ref_count_##A == 0) {             \
+            my_sockbuf_io_ref_##A = NULL;                   \
+            memset(&my_sockbuf_io_struct_##A, 0, sizeof(*io));  \
+        }                                                   \
         return;                                             \
     }
     SUPER()
     #undef GO
-    printf_log(LOG_NONE, "Warning, No available liblber sockbuf_io slot found.\n");
+    printf_log(LOG_NONE, "Warning, the requested sockbuf_io slot does not exist\n");
 }
 
 #undef SUPER
 
 EXPORT int my_ber_sockbuf_add_io(x64emu_t* emu, void* sb, my_sockbuf_io_t* io, int layer, void* arg)
 {
-    return my->ber_sockbuf_add_io(sb, allocate_sockbuf_io_Struct(io), layer, arg);
+    return my->ber_sockbuf_add_io(sb, find_sockbuf_io_Struct(io, 1), layer, arg);
 }
 
 EXPORT int my_ber_sockbuf_remove_io(x64emu_t* emu, void* sb, my_sockbuf_io_t* io, int layer)
 {
-    int ret = my->ber_sockbuf_remove_io(sb, find_sockbuf_io_Struct(io), layer);
-    reset_sockbuf_io_Struct(io);
+    int ret = my->ber_sockbuf_remove_io(sb, find_sockbuf_io_Struct(io, 0), layer);
+    deallocate_sockbuf_io_Struct(io);
     return ret;
 }
 

--- a/src/wrapped/wrappedlber_private.h
+++ b/src/wrapped/wrappedlber_private.h
@@ -122,7 +122,7 @@ GOM(ber_sockbuf_add_io, iFEppip)
 //DATA(ber_sockbuf_io_fd, 
 //DATA(ber_sockbuf_io_readahead, 
 //DATA(ber_sockbuf_io_tcp, 
-//GO(ber_sockbuf_remove_io, 
+GOM(ber_sockbuf_remove_io, iFEppi)
 //GO(ber_sos_dump, 
 //GO(ber_start, 
 GO(ber_start_seq, iFpL)


### PR DESCRIPTION
Both `my_gpgme_data_new_from_cbs` and `my_ber_sockbuf_add_io` are supplied with stack-allocated variables. These variables go out of live scope once the function returns and must not be accessed afterwards.

Set it in:

1. https://github.com/gpg/gpgme/blob/master/src/data-user.c#L99 
2. https://github.com/delphij/openldap/blob/master/libraries/liblber/sockbuf.c#L201
