### PR TITLE
[SYSCALL] Align io_uring epoll events

### DIFF
--- a/src/emu/x64syscall.c
+++ b/src/emu/x64syscall.c
@@ -33,7 +33,7 @@
 #include "x64run_private.h"
 //#include "x64primop.h"
 #include "x64trace.h"
-//#include "myalign.h"
+#include "myalign.h"
 #include "box64context.h"
 #include "callback.h"
 #include "signals.h"
@@ -377,10 +377,10 @@ static const scwrap_t syscallwrap[] = {
     [332] = {__NR_statx, 5},
     #endif
     #ifdef __NR_io_uring_setup
-    [425] = {__NR_io_uring_setup, 2},
+    //[425] = {__NR_io_uring_setup, 2},
     #endif
     #ifdef __NR_io_uring_enter
-    [426] = {__NR_io_uring_enter, 6},
+    //[426] = {__NR_io_uring_enter, 6},
     #endif
     #ifdef __NR_io_uring_register
     [427] = {__NR_io_uring_register, 4},
@@ -618,6 +618,7 @@ void EXPORT x64Syscall_linux(x64emu_t *emu)
                 S_RAX = -errno;
             break;
         case 3:  // sys_close
+            io_uring_setup_unregister(S_EDI);
             S_RAX = close(S_EDI);
             if(S_RAX==-1)
                 S_RAX = -errno;
@@ -1038,6 +1039,30 @@ void EXPORT x64Syscall_linux(x64emu_t *emu)
         case 317:   // sys_seccomp
             R_RAX = 0;  // ignoring call
             break;
+        #ifdef __NR_io_uring_setup
+        case 425: { // sys_io_uring_setup
+            void* params = (void*)R_RSI;
+            S_RAX = syscall(__NR_io_uring_setup, R_EDI, params);
+            if(S_RAX==-1)
+                S_RAX = -errno;
+            else
+                io_uring_setup_register(S_RAX, params);
+            break;
+        }
+        #endif
+        #ifdef __NR_io_uring_enter
+        case 426: { // sys_io_uring_enter
+            my_io_uring_aligned_token_t tok = {0};
+            io_uring_enter_before(S_EDI, R_ESI, &tok);
+            S_RAX = syscall(__NR_io_uring_enter, R_EDI, R_ESI, R_EDX, R_R10, R_R8, R_R9);
+            int e = errno;
+            io_uring_enter_after(&tok);
+            errno = e;
+            if(S_RAX==-1)
+                S_RAX = -errno;
+            break;
+        }
+        #endif
         case 334: // It is helpeful to run static binary
             R_RAX = -ENOSYS;
             break;
@@ -1121,6 +1146,7 @@ long EXPORT my_syscall(x64emu_t *emu)
         case 2: // sys_open
             return my_open(emu, (char*)R_RSI, of_convert(R_EDX), R_ECX);
         case 3:  // sys_close
+            io_uring_setup_unregister(R_ESI);
             return close(R_ESI);
         case 4: // sys_stat
             return my_stat(emu, (void*)R_RSI, (void*)R_RDX);
@@ -1413,6 +1439,26 @@ long EXPORT my_syscall(x64emu_t *emu)
         #endif
         case 317:   // sys_seccomp
             return 0;  // ignoring call
+        #ifdef __NR_io_uring_setup
+        case 425: { // sys_io_uring_setup
+            void* params = (void*)R_RDX;
+            long r = syscall(__NR_io_uring_setup, R_ESI, params);
+            if(r >= 0)
+                io_uring_setup_register((int)r, params);
+            return r;
+        }
+        #endif
+        #ifdef __NR_io_uring_enter
+        case 426: { // sys_io_uring_enter
+            my_io_uring_aligned_token_t tok = {0};
+            io_uring_enter_before(S_ESI, R_EDX, &tok);
+            long r = syscall(__NR_io_uring_enter, R_RSI, R_RDX, R_RCX, R_R8, R_R9, u64(0));
+            int e = errno;
+            io_uring_enter_after(&tok);
+            errno = e;
+            return r;
+        }
+        #endif
         #ifndef __NR_faccessat2
         case 439:
             return faccessat(S_ESI, (void*)R_RDX, (mode_t)R_RCX, S_R8d);

--- a/src/include/myalign.h
+++ b/src/include/myalign.h
@@ -324,5 +324,17 @@ typedef struct my_x64_user_s
   unsigned long long int	u_debugreg [8];
 } my_x64_user_t;
 
+// io_uring sqe epoll_event alignment
+typedef struct io_uring_aligned_token_s {
+    void* entries;
+    uint32_t count;
+} my_io_uring_aligned_token_t;
+
+int  io_uring_is_ring(int fd);
+void io_uring_setup_register(int fd, const void* params_ptr);
+void io_uring_setup_unregister(int fd);
+void io_uring_mmap_register(int fd, off_t offset, void* addr, size_t length);
+void io_uring_enter_before(int fd, uint32_t submit, my_io_uring_aligned_token_t* tok);
+void io_uring_enter_after(my_io_uring_aligned_token_t* token);
 
 #endif  //__MY_ALIGN__H_

--- a/src/libtools/myalign.c
+++ b/src/libtools/myalign.c
@@ -4,11 +4,13 @@
 #include <stdint.h>
 #include <wchar.h>
 #include <sys/epoll.h>
+#include <sys/syscall.h>
 #include <fts.h>
 #include <sys/stat.h>
 #include <sys/sem.h>
 #include <pthread.h>
 
+#include "khash.h"
 #include "x64emu.h"
 #include "emu/x64emu_private.h"
 #include "myalign.h"
@@ -1760,3 +1762,236 @@ void unregister_xcb_display(void* d)
             return;
         }
 }
+
+#ifdef __NR_io_uring_setup
+#include <linux/io_uring.h>
+
+typedef struct my_iouring_ring_s {
+    uint32_t sq_entries;
+    uint32_t flags;
+    void*    sq_ring;
+    size_t   sq_ring_len;
+    void*    sqes;
+    size_t   sqes_len;
+    uint32_t sqoff_tail;
+    uint32_t sqoff_ring_mask;
+    uint32_t sqoff_array;
+} my_io_uring_ring_t;
+
+KHASH_MAP_INIT_INT(io_uring_ring, my_io_uring_ring_t)
+static kh_io_uring_ring_t *my_iouring_rings = NULL;
+
+static pthread_mutex_t my_iouring_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static my_io_uring_ring_t* find_uring(int fd)
+{
+    if(!my_iouring_rings)
+        return NULL;
+    khint_t k = kh_get(io_uring_ring, my_iouring_rings, fd);
+    if(k != kh_end(my_iouring_rings))
+        return &kh_value(my_iouring_rings, k);
+    return NULL;
+}
+
+static void drop_uring(int fd)
+{
+    if(!my_iouring_rings)
+        return;
+    khint_t k = kh_get(io_uring_ring, my_iouring_rings, fd);
+    if(k != kh_end(my_iouring_rings))
+        kh_del(io_uring_ring, my_iouring_rings, k);
+}
+
+void io_uring_setup_register(int fd, const void* params)
+{
+    int ret;
+    if (fd < 0 || !params)
+        return;
+    const struct io_uring_params* p = (const struct io_uring_params*)params;
+
+    pthread_mutex_lock(&my_iouring_lock);
+
+    drop_uring(fd);
+    if(!my_iouring_rings) {
+        my_iouring_rings = kh_init(io_uring_ring);
+    }
+
+    khint_t k = kh_put(io_uring_ring, my_iouring_rings, fd, &ret);
+    kh_value(my_iouring_rings, k).sq_entries = p->sq_entries;
+    kh_value(my_iouring_rings, k).flags = p->flags;
+    kh_value(my_iouring_rings, k).sqoff_tail = p->sq_off.tail;
+    kh_value(my_iouring_rings, k).sqoff_ring_mask = p->sq_off.ring_mask;
+    kh_value(my_iouring_rings, k).sqoff_array = p->sq_off.array;
+    kh_value(my_iouring_rings, k).sq_ring = NULL;
+    kh_value(my_iouring_rings, k).sq_ring_len = 0;
+    kh_value(my_iouring_rings, k).sqes = NULL;
+    kh_value(my_iouring_rings, k).sqes_len = 0;
+
+    pthread_mutex_unlock(&my_iouring_lock);
+}
+
+int io_uring_is_ring(int fd)
+{
+    if (fd < 0)
+        return 0;
+    pthread_mutex_lock(&my_iouring_lock);
+    int ret = find_uring(fd) != NULL;
+    pthread_mutex_unlock(&my_iouring_lock);
+    return ret;
+}
+
+void io_uring_mmap_register(int fd, off_t offset, void* addr, size_t length)
+{
+    if (!addr)
+        return;
+
+    uint64_t off = (uint64_t)offset;
+    if (off != IORING_OFF_SQ_RING && off != IORING_OFF_SQES)
+        return;
+
+    pthread_mutex_lock(&my_iouring_lock);
+    my_io_uring_ring_t* r = find_uring(fd);
+    if (r) {
+        if (off == IORING_OFF_SQ_RING) {
+            r->sq_ring = addr;
+            r->sq_ring_len = length;
+        } else if (off == IORING_OFF_SQES) {
+            r->sqes = addr;
+            r->sqes_len = length;
+        }
+    }
+    pthread_mutex_unlock(&my_iouring_lock);
+}
+
+void io_uring_setup_unregister(int fd)
+{
+    if (fd < 0)
+        return;
+    pthread_mutex_lock(&my_iouring_lock);
+    drop_uring(fd);
+    pthread_mutex_unlock(&my_iouring_lock);
+}
+
+typedef struct io_uring_aligned_sqe_s {
+    uint64_t original_addr;
+    struct   io_uring_sqe* sqe;
+    struct   epoll_event event;
+} my_io_uring_aligned_sqe_t;
+
+#define X86_64_IORING_SETUP_SQPOLL      (1U << 1)
+#define X86_64_IORING_SETUP_SQE128      (1U << 10)
+#define X86_64_IORING_SETUP_NO_SQARRAY  (1U << 16)
+
+void io_uring_enter_before(int fd, uint32_t submit, my_io_uring_aligned_token_t* tok)
+{
+    if (submit == 0 || fd < 0)
+        return;
+
+    pthread_mutex_lock(&my_iouring_lock);
+    my_io_uring_ring_t* r = find_uring(fd);
+
+    if (!r || !r->sq_ring || !r->sqes || !r->sq_entries) {
+        pthread_mutex_unlock(&my_iouring_lock);
+        return;
+    }
+
+    if ((r->flags & X86_64_IORING_SETUP_SQPOLL) ||
+        (r->flags & X86_64_IORING_SETUP_SQE128)) {
+        static int warned = 0;
+        if (!warned) {
+            printf_log(LOG_INFO, "Don't support IORING_SETUP_SQPOLL and IORING_SETUP_SQE128\n");
+            warned = 1;
+        }
+        pthread_mutex_unlock(&my_iouring_lock);
+        return;
+    }
+
+    uint32_t* sq_tail = (uint32_t*)((char*)r->sq_ring + r->sqoff_tail);
+    uint32_t* sq_ring_mask = (uint32_t*)((char*)r->sq_ring + r->sqoff_ring_mask);
+    struct io_uring_sqe* sqes = (struct io_uring_sqe*)r->sqes;
+
+    uint32_t tail = *sq_tail;
+    uint32_t mask = *sq_ring_mask;
+
+    // Linux 6.6 supports the IORING_SETUP_NO_SQARRAY mode, where the ring index
+    // can be used directly as the SQE index.
+    int no_sqarray = (r->flags & X86_64_IORING_SETUP_NO_SQARRAY) ? 1 : 0;
+    uint32_t* sq_array = no_sqarray ? NULL : (uint32_t*)((char*)r->sq_ring + r->sqoff_array);
+
+    tok->count = 0;
+    tok->entries = box_calloc(submit, sizeof(my_io_uring_aligned_sqe_t));
+    my_io_uring_aligned_sqe_t* entries = (my_io_uring_aligned_sqe_t*)tok->entries;
+
+    // Submit the [tail-submit, tail) elements in the ring.
+    for (int i = 0; i < submit; ++i) {
+        uint32_t ring_idx = (tail - submit + i) & mask;
+        uint32_t sqe_idx = no_sqarray ? ring_idx : sq_array[ring_idx];
+        if (sqe_idx >= r->sq_entries)
+            continue;
+        struct io_uring_sqe* sqe =
+            (struct io_uring_sqe*)((char*)sqes + (size_t)sqe_idx * sizeof(struct io_uring_sqe));
+
+        if (sqe->opcode != IORING_OP_EPOLL_CTL)
+            continue;
+        if (sqe->len == EPOLL_CTL_DEL || sqe->addr == 0)
+            continue;
+
+        my_io_uring_aligned_sqe_t* ae = &entries[tok->count++];
+        ae->sqe = sqe;
+        ae->original_addr = sqe->addr;
+        AlignEpollEvent(&ae->event, (void*)(uintptr_t)sqe->addr, 1);
+        sqe->addr = (uint64_t)(uintptr_t)(&ae->event);
+    }
+    pthread_mutex_unlock(&my_iouring_lock);
+}
+
+void io_uring_enter_after(my_io_uring_aligned_token_t* tok)
+{
+    if (!tok->entries)
+        return;
+
+    my_io_uring_aligned_sqe_t* entries = (my_io_uring_aligned_sqe_t*)tok->entries;
+
+    pthread_mutex_lock(&my_iouring_lock);
+    for (int i = 0; i < tok->count; ++i) {
+        my_io_uring_aligned_sqe_t* ae = &entries[i];
+        ae->sqe->addr = ae->original_addr;
+    }
+    pthread_mutex_unlock(&my_iouring_lock);
+
+    box_free(tok->entries);
+}
+#else
+#warning "No __NR_io_uring_setup"
+void io_uring_setup_register(int fd, const void* params_ptr)
+{
+    (void)fd;
+    (void)parans_ptr;
+}
+void io_uring_setup_unregister(int fd)
+{
+    (void)fd;
+}
+int io_uring_is_ring(int fd)
+{
+    (void)fd;
+    return 0;
+}
+void io_uring_mmap_register(int fd, off_t offset, void* addr, size_t length)
+{
+    (void)fd;
+    (void)offset;
+    (void)addr;
+    (void)length;
+}
+void io_uring_enter_before(int fd, uint32_t submit, my_io_uring_aligned_token_t* tok)
+{
+    (void)fd;
+    (void)submit;
+    (void)tok;
+}
+void io_uring_enter_after(my_io_uring_aligned_token_t* tok)
+{
+    (void)tok;
+}
+#endif

--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -3847,6 +3847,8 @@ EXPORT void* my_mmap64(x64emu_t* emu, void *addr, size_t length, int prot, int f
     }
     #endif
     if(ret!=MAP_FAILED) {
+        if(fd >= 0 && io_uring_is_ring(fd))
+            io_uring_mmap_register(fd, offset, ret, length);
         if (emu && !(flags & MAP_ANONYMOUS) && (fd > 0)) {
             // the last_mmap will allow mmap created by wine, even those that have hole, to be fully tracked as one single mmap
             // check if the file is actually a PE file to be safe.


### PR DESCRIPTION
This patch addresses an issue where repeated `epoll_pwait` calls cause a hang upon executing `copilot --version`.

While `epoll_wait` family functions perform alignment handling for `epoll_event`, the `epoll_event` passed for `IORING_OP_EPOLL_CTL` submitted through `io_uring_enter` lacks such alignment handling. This results in failures when `io_uring` operates in conjunction with `epoll`.

This patch does the following work:

1. Rewrite the `io_uring_setup` syscall handler to record uring fd state.

2. Track virtual addresses of `IORING_OFF_SQ_RING` and `IORING_OFF_SQES` of the uring fd when mmap is performed.

3. Rewrite the `io_uring_enter` syscall handler. Prior to the `io_uring_enter` syscall, align `epoll_event` if the operation is `IORING_OP_EPOLL_CTL`, restore and clean up after the syscall completes.