### PR TITLE
[WRAPPER] Fix some logic errors in #4214

### DIFF
--- a/src/wrapped/generated/functions_list.txt
+++ b/src/wrapped/generated/functions_list.txt
@@ -6836,6 +6836,7 @@ wrappednss3:
 - vFp:
   - PK11_SetPasswordFunc
   - PORT_SetUCS2_ASCIIConversionFunction
+  - PORT_SetUCS2_UTF8ConversionFunction
 - iFpp:
   - CERT_RegisterAlternateOCSPAIAInfoCallBack
   - NSS_RegisterShutdown

--- a/src/wrapped/generated/wrappednss3types.h
+++ b/src/wrapped/generated/wrappednss3types.h
@@ -18,6 +18,7 @@ typedef int32_t (*iFpIppp_t)(void*, int64_t, void*, void*, void*);
 #define SUPER() ADDED_FUNCTIONS() \
 	GO(PK11_SetPasswordFunc, vFp_t) \
 	GO(PORT_SetUCS2_ASCIIConversionFunction, vFp_t) \
+	GO(PORT_SetUCS2_UTF8ConversionFunction, vFp_t) \
 	GO(CERT_RegisterAlternateOCSPAIAInfoCallBack, iFpp_t) \
 	GO(NSS_RegisterShutdown, iFpp_t) \
 	GO(CERT_PKIXVerifyCert, iFpIppp_t)

--- a/src/wrapped/wrappedlibfuse.c
+++ b/src/wrapped/wrappedlibfuse.c
@@ -286,8 +286,8 @@ static void* find_getattr_Fct(void* fct)
 static uintptr_t my_setattr_fct_##A = 0;                                            \
 static void my_setattr_##A(void* a, unsigned long b, struct stat* c, int d, void* e)\
 {                                                                                   \
-    struct stat c_;                                                                 \
-    AlignStat64(c, &c_);                                                            \
+    struct x64_stat64 c_;                                                           \
+    UnalignStat64(c, &c_);                                                          \
     printf_log(LOG_DEBUG, "fuse: call %s\n", "setattr");                            \
     RunFunctionFmt(my_setattr_fct_##A, "pLpip", a, b, &c_, d, e);       \
 }
@@ -337,7 +337,7 @@ static uintptr_t my_mknod_fct_##A = 0;                                          
 static void my_mknod_##A(void* a, unsigned long b, const char* c, mode_t d, dev_t e)    \
 {                                                                                       \
     printf_log(LOG_DEBUG, "fuse: call %s\n", "mknod");                                  \
-    RunFunctionFmt(my_mknod_fct_##A, "pLpuL", a, b, c, of_convert(d), e);   \
+    RunFunctionFmt(my_mknod_fct_##A, "pLpuL", a, b, c, d, e);                           \
 }
 SUPER()
 #undef GO
@@ -361,7 +361,7 @@ static uintptr_t my_mkdir_fct_##A = 0;                                          
 static void my_mkdir_##A(void* a, unsigned long b, const char* c, mode_t d)         \
 {                                                                                   \
     printf_log(LOG_DEBUG, "fuse: call %s\n", "mkdir");                              \
-    RunFunctionFmt(my_mkdir_fct_##A, "pLpu", a, b, c, of_convert(d));   \
+    RunFunctionFmt(my_mkdir_fct_##A, "pLpu", a, b, c, d);                           \
 }
 SUPER()
 #undef GO
@@ -889,7 +889,7 @@ static uintptr_t my_create_fct_##A = 0;                                         
 static void my_create_##A(void* a, unsigned long b, const char* c, mode_t d, void* e)   \
 {                                                                                       \
     printf_log(LOG_DEBUG, "fuse: call %s\n", "create");             \
-    RunFunctionFmt(my_create_fct_##A, "pLpup", a, b, c, of_convert(d), e);           \
+    RunFunctionFmt(my_create_fct_##A, "pLpup", a, b, c, d, e);                          \
 }
 SUPER()
 #undef GO

--- a/src/wrapped/wrappedlibm.c
+++ b/src/wrapped/wrappedlibm.c
@@ -234,15 +234,15 @@ FROUND(llrintf, float, long)
 FROUND(nearbyint, double, double)
 FROUND(nearbyintf, float, float)
 #ifdef HAVE_LD80BITS
-FROUND(llrintl, long double, long double)
+FROUND(llrintl, long double, long long)
 #else
-EXPORT double my_llrintl(x64emu_t* emu, double val)
+EXPORT int64_t my_llrintl(x64emu_t* emu, double val)
 {
     if (BOX64ENV(sync_rounding)) {
         int round = emu->cw.x16 & 0xc00;
         fesetround(TO_NATIVE(round));
     }
-    return llrint(val);
+    return (int64_t)llrint(val);
 }
 EXPORT double my_nexttoward(x64emu_t* emu, double val, double to)
 {

--- a/src/wrapped/wrappedlibpcre216.c
+++ b/src/wrapped/wrappedlibpcre216.c
@@ -129,9 +129,9 @@ static void* find_private_free_Fct(void* fct)
 // callout_function
 #define GO(A)   \
 static uintptr_t my_callout_function_fct_##A = 0;                       \
-static int my_callout_function_##A(void* a)                             \
+static int my_callout_function_##A(void* a, void *b)                    \
 {                                                                       \
-    return (int)RunFunctionFmt(my_callout_function_fct_##A, "p", a);    \
+    return (int)RunFunctionFmt(my_callout_function_fct_##A, "pp", a, b);\
 }
 SUPER()
 #undef GO

--- a/src/wrapped/wrappedlibssl.c
+++ b/src/wrapped/wrappedlibssl.c
@@ -442,10 +442,10 @@ EXPORT void my_SSL_set_verify(x64emu_t* emu, void* ctx, int mode, void* f)
     my->SSL_set_verify(ctx, mode, find_verify_Fct(f));
 }
 
-EXPORT void my_SSL_get_ex_new_index(x64emu_t* emu, long argl, void* argp, void* new_func, void* dup_func, void* free_func)
+EXPORT int my_SSL_get_ex_new_index(x64emu_t* emu, long argl, void* argp, void* new_func, void* dup_func, void* free_func)
 {
     (void)emu;
-    my->SSL_get_ex_new_index(argl, argp, find_ex_new_Fct(new_func), find_ex_dup_Fct(dup_func), find_ex_free_Fct(free_func));
+    return my->SSL_get_ex_new_index(argl, argp, find_ex_new_Fct(new_func), find_ex_dup_Fct(dup_func), find_ex_free_Fct(free_func));
 }
 
 EXPORT void my_SSL_set_psk_client_callback(x64emu_t* emu, void* ctx, void* cb)

--- a/src/wrapped/wrappedlibtiff5.c
+++ b/src/wrapped/wrappedlibtiff5.c
@@ -60,9 +60,9 @@ static void* find_TIFFReadWriteProc_Fct(void* fct)
 // TIFFSeekProc
 #define GO(A)   \
 static uintptr_t my_TIFFSeekProc_fct_##A = 0;                               \
-static ssize_t my_TIFFSeekProc_##A(void* a, ssize_t b)                      \
+static ssize_t my_TIFFSeekProc_##A(void* a, ssize_t b, int c)               \
 {                                                                           \
-    return (ssize_t)RunFunctionFmt(my_TIFFSeekProc_fct_##A, "pl", a, b);    \
+    return (ssize_t)RunFunctionFmt(my_TIFFSeekProc_fct_##A, "pli", a, b, c);\
 }
 SUPER()
 #undef GO

--- a/src/wrapped/wrappedlibxt.c
+++ b/src/wrapped/wrappedlibxt.c
@@ -124,6 +124,16 @@ static void* findXtErrorMsgHandlerFct(void* fct)
     printf_log(LOG_NONE, "Warning, no more slot for libXt XtErrorMsgHandler callback\n");
     return NULL;
 }
+static void* reverseXtErrorMsgHandlerFct(void* fct)
+{
+    if(!fct) return fct;
+    uintptr_t bridge = CheckBridged(my_lib->w.bridge, vFpppppp, fct);
+    if(bridge) return (void*)bridge;
+    #define GO(A) if(my_XtErrorMsgHandler_##A == fct) return (void*)my_XtErrorMsgHandler_fct_##A;
+    SUPER()
+    #undef GO
+    return (void*)AddBridge(my_lib->w.bridge, vFpppppp, fct, 0, NULL);
+}
 // XtErrorHandler
 #define GO(A)   \
 static uintptr_t my_XtErrorHandler_fct_##A = 0;         \
@@ -145,6 +155,16 @@ static void* findXtErrorHandlerFct(void* fct)
     #undef GO
     printf_log(LOG_NONE, "Warning, no more slot for libXt XtErrorHandler callback\n");
     return NULL;
+}
+static void* reverseXtErrorHandlerFct(void* fct)
+{
+    if(!fct) return fct;
+    uintptr_t bridge = CheckBridged(my_lib->w.bridge, vFp, fct);
+    if(bridge) return (void*)bridge;
+    #define GO(A) if(my_XtErrorHandler_##A == fct) return (void*)my_XtErrorHandler_fct_##A;
+    SUPER()
+    #undef GO
+    return (void*)AddBridge(my_lib->w.bridge, vFp, fct, 0, NULL);
 }
 // XtEventHandler
 #define GO(A)   \
@@ -175,7 +195,7 @@ static void* findXtEventHandlerFct(void* fct)
 EXPORT void my_XtAddEventHandler(x64emu_t* emu, void* w, uint32_t mask, int32_t maskable, void* cb, void* data)
 {
     (void)emu;
-    void* fct = findEventFct(cb);
+    void* fct = findXtEventHandlerFct(cb);
     my->XtAddEventHandler(w, mask, maskable, fct, data);
 }
 
@@ -191,24 +211,24 @@ EXPORT long my_XtAppAddInput(x64emu_t* emu, void* context, int source, void* con
     return my->XtAppAddInput(context, source, cond, findInputCallbackFct(proc), data);
 }
 
-EXPORT void my_XtAppSetWarningMsgHandler(x64emu_t* emu, void* ctx, void* f)
+EXPORT void* my_XtAppSetWarningMsgHandler(x64emu_t* emu, void* ctx, void* f)
 {
-    my->XtAppSetWarningMsgHandler(ctx, findXtErrorMsgHandlerFct(f));
+    return reverseXtErrorMsgHandlerFct(my->XtAppSetWarningMsgHandler(ctx, findXtErrorMsgHandlerFct(f)));
 }
 
-EXPORT void my_XtAppSetErrorMsgHandler(x64emu_t* emu, void* ctx, void* f)
+EXPORT void* my_XtAppSetErrorMsgHandler(x64emu_t* emu, void* ctx, void* f)
 {
-    my->XtAppSetErrorMsgHandler(ctx, findXtErrorMsgHandlerFct(f));
+    return reverseXtErrorMsgHandlerFct(my->XtAppSetErrorMsgHandler(ctx, findXtErrorMsgHandlerFct(f)));
 }
 
-EXPORT void my_XtAppSetWarningHandler(x64emu_t* emu, void* ctx, void* f)
+EXPORT void* my_XtAppSetWarningHandler(x64emu_t* emu, void* ctx, void* f)
 {
-    my->XtAppSetWarningHandler(ctx, findXtErrorHandlerFct(f));
+    return reverseXtErrorHandlerFct(my->XtAppSetWarningHandler(ctx, findXtErrorHandlerFct(f)));
 }
 
-EXPORT void my_XtAppSetErrorHandler(x64emu_t* emu, void* ctx, void* f)
+EXPORT void* my_XtAppSetErrorHandler(x64emu_t* emu, void* ctx, void* f)
 {
-    my->XtAppSetErrorHandler(ctx, findXtErrorHandlerFct(f));
+    return reverseXtErrorHandlerFct(my->XtAppSetErrorHandler(ctx, findXtErrorHandlerFct(f)));
 }
 
 EXPORT void my_XtAddRawEventHandler(x64emu_t* emu, void* w, uint32_t mask, int nonmaskable, void* f, void* data)

--- a/src/wrapped/wrappednss3.c
+++ b/src/wrapped/wrappednss3.c
@@ -228,6 +228,11 @@ EXPORT void my_PORT_SetUCS2_ASCIIConversionFunction(x64emu_t* emu, void* f)
     my->PORT_SetUCS2_ASCIIConversionFunction(find_PORTCharConversionWSwapFunc_Fct(f));
 }
 
+EXPORT void my_PORT_SetUCS2_UTF8ConversionFunction(x64emu_t* emu, void* f)
+{
+    my->PORT_SetUCS2_UTF8ConversionFunction(find_PORTCharConversionWSwapFunc_Fct(f));
+}
+
 EXPORT int my_NSS_RegisterShutdown(x64emu_t* emu, void* f, void* data)
 {
     return my->NSS_RegisterShutdown(find_NSS_ShutdownFunc_Fct(f), data);

--- a/src/wrapped/wrappednss3_private.h
+++ b/src/wrapped/wrappednss3_private.h
@@ -655,7 +655,7 @@ GO(PORT_NewArena, pFL)
 GO(PORT_Realloc, pFpL)
 GO(PORT_SetError, vFi)
 GOM(PORT_SetUCS2_ASCIIConversionFunction, vFEp)
-GO(PORT_SetUCS2_UTF8ConversionFunction, vFi)
+GOM(PORT_SetUCS2_UTF8ConversionFunction, vFEp)
 //GO(PORT_SetUCS4_UTF8ConversionFunction, 
 GO(PORT_Strdup, pFp)
 GO(PORT_UCS2_ASCIIConversion, iFipupupi)


### PR DESCRIPTION
1. Add Xt returned error-handler conversion.

2. Fix FUSE stat and mode argument conversions.

3. Fix llrintl return values.

4. Add the `user_data` argument to PCRE2 callouts.

5. Add the NSS UCS2-to-UTF8 callback wrapper.

6. Add the whence argument to TIFF seek callbacks.