### PR TITLE
[CORE] Fix some panic errors reported in #4214

### DIFF
--- a/src/wrapped/wrappedlibasound.c
+++ b/src/wrapped/wrappedlibasound.c
@@ -281,8 +281,14 @@ void* my_dlvsym(x64emu_t* emu, void *handle, void *symbol, void *version);
 EXPORT void * my_snd_dlopen(x64emu_t* emu, void* name, int mode, void* errbuf, size_t errbuflen)
 {
     void* ret = my_dlopen(emu, name, mode);  // Does NULL name (so dlopen libasound) need special treatment?
-    if(!ret && errbuf) {
-        strncpy(errbuf, my_dlerror(emu), errbuflen);
+    if(!ret && errbuf && errbuflen) {
+        const char* err = my_dlerror(emu);
+        if(err) {
+            strncpy(errbuf, err, errbuflen-1);
+            ((char *)errbuf)[errbuflen-1] = '\0';
+        } else {
+            ((char *)errbuf)[0] = '\0';
+        }
     }
     return ret;
 }

--- a/src/wrapped/wrappedlibsqlite3.c
+++ b/src/wrapped/wrappedlibsqlite3.c
@@ -346,6 +346,8 @@ EXPORT void* my_sqlite3_mprintf(x64emu_t *emu, void* fmt, void* b) {
 EXPORT void* my_sqlite3_database_file_object(x64emu_t* emu, void* a)
 {
     my_sqlite3_file_t* ret = my->sqlite3_database_file_object(a);
+    if(!ret || !ret->pMethods)
+        return ret;
     // add autobridge on all the functions
     #define GO(A, W)    if(ret->pMethods->A) AddAutomaticBridge(my_lib->w.bridge, W, ret->pMethods->A, 0, #A)
     GO(xClose, iFp);

--- a/src/wrapped/wrappedlibusb1.c
+++ b/src/wrapped/wrappedlibusb1.c
@@ -151,7 +151,7 @@ EXPORT int my_libusb_cancel_transfer(x64emu_t* emu, my_libusb_transfer_t* t)
 
 EXPORT void my_libusb_free_transfer(x64emu_t* emu, my_libusb_transfer_t* t)
 {
-    t->callback = findtransfertFct(t->callback);
+    if (t) t->callback = findtransfertFct(t->callback);
     my->libusb_free_transfer(t);
 }
 

--- a/src/wrapped32/wrappedlibc.c
+++ b/src/wrapped32/wrappedlibc.c
@@ -2483,9 +2483,11 @@ EXPORT void* my32_ctime(void* t)
 EXPORT int my32_utimensat(int dirfd, void* name, void* times, int flags)
 {
     struct timespec times_l[2] = {0};
-    from_struct_LL((struct_LL_t*)&times_l[0], to_ptrv(times));
-    from_struct_LL((struct_LL_t*)&times_l[1], to_ptrv(times)+8);
-    return utimensat(dirfd, name, times_l, flags);
+    if (times) {
+        from_struct_LL((struct_LL_t*)&times_l[0], to_ptrv(times));
+        from_struct_LL((struct_LL_t*)&times_l[1], to_ptrv(times)+8);
+    }
+    return utimensat(dirfd, name, times ? times_l : NULL, flags);
 }
 
 #ifndef ANDROID
@@ -3281,31 +3283,37 @@ EXPORT int my32_nanosleep(const struct timespec *req, struct timespec *rem)
 EXPORT int my32_utimes(x64emu_t* emu, const char* name, uint32_t* times)
 {
     struct timeval tm[2];
-    tm[0].tv_sec = times[0];
-    tm[0].tv_usec = times[1];
-    tm[1].tv_sec = times[2];
-    tm[1].tv_usec = times[3];
-    return utimes(name, tm);
+    if (times) {
+        tm[0].tv_sec = times[0];
+        tm[0].tv_usec = times[1];
+        tm[1].tv_sec = times[2];
+        tm[1].tv_usec = times[3];
+    }
+    return utimes(name, times ? tm : NULL);
 }
 
 EXPORT int my32_futimes(x64emu_t* emu, int fd, uint32_t* times)
 {
     struct timeval tm[2];
-    tm[0].tv_sec = times[0];
-    tm[0].tv_usec = times[1];
-    tm[1].tv_sec = times[2];
-    tm[1].tv_usec = times[3];
-    return futimes(fd, tm);
+    if (times) {
+        tm[0].tv_sec = times[0];
+        tm[0].tv_usec = times[1];
+        tm[1].tv_sec = times[2];
+        tm[1].tv_usec = times[3];
+    }
+    return futimes(fd, times ? tm : NULL);
 }
 
 EXPORT int my32_futimens(x64emu_t* emu, int fd, uint32_t* times)
 {
     struct timespec tm[2];
-    tm[0].tv_sec = times[0];
-    tm[0].tv_nsec = times[1];
-    tm[1].tv_sec = times[2];
-    tm[1].tv_nsec = times[3];
-    return futimens(fd, tm);
+    if (times) {
+        tm[0].tv_sec = times[0];
+        tm[0].tv_nsec = times[1];
+        tm[1].tv_sec = times[2];
+        tm[1].tv_nsec = times[3];
+    }
+    return futimens(fd, times ? tm : NULL);
 }
 
 EXPORT long my32_strtol(const char* s, char** endp, int base)


### PR DESCRIPTION
1. `dlerror` may return NULL.
2. `sqlite3_database_file_object` may return NULL or it's `pMethods` may be NULL.
3. The parameter of `libusb_free_transfer` may be NULL.
4. The parameter of `utimensat` may be NULL.