### PR TITLE
[CORE] Fix some logic errors reported in #4214

### DIFF
--- a/src/emu/x64run0f.c
+++ b/src/emu/x64run0f.c
@@ -180,12 +180,12 @@ uintptr_t Run0F(x64emu_t *emu, rex_t rex, uintptr_t addr, int *step)
             GETED(0);
             GETGD;
             CHECK_FLAGS(emu);
-            tmp8u = ED->word[0]>>3;
-            tmp8s = !!(ED->word[0]&2);
-            if (tmp8u>0x10 || !tmp8s?emu->segldt[tmp8u].present:my_context->seggdt[tmp8u].present) {
+            tmp32u = ED->word[0]>>3;
+            tmp8s = !!(ED->word[0]&4);
+            if (tmp32u >= 16 || !(tmp8s?emu->segldt[tmp32u].present:my_context->seggdt[tmp32u].present)) {
                 CLEAR_FLAG(F_ZF);
             } else {
-                GD->dword[0] = tmp8s?emu->segldt[tmp8u].limit:my_context->seggdt[tmp8u].limit;
+                GD->dword[0] = tmp8s?emu->segldt[tmp32u].limit:my_context->seggdt[tmp32u].limit;
                 SET_FLAG(F_ZF);
             }
             break;

--- a/src/emu/x64run66f0.c
+++ b/src/emu/x64run66f0.c
@@ -104,13 +104,13 @@ uintptr_t Run66F0(x64emu_t *emu, rex_t rex, uintptr_t addr)
                             tmp8u &= 15;
                             if ((uintptr_t)ED & 1) {
                                 do {
-                                    tmp32u = native_lock_read_b(ED + (tmp8u >> 3));
+                                    tmp32u = native_lock_read_b(&(ED->byte[tmp8u >> 3]));
                                     if (tmp32u & (1 << (tmp8u & 7))) {
                                         SET_FLAG(F_CF);
                                         tmp32s = 0;
                                     } else {
                                         tmp32u ^= (1 << (tmp8u & 7));
-                                        tmp32s = native_lock_write_b(ED + (tmp8u >> 3), tmp32u);
+                                        tmp32s = native_lock_write_b(&(ED->byte[tmp8u >> 3]), tmp32u);
                                         CLEAR_FLAG(F_CF);
                                     }
                                 } while (tmp32s);
@@ -150,11 +150,11 @@ uintptr_t Run66F0(x64emu_t *emu, rex_t rex, uintptr_t addr)
                             tmp8u &= 15;
                             if ((uintptr_t)ED & 1) {
                                 do {
-                                    tmp32u = native_lock_read_b(ED + (tmp8u >> 3));
+                                    tmp32u = native_lock_read_b(&(ED->byte[tmp8u >> 3]));
                                     if (tmp32u & (1 << (tmp8u & 7))) {
                                         SET_FLAG(F_CF);
                                         tmp32u ^= (1 << (tmp8u & 7));
-                                        tmp32s = native_lock_write_b(ED + (tmp8u >> 3), tmp32u);
+                                        tmp32s = native_lock_write_b(&(ED->byte[tmp8u >> 3]), tmp32u);
                                     } else {
                                         CLEAR_FLAG(F_CF);
                                         tmp32s = 0;
@@ -196,7 +196,7 @@ uintptr_t Run66F0(x64emu_t *emu, rex_t rex, uintptr_t addr)
                             tmp8u &= 15;
                             if ((uintptr_t)ED & 1) {
                                 do {
-                                    tmp32u = native_lock_read_b(ED + (tmp8u >> 3));
+                                    tmp32u = native_lock_read_b(&(ED->byte[tmp8u >> 3]));
                                     if (tmp32u & (1 << (tmp8u & 7))) {
                                         SET_FLAG(F_CF);
                                         tmp32s = 0;
@@ -204,7 +204,7 @@ uintptr_t Run66F0(x64emu_t *emu, rex_t rex, uintptr_t addr)
                                         CLEAR_FLAG(F_CF);
                                     }
                                     tmp32u ^= (1 << (tmp8u & 7));
-                                    tmp32s = native_lock_write_b(ED + (tmp8u >> 3), tmp32u);
+                                    tmp32s = native_lock_write_b(&(ED->byte[tmp8u >> 3]), tmp32u);
                                 } while (tmp32s);
                             } else {
                                 do {

--- a/src/emu/x64runf0.c
+++ b/src/emu/x64runf0.c
@@ -78,7 +78,7 @@ uintptr_t RunF0(x64emu_t *emu, rex_t rex, uintptr_t addr)
             GETED(0);                                               \
             GETGD;                                                  \
             if(F) {CHECK_FLAGS(emu); eflags=emu->eflags;}           \
-            if(((uintptr_t)ED)&(3<<rex.w)) {                        \
+            if(((uintptr_t)ED)&(rex.w?7:3)) {                       \
                 if(rex.w) {                                         \
                     do {                                            \
                         if(F) emu->eflags = eflags;                 \

--- a/src/libtools/my_x11_defs_32.h
+++ b/src/libtools/my_x11_defs_32.h
@@ -1765,9 +1765,9 @@ typedef struct my_XIEnterEvent_32_s {
     int                     deviceid;
     int                     sourceid;
     int                     detail;
-    XID                     root;
-    XID                     event;
-    XID                     child;
+    XID_32                  root;
+    XID_32                  event;
+    XID_32                  child;
     double                  root_x;
     double                  root_y;
     double                  event_x;

--- a/src/libtools/signal_private.h
+++ b/src/libtools/signal_private.h
@@ -80,7 +80,7 @@ struct x64_fpstate
   uint64_t          rdp;
   uint32_t          mxcsr;
   uint32_t          mxcsr_mask;
-  struct x64_fpreg  _st[8];
+  struct x64_fpxreg  _st[8];
   struct x64_xmmreg _xmm[16];
   uint32_t          res[24];
 }__attribute__((packed));

--- a/src/libtools/vulkanoverlay.c
+++ b/src/libtools/vulkanoverlay.c
@@ -876,22 +876,22 @@ void* LoadVulkanOverlay(const char* path, int flags)
         } else if(getenv("HOME")) {
             snprintf(tmp, sizeof(tmp)-1, "%s/.config/vulkan/implicit_layer.d/*.json", getenv("HOME"));
         }
-        int flags = GLOB_APPEND;
-        if(strlen(tmp)) glob(tmp, 0, NULL, &pglob); else flags = 0;
+        int glob_flags = GLOB_APPEND;
+        if(strlen(tmp)) glob(tmp, 0, NULL, &pglob); else glob_flags = 0;
         if(getenv("XDG_CONFIG_DIRS")) {
             snprintf(tmp, sizeof(tmp)-1, "%s/vulkan/implicit_layer.d/*.json", getenv("XDG_CONFIG_DIRS"));
         } else {
             snprintf(tmp, sizeof(tmp)-1, "/etc/xdg/vulkan/implicit_layer.d/*.json");
         }
-        glob(tmp, flags, NULL, &pglob);
-        flags = GLOB_APPEND;
+        glob(tmp, glob_flags, NULL, &pglob);
+        glob_flags = GLOB_APPEND;
         tmp[0] = 0;
         if(getenv("XDG_DATA_HOME")) {
             snprintf(tmp, sizeof(tmp)-1, "%s/vulkan/implicit_layer.d/*.json", getenv("XDG_DATA_HOME"));
         } else if(getenv("HOME")) {
             snprintf(tmp, sizeof(tmp)-1, "%s/.local/share/vulkan/implicit_layer.d/*.json", getenv("HOME"));
         }
-        glob(tmp, flags, NULL, &pglob);
+        glob(tmp, glob_flags, NULL, &pglob);
         // should also search XDG_DATA_DIRS, but it's a list, so a bit anoying to do...
 
         // now, look through all the json collected to find one that reference the lib


### PR DESCRIPTION
1. `||` has higher precedence than `?:`, TI bit locates at bit2.

2. `ED` is a `reg64_t *` and it gets scaled by `sizeof(reg64_t)`.

3. Use `rex.w?7:3` to check whether address is aligned or not.