### PR TITLE
[CORE] Fix some logic errors reported in #4214

### DIFF
--- a/src/libtools/myalign.c
+++ b/src/libtools/myalign.c
@@ -96,7 +96,7 @@ void myStackAlign(x64emu_t* emu, const char* fmt, uint64_t* st, uint64_t* mystac
                         ++mystack;
                         ++p; 
                         break; // fetch an int in the stack....
-                    case ' ': state=0; ++p; break;
+                    case ' ': ++p; break;
                     default:
                         state=20; // other stuff, put an int...
                 }
@@ -747,7 +747,7 @@ void myStackAlignValist(x64emu_t* emu, const char* fmt, uint64_t* mystack, x64_v
                         ++mystack;
                         ++p; 
                         break; // fetch an int in the stack....
-                    case ' ': state=0; ++p; break;
+                    case ' ': ++p; break;
                     default:
                         state=20; // other stuff, put an int...
                 }
@@ -907,7 +907,7 @@ void myStackAlignWValist(x64emu_t* emu, const char* fmt, uint64_t* mystack, x64_
                         ++mystack;
                         ++p; 
                         break; // fetch an int in the stack....
-                    case ' ': state=0; ++p; break;
+                    case ' ': ++p; break;
                     default:
                         state=20; // other stuff, put an int...
                 }
@@ -1214,7 +1214,7 @@ void myStackAlignGVariantNewVa(x64emu_t* emu, const char* fmt, uint64_t* scratch
     const char *p = fmt;
     int state = 0;
     int inblocks = 0;
-    int tmp;
+    int tmp = 0;
 
     do {
         switch(state) {
@@ -1253,9 +1253,9 @@ void myStackAlignGVariantNewVa(x64emu_t* emu, const char* fmt, uint64_t* scratch
                     case '(': ++inblocks; break;
                     case '}':
                     case ')': --inblocks; break;
-                    case 'a': state = 1; break; // GVariantBuilder* or GVariantIter**
+                    case 'a': state = 1; tmp = 0; break; // GVariantBuilder* or GVariantIter**
                     case 'm': state = 2; break; // maybe types
-                    case '@': state = 3; break; // GVariant* of type [type]
+                    case '@': state = 3; tmp = 0; break; // GVariant* of type [type]
                     case '^': state = 4; break; // pointer value
                     case '&': break; // pointer: do nothing
                 }
@@ -1411,7 +1411,7 @@ void myStackAlignGVariantNew(x64emu_t* emu, const char* fmt, uint64_t* st, uint6
     const char *p = fmt;
     int state = 0;
     int inblocks = 0;
-    int tmp;
+    int tmp = 0;
     int xmm = R_EAX;
 
     do {
@@ -1436,10 +1436,11 @@ void myStackAlignGVariantNew(x64emu_t* emu, const char* fmt, uint64_t* st, uint6
                     case 't': // guint64
                         if (pos < 6)
                             *mystack = emu->regs[regs_abi[pos++]].q[0];
-                        else
+                        else {
                             *mystack = *st;
+                            ++st;
+                        }
                         ++mystack;
-                        ++st;
                         break;
                     case 'd': // gdouble
                         if (xmm) {
@@ -1456,9 +1457,9 @@ void myStackAlignGVariantNew(x64emu_t* emu, const char* fmt, uint64_t* st, uint6
                     case '(': ++inblocks; break;
                     case '}':
                     case ')': --inblocks; break;
-                    case 'a': state = 1; break; // GVariantBuilder* or GVariantIter**
+                    case 'a': state = 1; tmp = 0; break; // GVariantBuilder* or GVariantIter**
                     case 'm': state = 2; break; // maybe types
-                    case '@': state = 3; break; // GVariant* of type [type]
+                    case '@': state = 3; tmp = 0; break; // GVariant* of type [type]
                     case '^': state = 4; break; // pointer value
                     case '&': break; // pointer: do nothing
                 }
@@ -1474,10 +1475,11 @@ void myStackAlignGVariantNew(x64emu_t* emu, const char* fmt, uint64_t* st, uint6
                 if (tmp == 0) {
                     if (pos < 6)
                         *mystack = emu->regs[regs_abi[pos++]].q[0];
-                    else
+                    else {
                         *mystack = *st;
+                        ++st;
+                    }
                     ++mystack;
-                    ++st;
                     state = 0;
                 }
                 break;
@@ -1500,10 +1502,11 @@ void myStackAlignGVariantNew(x64emu_t* emu, const char* fmt, uint64_t* st, uint6
                         // Add a gboolean or gboolean*, no char increment
                         if (pos < 6)
                             *mystack = emu->regs[regs_abi[pos++]].q[0];
-                        else
+                        else {
                             *mystack = *st;
+                            ++st;
+                        }
                         ++mystack;
-                        ++st;
                         --p;
                         state = 0;
                         break;
@@ -1526,10 +1529,11 @@ void myStackAlignGVariantNew(x64emu_t* emu, const char* fmt, uint64_t* st, uint6
                     default: // Default to add a gboolean & reinit state?
                         if (pos < 6)
                             *mystack = emu->regs[regs_abi[pos++]].q[0];
-                        else
+                        else {
                             *mystack = *st;
+                            ++st;
+                        }
                         ++mystack;
-                        ++st;
                         --p;
                         state = 0;
                 }
@@ -1553,10 +1557,11 @@ void myStackAlignGVariantNew(x64emu_t* emu, const char* fmt, uint64_t* st, uint6
                 if (tmp == 0) {
                     if (pos < 6)
                         *mystack = emu->regs[regs_abi[pos++]].q[0];
-                    else
+                    else {
                         *mystack = *st;
+                        ++st;
+                    }
                     ++mystack;
-                    ++st;
                     state = 0;
                 }
                 break;
@@ -1569,10 +1574,11 @@ void myStackAlignGVariantNew(x64emu_t* emu, const char* fmt, uint64_t* st, uint6
                 if ((*p == 's') || (*p == 'o') || (*p == 'y')) {
                     if (pos < 6)
                         *mystack = emu->regs[regs_abi[pos++]].q[0];
-                    else
+                    else {
                         *mystack = *st;
+                        ++st;
+                    }
                     ++mystack;
-                    ++st;
                     state = 0;
                 } else if (*p == '&') state = 6;
                 else if (*p == 'a') state = 7;
@@ -1582,10 +1588,11 @@ void myStackAlignGVariantNew(x64emu_t* emu, const char* fmt, uint64_t* st, uint6
                 if ((*p == 's') || (*p == 'o')) {
                     if (pos < 6)
                         *mystack = emu->regs[regs_abi[pos++]].q[0];
-                    else
+                    else {
                         *mystack = *st;
+                        ++st;
+                    }
                     ++mystack;
-                    ++st;
                     state = 0;
                 } else if (*p == 'a') state = 7;
                 else state = 0; //???
@@ -1594,10 +1601,11 @@ void myStackAlignGVariantNew(x64emu_t* emu, const char* fmt, uint64_t* st, uint6
                 if (*p == 'y') {
                     if (pos < 6)
                         *mystack = emu->regs[regs_abi[pos++]].q[0];
-                    else
+                    else {
                         *mystack = *st;
+                        ++st;
+                    }
                     ++mystack;
-                    ++st;
                     state = 0;
                 } else state = 0; //???
                 break;
@@ -1609,10 +1617,11 @@ void myStackAlignGVariantNew(x64emu_t* emu, const char* fmt, uint64_t* st, uint6
                 if (*p == 'y') {
                     if (pos < 6)
                         *mystack = emu->regs[regs_abi[pos++]].q[0];
-                    else
+                    else {
                         *mystack = *st;
+                        ++st;
+                    }
                     ++mystack;
-                    ++st;
                     state = 0;
                 } else state = 0; //???
                 break;

--- a/src/libtools/myalign32.c
+++ b/src/libtools/myalign32.c
@@ -80,18 +80,11 @@ void myStackAlign32(const char* fmt, uint32_t* st, uint64_t* mystack)
                     case 's': state = 30; break; // pointers
                     case '$': ++p; break; // should issue a warning, it's not handled...
                     case '*': *(mystack++) = *(st++); ++p; break; // fetch an int in the stack....
-                    case ' ': state=(state==1)?6:0; ++p; break;
+                    case ' ': ++p; break;
                     default:
                         state=20; // other stuff, put an int...
                 }
                 break;
-            case 6: // %"space", wants number number now
-                    switch(*p) {
-                        case '0'...'9': state = 1; ++p; break;
-                        default:
-                            state = 0; break;   // something else
-                    }
-                    break;
             case 11:    //double
             case 12:    //%lg, still double
             case 13:    //%llg, still double
@@ -758,18 +751,11 @@ void myStackAlignW32(const char* fmt, uint32_t* st, uint64_t* mystack)
                     case 's': state = 30; break; // pointers
                     case '$': ++p; break; // should issue a warning, it's not handled...
                     case '*': *(mystack++) = *(st++); ++p; break; // fetch an int in the stack....
-                    case ' ': state=(state==1)?6:0; ++p; break;
+                    case ' ': ++p; break;
                     default:
                         state=20; // other stuff, put an int...
                 }
                 break;
-            case 6: // %"space", wants number number now
-                    switch(*p) {
-                        case '0'...'9': state = 1; ++p; break;
-                        default:
-                            state = 0; break;   // something else
-                    }
-                    break;
             case 11:    //double
             case 12:    //%lg, still double
             case 13:    //%llg, still double


### PR DESCRIPTION
1. Preserve `state` across spaces and `%m` modifiers.

2. Initialize GVariant parser state(`tmp`) for `a` and `@` formats.

3. Advance the `st` only when an argument is read from stack.

4. Ignore NULL in XCB display registrations.

5. Fix space handling in the 32-bit wide scanf parser.