### PR TITLE
[BOX32] Revive fwprintf/vfwprintf/vwprintf wrappers

### DIFF
--- a/src/wrapped32/wrappedlibc.c
+++ b/src/wrapped32/wrappedlibc.c
@@ -976,6 +976,14 @@ EXPORT int my32_wprintf(x64emu_t *emu, void* fmt, void* V) {
     }
     return vwprintf(fmt, VARARGS_32);
 }
+EXPORT int my32_vwprintf(x64emu_t *emu, void* fmt, void* b) __attribute__((alias("my32_wprintf")));
+EXPORT int my32_fwprintf(x64emu_t *emu, void* F, void* fmt, void* V)  {
+    // need to align on arm
+    myStackAlignW32((const char*)fmt, V, emu->scratch);
+    PREPARE_VALIST_32;
+    return vfwprintf((FILE*)F, fmt, VARARGS_32);
+}
+EXPORT int my32_vfwprintf(x64emu_t *emu, void* F, void* fmt, void* b) __attribute__((alias("my32_fwprintf")));
 #if 0
 EXPORT int my32___wprintf_chk(x64emu_t *emu, int flag, void* fmt, void* V) {
     #ifndef NOALIGN
@@ -989,42 +997,7 @@ EXPORT int my32___wprintf_chk(x64emu_t *emu, int flag, void* fmt, void* V) {
     return vwprintf((const wchar_t*)fmt, (va_list)V);
     #endif
 }
-EXPORT int my32_fwprintf(x64emu_t *emu, void* F, void* fmt, void* V)  {
-    #ifndef NOALIGN
-    // need to align on arm
-    myStackAlignW((const char*)fmt, V, emu->scratch);
-    PREPARE_VALIST_32;
-    void* f = vfwprintf;
-    return ((iFppp_t)f)(F, fmt, VARARGS_32);
-    #else
-    // other platform don't need that
-    return vfwprintf((FILE*)F, (const wchar_t*)fmt, V);
-    #endif
-}
 EXPORT int my32___fwprintf_chk(x64emu_t *emu, void* F, void* fmt, void* V) __attribute__((alias("my32_fwprintf")));
-
-EXPORT int my32_vfwprintf(x64emu_t *emu, void* F, void* fmt, void* b) {
-    #ifndef NOALIGN
-    myStackAlignW((const char*)fmt, b, emu->scratch);
-    PREPARE_VALIST_32;
-    void* f = vfwprintf;
-    return ((iFppp_t)f)(F, fmt, VARARGS_32);
-    #else
-    return vfwprintf(F, fmt, b);
-    #endif
-}
-
-EXPORT int my32_vwprintf(x64emu_t *emu, void* fmt, void* b) {
-    #ifndef NOALIGN
-    myStackAlignW((const char*)fmt, b, emu->scratch);
-    PREPARE_VALIST_32;
-    void* f = vwprintf;
-    return ((iFpp_t)f)(fmt, VARARGS_32);
-    #else
-    void* f = vwprintf;
-    return ((iFpp_t)f)(fmt, b);
-    #endif
-}
 #endif
 EXPORT void *my32_div(void *result, int numerator, int denominator) {
     *(div_t *)result = div(numerator, denominator);

--- a/src/wrapped32/wrappedlibc_private.h
+++ b/src/wrapped32/wrappedlibc_private.h
@@ -454,7 +454,7 @@ GO2(__futimens64, iEip, futimens)
 GOWM(futimes, iEEip)
 //GO(futimesat, iEippp)
 // fwide
-//GOWM(fwprintf, iEEppV)   //%%
+GOWM(fwprintf, iEESpV)   //%%
 //GOM(__fwprintf_chk, iEEpvpV) //%%
 //GO(__fwritable, iEp)
 GOW(fwrite, LEpLLS)
@@ -1951,7 +1951,7 @@ GOM(vfprintf, iEESpp) //%%
 GOM(__vfprintf_chk, iEESipp) //%%
 //GOWM(vfscanf, iEEppp)  //%%
 // __vfscanf
-//GOWM(vfwprintf, iEEppp)    //%%
+GOWM(vfwprintf, iEESpp)    //%%
 //GO2(__vfwprintf_chk, iEEpvpp, my_vfwprintf)
 //GOW(vfwscanf, iEppp)
 // vhangup
@@ -1976,7 +1976,7 @@ GOM(__vsyslog_chk, vEEiipp)
 // vtimes
 //GOM(vwarn, vEEppp) //%%
 // vwarnx
-//GOM(vwprintf, iEEpp) //%%
+GOM(vwprintf, iEEpp) //%%
 //GO2(__vwprintf_chk, iEEvpp, my_vwprintf)
 //GO(vwscanf, iEpp)
 GOW(wait, iEp)


### PR DESCRIPTION
These three had their table entries commented out and implementations parked in `#if 0` since before the W32 renames, so 32-bit programs using them abort with `Symbol fwprintf not found`. Reworked to the current pattern following `my32_wprintf`; the FILE arguments use the `S` conversion types like `fprintf`/`vfprintf`. Existing wrapper types only — no regeneration needed.

Tested on x86_64 with BOX32: an i386 test hitting all three fails with symbol-not-found on main and prints correctly with this patch. Originally hit via a closed-source i386 wide-char tool from an ASUS router SDK (as discussed on Discord).