### PR TITLE
[MEM] Reduced autocrc overhead by merging guest page protections

### DIFF
--- a/src/custommem.c
+++ b/src/custommem.c
@@ -1407,6 +1407,15 @@ void* box32_dynarec_mmap(size_t size, int fd, off_t offset)
     return ret;
 }
 
+static int alignGuestPageRange(uintptr_t* addr, size_t size, uintptr_t* end)
+{
+    if (!size) return 0;
+    *end = *addr + size;
+    *addr &= ~(X86_PAGE_SIZE - 1);
+    *end = (*end + X86_PAGE_SIZE - 1) & ~(X86_PAGE_SIZE - 1);
+    return *end > *addr;
+}
+
 #ifdef DYNAREC
 typedef struct mmaplist_s {
     blocklist_t**   chunks;
@@ -2249,15 +2258,6 @@ uintptr_t getJumpAddress64(uintptr_t addr)
     #else
     return (uintptr_t)box64_jmptbl2[idx2][idx1][idx0];
     #endif
-}
-
-static int alignGuestPageRange(uintptr_t* addr, size_t size, uintptr_t* end)
-{
-    if (!size) return 0;
-    *end = *addr + size;
-    *addr &= ~(X86_PAGE_SIZE - 1);
-    *end = (*end + X86_PAGE_SIZE - 1) & ~(X86_PAGE_SIZE - 1);
-    return *end > *addr;
 }
 
 static void setGuestDynProtection_locked(uintptr_t addr, size_t size)

--- a/src/custommem.c
+++ b/src/custommem.c
@@ -70,8 +70,11 @@ pthread_mutex_t     mutex_blocks;
 #endif
 //#define TRACE_MEMSTAT
 rbtree_t* memprot = NULL;
-// fake guest 4k page permissions for non4k systems, used by getrlimit for example.
+// guest 4K page permissions for hosts with larger pages.
 static rbtree_t* memprot_guest = NULL;
+// guest 4K pages contain source code that the dynarec wants to write-protect
+static rbtree_t* memprot_guest_dyn = NULL;
+
 int have48bits = 0;
 static int inited = 0;
 typedef enum {
@@ -2248,27 +2251,102 @@ uintptr_t getJumpAddress64(uintptr_t addr)
     #endif
 }
 
-// Helper: check if any sub-range in a host page has PROT_WRITE that is NOT part of the
-// dynarec-protected range [prot_start, prot_end). This detects mixed code+data host pages
-// on systems with large pages (e.g. 64KB) where mprotect to remove PROT_WRITE would also
-// strip writability from data regions, causing EFAULT on kernel writes (e.g. read() syscall).
-// Must be called with LOCK_PROT() held.
+static int alignGuestPageRange(uintptr_t* addr, size_t size, uintptr_t* end)
+{
+    if (!size) return 0;
+    *end = *addr + size;
+    *addr &= ~(X86_PAGE_SIZE - 1);
+    *end = (*end + X86_PAGE_SIZE - 1) & ~(X86_PAGE_SIZE - 1);
+    return *end > *addr;
+}
+
+static void setGuestDynProtection_locked(uintptr_t addr, size_t size)
+{
+    uintptr_t end;
+    if (box64_pagesize <= X86_PAGE_SIZE || !memprot_guest_dyn || !alignGuestPageRange(&addr, size, &end))
+        return;
+    rb_set(memprot_guest_dyn, addr, end, 1);
+}
+
+static void freeGuestDynProtection_locked(uintptr_t addr, size_t size)
+{
+    uintptr_t end;
+    if (box64_pagesize <= X86_PAGE_SIZE || !memprot_guest_dyn || !alignGuestPageRange(&addr, size, &end))
+        return;
+    rb_unset(memprot_guest_dyn, addr, end);
+}
+
+static int guestPageHasWrite_locked(uintptr_t guest_page)
+{
+    uintptr_t scan = guest_page;
+    uintptr_t guest_end = guest_page + X86_PAGE_SIZE;
+    while (scan < guest_end) {
+        uint32_t prot = 0;
+        uintptr_t bend = guest_end;
+        if (!memprot_guest || !rb_get_end(memprot_guest, scan, &prot, &bend)) {
+            prot = rb_get(memprot, scan) & ~PROT_CUSTOM;
+            if (!prot)
+                prot = PROT_READ | PROT_WRITE | PROT_EXEC;
+        }
+        if (prot & PROT_WRITE)
+            return 1;
+        if (bend > guest_end)
+            bend = guest_end;
+        if (bend <= scan)
+            break;
+        scan = bend;
+    }
+    return 0;
+}
+
 static int hostPageHasExternalWrite_locked(uintptr_t host_page, uintptr_t prot_start, uintptr_t prot_end)
 {
-    uintptr_t scan = host_page;
     uintptr_t host_end = host_page + box64_pagesize;
-    while(scan < host_end) {
-        uint32_t p = 0;
-        uintptr_t bend = 0;
-        rb_get_end(memprot, scan, &p, &bend);
-        if(bend > host_end)
-            bend = host_end;
-        if(p && (p & PROT_WRITE) && !(p & PROT_DYN)) {
-            if(scan < prot_start || bend > prot_end) {
-                return 1;
-            }
-        }
-        scan = bend;
+    for (uintptr_t page = host_page; page < host_end; page += X86_PAGE_SIZE) {
+        if (!guestPageHasWrite_locked(page)) continue;
+        if (prot_end > prot_start && page < prot_end && page + X86_PAGE_SIZE > prot_start) continue;
+        if (memprot_guest_dyn && rb_get(memprot_guest_dyn, page)) continue;
+        return 1;
+    }
+    return 0;
+}
+
+// apply the real host-page protection implied by the current guest page
+// returns 1 if needs rebuild
+static int applyDBHostPageProtection_locked(uintptr_t cur, uintptr_t bend, uint32_t prot, uintptr_t prot_start, uintptr_t prot_end, int protect_requested)
+{
+    uint32_t old_prot = prot;
+    uint32_t dyn = prot & PROT_DYN;
+    uint32_t base_prot = prot & ~PROT_CUSTOM;
+    if (!prot) base_prot = PROT_READ | PROT_WRITE | PROT_EXEC;
+
+    if ((dyn & PROT_NOPROT) || ((dyn & PROT_NEVERCLEAN) && !(dyn & PROT_NEVERCLEAN_MIXED))) return 0;
+    if (!protect_requested && !dyn) return 0;
+    if (!base_prot) return 0;
+
+    int external_write = box64_pagesize > X86_PAGE_SIZE && hostPageHasExternalWrite_locked(cur & ~(box64_pagesize - 1), prot_start, prot_end);
+
+    if (external_write && (base_prot & PROT_WRITE)) {
+        if ((dyn & PROT_DYNAREC) && !(dyn & PROT_NEVERCLEAN))
+            mprotect((void*)cur, bend - cur, base_prot);
+        // a neighboring guest page needs write access
+        prot = base_prot | PROT_DYNAREC | PROT_NEVERCLEAN | PROT_NEVERCLEAN_MIXED;
+    } else if (base_prot & PROT_WRITE) {
+        if (!(dyn & PROT_DYNAREC) || (dyn & PROT_NEVERCLEAN_MIXED))
+            mprotect((void*)cur, bend - cur, base_prot & ~PROT_WRITE);
+        prot = base_prot | PROT_DYNAREC;
+    } else {
+        prot = base_prot | PROT_DYNAREC_R;
+    }
+
+    if (prot != old_prot)
+        rb_set(memprot, cur, bend, prot);
+
+    int old_mixed = (old_prot & PROT_NEVERCLEAN_MIXED) != 0;
+    int new_mixed = (prot & PROT_NEVERCLEAN_MIXED) != 0;
+    if (old_mixed != new_mixed) {
+        dynarec_log(LOG_INFO, "Dynarec host page %p switched to %s mode\n", (void*)(cur & ~(box64_pagesize - 1)), new_mixed ? "always_test" : "write-protected");
+        return 1;
     }
     return 0;
 }
@@ -2280,43 +2358,23 @@ void protectDBJumpTable(uintptr_t addr, size_t size, void* jump, void* ref)
 
     uintptr_t cur = addr&~(box64_pagesize-1);
     uintptr_t end = ALIGN(addr+size);
+    int rebuild = 0;
 
     LOCK_PROT();
+    setGuestDynProtection_locked(addr, size);
     while(cur!=end) {
-        uint32_t prot = 0, oprot;
+        uint32_t prot = 0;
         uintptr_t bend = 0;
         rb_get_end(memprot, cur, &prot, &bend);
         if(bend>end)
             bend = end;
-        oprot = prot;
-        uint32_t dyn = prot&PROT_DYN;
-        if(!prot)
-            prot = PROT_READ | PROT_WRITE | PROT_EXEC;
-        if(!(dyn&PROT_NEVERPROT)) {
-            prot&=~PROT_CUSTOM;
-            if(prot&PROT_WRITE) {
-                if(!dyn) {
-                    if(box64_pagesize > 4096) {
-                        uintptr_t host_page = cur & ~(box64_pagesize-1);
-                        if(hostPageHasExternalWrite_locked(host_page, addr, addr+size)) {
-                            dynarec_log(LOG_INFO, "protectDBJumpTable: mixed code+data host page %p, using always_test instead of mprotect\n", (void*)host_page);
-                            prot |= PROT_NEVERCLEAN;
-                        } else {
-                            mprotect((void*)cur, bend-cur, prot&~PROT_WRITE);
-                        }
-                    } else {
-                        mprotect((void*)cur, bend-cur, prot&~PROT_WRITE);
-                    }
-                }
-                prot |= PROT_DYNAREC;
-            } else
-                prot |= PROT_DYNAREC_R;
+        if (applyDBHostPageProtection_locked(cur, bend, prot, addr, addr + size, 1)) {
+            rebuild = 1;
+            cleanDBFromAddressRange(cur, bend - cur, 2);
         }
-        if (prot != oprot) // If the node doesn't exist, then prot != 0
-            rb_set(memprot, cur, bend, prot);
         cur = bend;
     }
-    if(jump)
+    if (jump && !rebuild)
         setJumpTableIfRef64((void*)addr, jump, ref);
     UNLOCK_PROT();
 }
@@ -2330,43 +2388,15 @@ void protectDB(uintptr_t addr, uintptr_t size)
     uintptr_t end = ALIGN(addr+size);
 
     LOCK_PROT();
+    setGuestDynProtection_locked(addr, size);
     while(cur!=end) {
-        uint32_t prot = 0, oprot;
+        uint32_t prot = 0;
         uintptr_t bend = 0;
         rb_get_end(memprot, cur, &prot, &bend);
         if(bend>end)
             bend = end;
-        oprot = prot;
-        uint32_t dyn = prot&PROT_DYN;
-        if(!prot)
-            prot = PROT_READ | PROT_WRITE | PROT_EXEC;
-        if(!(dyn&PROT_NEVERPROT)) {
-            prot&=~PROT_CUSTOM;
-            if(prot&PROT_WRITE) {
-                if(!dyn) {
-                    // On large-page systems, check if removing PROT_WRITE from this host page
-                    // would also affect writable data regions sharing the same host page.
-                    // If so, use PROT_NEVERCLEAN (always_test mode) instead of mprotect,
-                    // because kernel syscalls (e.g. read()) cannot be caught via SEGV and
-                    // would return EFAULT if the buffer is on a non-writable page.
-                    if(box64_pagesize > 4096) {
-                        uintptr_t host_page = cur & ~(box64_pagesize-1);
-                        if(hostPageHasExternalWrite_locked(host_page, addr, addr+size)) {
-                            dynarec_log(LOG_INFO, "protectDB: mixed code+data host page %p, using always_test instead of mprotect\n", (void*)host_page);
-                            prot |= PROT_NEVERCLEAN;
-                        } else {
-                            mprotect((void*)cur, bend-cur, prot&~PROT_WRITE);
-                        }
-                    } else {
-                        mprotect((void*)cur, bend-cur, prot&~PROT_WRITE);
-                    }
-                }
-                prot |= PROT_DYNAREC;
-            } else
-                prot |= PROT_DYNAREC_R;
-        }
-        if (prot != oprot) // If the node doesn't exist, then prot != 0
-            rb_set(memprot, cur, bend, prot);
+        if (applyDBHostPageProtection_locked(cur, bend, prot, addr, addr + size, 1))
+            cleanDBFromAddressRange(cur, bend - cur, 2);
         cur = bend;
     }
     UNLOCK_PROT();
@@ -2381,6 +2411,7 @@ void unprotectDB(uintptr_t addr, size_t size, int mark)
     uintptr_t end = ALIGN(addr+size);
 
     LOCK_PROT();
+    freeGuestDynProtection_locked(cur, end - cur);
     while(cur!=end) {
         uint32_t prot = 0, oprot;
         uintptr_t bend = 0;
@@ -2394,7 +2425,7 @@ void unprotectDB(uintptr_t addr, size_t size, int mark)
         oprot = prot;
         if(bend>end)
             bend = end;
-        if(!(prot&PROT_NEVERPROT)) {
+        if (!(prot & PROT_NEVERPROT) || (prot & PROT_NEVERCLEAN_MIXED)) {
             if(prot&PROT_DYNAREC) {
                 prot&=~PROT_DYN;
                 if(mark)
@@ -2421,6 +2452,7 @@ void neverprotectDB(uintptr_t addr, size_t size, int mark)
     uintptr_t end = ALIGN(addr+size);
 
     LOCK_PROT();
+    freeGuestDynProtection_locked(cur, end - cur);
     while(cur!=end) {
         uint32_t prot = 0, oprot;
         uintptr_t bend = 0;
@@ -2434,6 +2466,10 @@ void neverprotectDB(uintptr_t addr, size_t size, int mark)
         oprot = prot;
         if(bend>end)
             bend = end;
+        if (prot & PROT_NEVERCLEAN_MIXED) {
+            if (mark) cleanDBFromAddressRange(cur, bend - cur, (mark == 2) ? 2 : 0);
+            prot &= ~PROT_NEVERCLEAN_MIXED;
+        }
         if(!(prot&PROT_NEVERPROT)) {
             if(prot&PROT_DYNAREC) {
                 prot&=~PROT_DYN;
@@ -2589,6 +2625,26 @@ int checkInHotPage(uintptr_t addr)
     return ((idx==-1) || !hotpage[idx].cnt)?0:1;
 }
 
+static void updateDBHostProtectionForGuestRange(uintptr_t addr, size_t size)
+{
+    if (box64_pagesize <= X86_PAGE_SIZE || !size)
+        return;
+    uintptr_t cur = addr & ~(box64_pagesize - 1);
+    uintptr_t end = ALIGN(addr + size);
+    LOCK_PROT();
+    while (cur < end) {
+        uint32_t prot = 0;
+        uintptr_t bend = 0;
+        rb_get_end(memprot, cur, &prot, &bend);
+        if (bend > end)
+            bend = end;
+        if (applyDBHostPageProtection_locked(cur, bend, prot, 0, 0, 0))
+            cleanDBFromAddressRange(cur, bend - cur, 2);
+        cur = bend;
+    }
+    UNLOCK_PROT();
+}
+
 
 #endif
 
@@ -2612,7 +2668,7 @@ void updateProtection(uintptr_t addr, size_t size, uint32_t prot)
             cur = bend;
             continue;
         }
-        uint32_t never = dyn & PROT_NEVERCLEAN;
+        uint32_t never = dyn & (PROT_NEVERCLEAN | PROT_NEVERCLEAN_MIXED);
         #ifdef DYNAREC
         if(check && ((prot ^ oprot) & PROT_EXEC) && !never) { // prot_exec changed
             if(prot & PROT_EXEC) {
@@ -2810,30 +2866,33 @@ void freeProtection(uintptr_t addr, size_t size)
     LOCK_PROT();
     rb_unset(mapallmem, addr, addr+size);
     rb_unset(memprot, addr, addr+size);
+    if (memprot_guest_dyn)
+        rb_unset(memprot_guest_dyn, addr, addr + size);
     UNLOCK_PROT();
 }
 
-void setGuestFakeProtection(uintptr_t addr, size_t size, uint32_t prot)
+void setGuestProtection(uintptr_t addr, size_t size, uint32_t prot, int new_mapping)
 {
-    if(box64_pagesize <= X86_PAGE_SIZE || !memprot_guest || !size) return;
-    uintptr_t end = addr + size;
-    addr &= ~(X86_PAGE_SIZE - 1);
-    end = (end + X86_PAGE_SIZE - 1) & ~(X86_PAGE_SIZE - 1);
-    if(end <= addr) return;
+    uintptr_t end;
+    if (box64_pagesize <= X86_PAGE_SIZE || !memprot_guest || !alignGuestPageRange(&addr, size, &end)) return;
     LOCK_PROT();
     rb_set(memprot_guest, addr, end, prot & ~PROT_CUSTOM);
+    if ((new_mapping || !(prot & PROT_EXEC)) && memprot_guest_dyn)
+        rb_unset(memprot_guest_dyn, addr, end);
     UNLOCK_PROT();
+    #ifdef DYNAREC
+    if (BOX64ENV(dynarec)) updateDBHostProtectionForGuestRange(addr, end - addr);
+    #endif
 }
 
-void freeGuestFakeProtection(uintptr_t addr, size_t size)
+void freeGuestProtection(uintptr_t addr, size_t size)
 {
-    if(box64_pagesize <= X86_PAGE_SIZE || !memprot_guest || !size)return;
-    uintptr_t end = addr + size;
-    addr &= ~(X86_PAGE_SIZE - 1);
-    end = (end + X86_PAGE_SIZE - 1) & ~(X86_PAGE_SIZE - 1);
-    if(end <= addr) return;
+    uintptr_t end;
+    if (box64_pagesize <= X86_PAGE_SIZE || !memprot_guest || !alignGuestPageRange(&addr, size, &end)) return;
     LOCK_PROT();
     rb_unset(memprot_guest, addr, end);
+    if (memprot_guest_dyn)
+        rb_unset(memprot_guest_dyn, addr, end);
     UNLOCK_PROT();
 }
 
@@ -3141,6 +3200,7 @@ void init_custommem_helper(box64context_t* ctx)
             rb_set(blockstree, (uintptr_t)p_blocks[i].block, (uintptr_t)p_blocks[i].block+p_blocks[i].size, i);
     memprot = rbtree_init("memprot");
     memprot_guest = rbtree_init("memprot_guest");
+    memprot_guest_dyn = rbtree_init("memprot_guest_dyn");
 #ifdef DYNAREC
     #ifdef JMPTABL_SHIFT4
     for(int i=0; i<(1<<JMPTABL_SHIFT3); ++i) {
@@ -3247,6 +3307,8 @@ void fini_custommem_helper(box64context_t *ctx)
     memprot = NULL;
     rbtree_delete(memprot_guest);
     memprot_guest = NULL;
+    rbtree_delete(memprot_guest_dyn);
+    memprot_guest_dyn = NULL;
     rbtree_delete(mapallmem);
     mapallmem = NULL;
     rbtree_delete(blockstree);

--- a/src/include/custommem.h
+++ b/src/include/custommem.h
@@ -101,12 +101,18 @@ uintptr_t getJumpAddress64(uintptr_t addr);
 #endif //SAVE_MEM
 #endif
 
-#define PROT_NEVERCLEAN 0x100
-#define PROT_DYNAREC    0x80
-#define PROT_DYNAREC_R  0x40
-#define PROT_NOPROT     0x20
-#define PROT_DYN        (PROT_DYNAREC | PROT_DYNAREC_R | PROT_NOPROT | PROT_NEVERCLEAN)
-#define PROT_CUSTOM     (PROT_DYNAREC | PROT_DYNAREC_R | PROT_NOPROT | PROT_NEVERCLEAN)
+// used when Box64 cannot rely on write protection, so translated code must check whether its source bytes changed
+#define PROT_NEVERCLEAN       0x100
+// the NEVERCLEAN state is specifically caused by mixed 4 KiB pages inside a larger host page and may later be removed
+#define PROT_NEVERCLEAN_MIXED 0x200
+// the guest logically allows writing, but Box64 normally removed physical write permission to detect code changes
+#define PROT_DYNAREC          0x80
+// the guest page was already non-writable; Box64 did not artificially remove write permission.
+#define PROT_DYNAREC_R        0x40
+// Box64 should not manipulate this page’s protection.
+#define PROT_NOPROT           0x20
+#define PROT_DYN        (PROT_DYNAREC | PROT_DYNAREC_R | PROT_NOPROT | PROT_NEVERCLEAN | PROT_NEVERCLEAN_MIXED)
+#define PROT_CUSTOM     (PROT_DYNAREC | PROT_DYNAREC_R | PROT_NOPROT | PROT_NEVERCLEAN | PROT_NEVERCLEAN_MIXED)
 #define PROT_NEVERPROT  (PROT_NOPROT | PROT_NEVERCLEAN)
 #define PROT_WAIT       0xFF
 
@@ -117,8 +123,8 @@ void setProtection_box(uintptr_t addr, size_t size, uint32_t prot);
 void setProtection_stack(uintptr_t addr, size_t size, uint32_t prot);
 void setProtection_elf(uintptr_t addr, size_t size, uint32_t prot);
 void freeProtection(uintptr_t addr, size_t size);
-void setGuestFakeProtection(uintptr_t addr, size_t size, uint32_t prot);
-void freeGuestFakeProtection(uintptr_t addr, size_t size);
+void setGuestProtection(uintptr_t addr, size_t size, uint32_t prot, int new_mapping);
+void freeGuestProtection(uintptr_t addr, size_t size);
 int isGuestRangeFakelyProtected(uintptr_t addr, size_t size, uint32_t prot);
 void refreshProtection(uintptr_t addr);
 uint32_t getProtection(uintptr_t addr);

--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -3889,7 +3889,7 @@ EXPORT void* my_mmap64(x64emu_t* emu, void *addr, size_t length, int prot, int f
         #endif
         if(emu) {
             setProtection_mmap((uintptr_t)ret, length, prot);
-            setGuestFakeProtection((uintptr_t)ret, length, prot);
+            setGuestProtection((uintptr_t)ret, length, prot, 1);
         } else
             setProtection_box((uintptr_t)ret, length, prot);
         if(emulated_first_edge) {
@@ -3927,21 +3927,21 @@ EXPORT void* my_mremap(x64emu_t* emu, void* old_addr, size_t old_size, size_t ne
         if(ret==old_addr) {
             if(old_size && old_size<new_size) {
                 setProtection_mmap((uintptr_t)ret+old_size, new_size-old_size, prot);
-                setGuestFakeProtection((uintptr_t)ret+old_size, new_size-old_size, prot);
+                setGuestProtection((uintptr_t)ret+old_size, new_size-old_size, prot, 1);
                 #ifdef DYNAREC
                 if(BOX64ENV(dynarec))
                     addDBFromAddressRange((uintptr_t)ret+old_size, new_size-old_size);
                 #endif
             } else if(old_size && new_size<old_size) {
                 freeProtection((uintptr_t)ret+new_size, old_size-new_size);
-                freeGuestFakeProtection((uintptr_t)ret+new_size, old_size-new_size);
+                freeGuestProtection((uintptr_t)ret+new_size, old_size-new_size);
                 #ifdef DYNAREC
                 if(BOX64ENV(dynarec))
                     cleanDBFromAddressRange((uintptr_t)ret+new_size, old_size-new_size, 1);
                 #endif
             } else if(!old_size) {
                 setProtection_mmap((uintptr_t)ret, new_size, prot);
-                setGuestFakeProtection((uintptr_t)ret, new_size, prot);
+                setGuestProtection((uintptr_t)ret, new_size, prot, 1);
                 #ifdef DYNAREC
                 if(BOX64ENV(dynarec))
                     addDBFromAddressRange((uintptr_t)ret, new_size);
@@ -3954,14 +3954,14 @@ EXPORT void* my_mremap(x64emu_t* emu, void* old_addr, size_t old_size, size_t ne
             #endif
             ) {
                 freeProtection((uintptr_t)old_addr, old_size);
-                freeGuestFakeProtection((uintptr_t)old_addr, old_size);
+                freeGuestProtection((uintptr_t)old_addr, old_size);
                 #ifdef DYNAREC
                 if(BOX64ENV(dynarec))
                     cleanDBFromAddressRange((uintptr_t)old_addr, old_size, 1);
                 #endif
             }
             setProtection_mmap((uintptr_t)ret, new_size, prot); // should copy the protection from old block
-            setGuestFakeProtection((uintptr_t)ret, new_size, prot);
+            setGuestProtection((uintptr_t)ret, new_size, prot, 1);
             #ifdef DYNAREC
             if(BOX64ENV(dynarec))
                 addDBFromAddressRange((uintptr_t)ret, new_size);
@@ -4019,11 +4019,11 @@ EXPORT int my_munmap(x64emu_t* emu, void* addr, size_t length)
         else if(unmap_length)
             freeProtection(unmap_start, unmap_length);
         if(partial_host_pages) {
-            setGuestFakeProtection(start, length, 0);
+            setGuestProtection(start, length, 0, 0);
             if(unmap_length)
-                freeGuestFakeProtection(unmap_start, unmap_length);
+                freeGuestProtection(unmap_start, unmap_length);
         } else
-            freeGuestFakeProtection(start, length);
+            freeGuestProtection(start, length);
         RemoveMapping((uintptr_t)addr, length);
     }
     errno = e;  // preseve errno
@@ -4045,7 +4045,7 @@ EXPORT int my_mprotect(x64emu_t* emu, void *addr, unsigned long len, int prot)
         int ret = mprotect(addr, len, prot);
         if(!ret && len) {
             updateProtection(start, len, prot);
-            setGuestFakeProtection(start, len, prot);
+            setGuestProtection(start, len, prot, 0);
         }
         return ret;
     }
@@ -4063,7 +4063,7 @@ EXPORT int my_mprotect(x64emu_t* emu, void *addr, unsigned long len, int prot)
         int ret = mprotect((void*)host_start, box64_pagesize, host_prot);
         if(!ret) {
             updateProtection(host_start, box64_pagesize, host_prot);
-            setGuestFakeProtection(start, end - start, prot);
+            setGuestProtection(start, end - start, prot, 0);
         }
         return ret;
     }
@@ -4083,13 +4083,13 @@ EXPORT int my_mprotect(x64emu_t* emu, void *addr, unsigned long len, int prot)
         updateProtection(host_end, box64_pagesize, host_prot);
     }
     if(host_start == host_end) {
-        setGuestFakeProtection(start, end - start, prot);
+        setGuestProtection(start, end - start, prot, 0);
         return 0;
     }
     int ret = mprotect((void*)host_start, host_end - host_start, prot);
     if(!ret) {
         updateProtection(host_start, host_end - host_start, prot);
-        setGuestFakeProtection(start, end - start, prot);
+        setGuestProtection(start, end - start, prot, 0);
     }
     return ret;
 }


### PR DESCRIPTION
On non-4K hosts, several 4 KiB guest pages share one host page. A writable neighboring guest page previously forced the entire host page into NEVERCLEAN mode, introduces huge overhead on many games.

This PR tracks guest page permissions and DynaRec protections separately. Once all writable guest pages within a host page are covered by DynaRec, protect the host page and rebuild its blocks without autocrc.