### PR TITLE
[RV64_DYNAREC] Support some VBROADCAST opcode

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_avx_66_0f38.c
+++ b/src/dynarec/rv64/dynarec_rv64_avx_66_0f38.c
@@ -620,6 +620,53 @@ uintptr_t dynarec64_AVX_66_0F38(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t i
                 }
             }
             break;
+        case 0x18:
+            INST_NAME("VBROADCASTSS Gx, Ex");
+            nextop = F8;
+            GETGX();
+            GETEX(x2, 0, 1);
+            GETGY();
+            LWU(x4, wback, fixedaddress);
+            for (int i = 0; i < 4; ++i) {
+                SW(x4, gback, gdoffset + i * 4);
+            }
+            if (vex.l) {
+                for (int i = 0; i < 4; ++i) {
+                    SW(x4, gback, gyoffset + i * 4);
+                }
+            } else {
+                YMM0(gd);
+            }
+            break;
+        case 0x19:
+            INST_NAME("VBROADCASTSD Gx, Ex");
+            nextop = F8;
+            GETGX();
+            GETEX(x2, 0, 1);
+            GETGY();
+            if (!vex.l) UDF();
+            LD(x4, wback, fixedaddress);
+            for (int i = 0; i < 2; ++i) {
+                SD(x4, gback, gdoffset + i * 8);
+            }
+            for (int i = 0; i < 2; ++i) {
+                SD(x4, gback, gyoffset + i * 8);
+            }
+            break;
+        case 0x1A:
+            INST_NAME("VBROADCASTF128 Gx, Ex");
+            nextop = F8;
+            GETGX();
+            GETEX(x2, 0, 8);
+            GETGY();
+            if (!vex.l || MODREG) UDF();
+            LD(x4, wback, fixedaddress);
+            LD(x5, wback, fixedaddress + 8);
+            SD(x4, gback, gdoffset);
+            SD(x5, gback, gdoffset + 8);
+            SD(x4, gback, gyoffset);
+            SD(x5, gback, gyoffset + 8);
+            break;
         case 0x1C:
             INST_NAME("VPABSB Gx, Ex");
             nextop = F8;
@@ -974,6 +1021,20 @@ uintptr_t dynarec64_AVX_66_0F38(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t i
                 }
             } else
                 YMM0(gd);
+            break;
+        case 0x5A:
+            INST_NAME("VBROADCASTI128 Gx, Ex");
+            nextop = F8;
+            GETGX();
+            GETEX(x2, 0, 8);
+            GETGY();
+            if (!vex.l || MODREG) UDF();
+            LD(x4, wback, fixedaddress);
+            LD(x5, wback, fixedaddress + 8);
+            SD(x4, gback, gdoffset);
+            SD(x5, gback, gdoffset + 8);
+            SD(x4, gback, gyoffset);
+            SD(x5, gback, gyoffset + 8);
             break;
         default:
             DEFAULT;


### PR DESCRIPTION
These vbroadcast opcodes are used by WeMeet app.

Test cases:
1. https://github.com/zengdage/x86_64-inst-test/blob/main/simd/test_vbroadcast.c
2. https://github.com/zengdage/x86_64-inst-test/blob/main/simd/test_vbroadcast128.c .