### PR TITLE
[WRAPPER] Wrapper some libc symbols

### DIFF
--- a/src/libtools/static_threads.h
+++ b/src/libtools/static_threads.h
@@ -64,6 +64,7 @@ int my_pthread_mutexattr_setpshared(x64emu_t* emu, my_mutexattr_t *attr, int p);
 int my_pthread_mutexattr_settype(x64emu_t* emu, my_mutexattr_t *attr, int t);
 int my___pthread_mutexattr_settype(x64emu_t* emu, my_mutexattr_t *attr, int t);
 int my_pthread_mutexattr_setrobust(x64emu_t* emu, my_mutexattr_t *attr, int t);
+int my_pthread_mutexattr_setrobust_np(x64emu_t* emu, my_mutexattr_t *attr, int t);
 int my_pthread_mutex_init(pthread_mutex_t *m, my_mutexattr_t *att);
 int my___pthread_mutex_init(pthread_mutex_t *m, my_mutexattr_t *att);
 int my_pthread_condattr_destroy(x64emu_t* emu, my_condattr_t* c);

--- a/src/libtools/threads.c
+++ b/src/libtools/threads.c
@@ -1140,6 +1140,8 @@ EXPORT int my_pthread_mutexattr_setrobust(x64emu_t* emu, my_mutexattr_t *attr, i
 	attr->x86 = mattr.x86;
 	return ret;
 }
+EXPORT int my_pthread_mutexattr_setrobust_np(x64emu_t* emu, my_mutexattr_t *attr, int t)
+    __attribute__((alias("my_pthread_mutexattr_setrobust")));
 #endif
 
 #ifdef __SIZEOF_PTHREAD_MUTEX_T

--- a/src/wrapped/generated/functions_list.txt
+++ b/src/wrapped/generated/functions_list.txt
@@ -6370,6 +6370,7 @@ wrappedlibpthread:
   - pthread_mutexattr_setprotocol
   - pthread_mutexattr_setpshared
   - pthread_mutexattr_setrobust
+  - pthread_mutexattr_setrobust_np
   - pthread_mutexattr_settype
 - iFpL:
   - pthread_attr_setguardsize

--- a/src/wrapped/generated/wrappedlibpthreadtypes.h
+++ b/src/wrapped/generated/wrappedlibpthreadtypes.h
@@ -68,6 +68,7 @@ typedef int32_t (*iFpppp_t)(void*, void*, void*, void*);
 	GO(pthread_mutexattr_setprotocol, iFpi_t) \
 	GO(pthread_mutexattr_setpshared, iFpi_t) \
 	GO(pthread_mutexattr_setrobust, iFpi_t) \
+	GO(pthread_mutexattr_setrobust_np, iFpi_t) \
 	GO(pthread_mutexattr_settype, iFpi_t) \
 	GO(pthread_attr_setguardsize, iFpL_t) \
 	GO(pthread_attr_setstacksize, iFpL_t) \

--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -18,6 +18,8 @@ struct argp_state;
 #endif
 #ifdef STATICBUILD
 extern int _nl_msg_cat_cntr __attribute__((weak));
+extern const char *const _sys_siglist[] __asm__("__sys_siglist");
+extern const char *const sys_siglist[] __asm__("__sys_siglist");
 #endif
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/wrapped/wrappedlibc_private.h
+++ b/src/wrapped/wrappedlibc_private.h
@@ -2198,8 +2198,8 @@ GOW(sysinfo, iFp)
 GOM(syslog, vFEipV)
 GOM(__syslog_chk, vFEiipV)
 //DATA(sys_sigabbrev, 
-//DATA(_sys_siglist, 
-//DATA(sys_siglist, 
+DATA(_sys_siglist, 8)
+DATA(sys_siglist, 8)
 GOW(system, iFp)
 GOM(__sysv_signal, pFEip)
 GOWM(sysv_signal, pFEip)

--- a/src/wrapped/wrappedlibpthread_private.h
+++ b/src/wrapped/wrappedlibpthread_private.h
@@ -175,7 +175,7 @@ GO(pthread_mutexattr_setprioceiling, iFpi)
 GO(pthread_mutexattr_setprotocol, iFpi)
 GO(pthread_mutexattr_setpshared, iFpi)
 GO(pthread_mutexattr_setrobust, iFpi)
-//GO(pthread_mutexattr_setrobust_np, 
+GO2(pthread_mutexattr_setrobust_np, iFpi, pthread_mutexattr_setrobust)
 GO(__pthread_mutexattr_settype, iFpi)
 GO(pthread_mutexattr_settype, iFpi)
 #else
@@ -195,11 +195,11 @@ GOM(pthread_mutexattr_setprioceiling, iFEpi)
 GOM(pthread_mutexattr_setprotocol, iFEpi)
 GOM(pthread_mutexattr_setpshared, iFEpi)
 GOM(pthread_mutexattr_setrobust, iFEpi)
-//GO(pthread_mutexattr_setrobust_np, 
+GOM(pthread_mutexattr_setrobust_np, iFEpi)
 GOM(__pthread_mutexattr_settype, iFEpi)
 GOM(pthread_mutexattr_settype, iFEpi)
 #endif
-//GO(pthread_mutex_consistent_np, 
+GO2(pthread_mutex_consistent_np, iFp, pthread_mutex_consistent)
 GO(pthread_mutex_clocklock, iFpip)
 GO(pthread_mutex_consistent, iFp)
 GO(__pthread_mutex_destroy, iFp)


### PR DESCRIPTION
1. pthread_mutexattr_setrobust_np
2. pthread_mutex_consistent_np
3. sys_siglist

These symbols are used by libapr.so in dingtalk.