### PR TITLE
[RV64_DYNAREC] Support PHSUBD and PEXTRB opcode

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_660f38.c
+++ b/src/dynarec/rv64/dynarec_rv64_660f38.c
@@ -214,6 +214,38 @@ uintptr_t dynarec64_660F38(dynarec_rv64_t* dyn, uintptr_t addr, uint8_t opcode, 
                         }
                     }
                     break;
+                case 0x06:
+                    INST_NAME("PHSUBD Gx, Ex");
+                    nextop = F8;
+                    GETGX();
+                    // GX->sd[0] -= GX->sd[1];
+                    LW(x3, gback, gdoffset + 0 * 4);
+                    LW(x4, gback, gdoffset + 1 * 4);
+                    SUBW(x3, x3, x4);
+                    SW(x3, gback, gdoffset + 0 * 4);
+                    // GX->sd[1] = GX->sd[2] - GX->sd[3];
+                    LW(x3, gback, gdoffset + 2 * 4);
+                    LW(x4, gback, gdoffset + 3 * 4);
+                    SUBW(x3, x3, x4);
+                    SW(x3, gback, gdoffset + 1 * 4);
+                    if (MODREG && gd == ((nextop & 7) + (rex.b << 3))) {
+                        // GX->q[1] = GX->q[0];
+                        LD(x3, gback, gdoffset + 0);
+                        SD(x3, gback, gdoffset + 8);
+                    } else {
+                        GETEX(x2, 0, 12);
+                        // GX->sd[2] = EX->sd[0] - EX->sd[1];
+                        LW(x3, wback, fixedaddress + 0 * 4);
+                        LW(x4, wback, fixedaddress + 1 * 4);
+                        SUBW(x3, x3, x4);
+                        SW(x3, gback, gdoffset + 2 * 4);
+                        // GX->sd[3] = EX->sd[2] - EX->sd[3];
+                        LW(x3, wback, fixedaddress + 2 * 4);
+                        LW(x4, wback, fixedaddress + 3 * 4);
+                        SUBW(x3, x3, x4);
+                        SW(x3, gback, gdoffset + 3 * 4);
+                    }
+                    break;
                 case 0x08:
                     INST_NAME("PSIGNB Gx, Ex");
                     nextop = F8;
@@ -1148,6 +1180,24 @@ uintptr_t dynarec64_660F38(dynarec_rv64_t* dyn, uintptr_t addr, uint8_t opcode, 
                             SD(x5, gback, gdoffset + 8);
                             SD(x4, gback, gdoffset + 0);
                         }
+                    }
+                    break;
+                case 0x14:
+                    INST_NAME("PEXTRB Ed, Gx, Ib");
+                    nextop = F8;
+                    GETGX();
+                    if (MODREG) {
+                        ed = TO_NAT((nextop & 7) + (rex.b << 3));
+                        wback = 0;
+                    } else {
+                        addr = geted(dyn, addr, ninst, nextop, &wback, x2, x1, &fixedaddress, rex, NULL, 1, 1);
+                        ed = x1;
+                    }
+                    u8 = F8;
+                    LBU(ed, gback, gdoffset + (u8 & 15));
+                    if (wback) {
+                        SB(ed, wback, fixedaddress);
+                        SMWRITE2();
                     }
                     break;
                 case 0x16:


### PR DESCRIPTION
These two opcode are used by WeMeet app. 

I tested it by 

- https://github.com/zengdage/x86_64-inst-test/blob/main/simd/test_phadd_phsub.c#L94
- https://github.com/zengdage/x86_64-inst-test/blob/main/simd/test_pextr.c#L148