### PR TITLE
[CORE] Fix some errors reported in #4214

### DIFF
--- a/src/libtools/vulkanoverlay.c
+++ b/src/libtools/vulkanoverlay.c
@@ -65,7 +65,7 @@ void* wrapVulkanSymbol(my_vulkanoverlay_t* v, const char* name, uintptr_t x64)
         if(!strcmp(name, v->functions[i].f))
             rname = v->functions[i].name;
     if(!rname) rname = name;
-    khint_t k = kh_get(x64wrappers, v->wrappers, name);
+    khint_t k = kh_get(x64wrappers, v->wrappers, rname);
     if(k==kh_end(v->wrappers)) {
         printf_log(LOG_INFO, "Warning, unknown wrapper for %s in Vulkan Overlay\n", rname);
         return NULL;

--- a/src/tools/bridge.c
+++ b/src/tools/bridge.c
@@ -365,38 +365,6 @@ void fini_bridge_helper()
     cleanAlternate();
 }
 
-#ifdef BOX32
-int isNativeCall32(uintptr_t addr, uintptr_t* calladdress, uint16_t* retn)
-{
-#define PK(a)       *(uint8_t*)(addr+a)
-#define PK32(a)     *(uint32_t*)(addr+a)
-
-    if(!addr || !getProtection(addr))
-        return 0;
-    if(PK(0)==0xff && PK(1)==0x25) {  // absolute jump, maybe the GOT
-        ptr_t a1 = (PK32(2));   // need to add a check to see if the address is from the GOT !
-        addr = (uintptr_t)getAlternate(from_ptrv(a1)); 
-    }
-    if(addr<0x10000 || !getProtection(addr))    // too low, that is suspicious
-        return 0;
-    onebridge_t *b = (onebridge_t*)(addr);
-    if(b->CC==0xCC && b->S=='S' && b->C=='C' && b->w!=(wrapper_t)0 && b->f!=(uintptr_t)PltResolver32) {
-        // found !
-        if(retn) *retn = (b->C3==0xC2)?b->N:0;
-        if(calladdress) *calladdress = addr+1;
-        return 1;
-    }
-    return 0;
-#undef PK32
-#undef PK
-}
-#else
-int isNativeCall32(uintptr_t addr, uintptr_t* calladdress, uint16_t* retn)
-{
-    return 0;
-}
-#endif
-
 // Strict readable-range guard: native-call probing must fail-closed.
 // Wine mappings can be transient while loader updates protections.
 static int bridge_can_read_range(uintptr_t p, size_t sz)
@@ -422,6 +390,39 @@ static int bridge_can_read_range(uintptr_t p, size_t sz)
     }
     return 1;
 }
+
+#ifdef BOX32
+int isNativeCall32(uintptr_t addr, uintptr_t* calladdress, uint16_t* retn)
+{
+#define PK(a)       *(uint8_t*)(addr+a)
+#define PK32(a)     *(uint32_t*)(addr+a)
+
+    if (!bridge_can_read_range(addr, 6))
+        return 0;
+    if(PK(0)==0xff && PK(1)==0x25) {  // absolute jump, maybe the GOT
+        ptr_t a1 = (PK32(2));   // need to add a check to see if the address is from the GOT !
+        if (!bridge_can_read_range(from_ptr(a1), sizeof(ptr_t))) return 0;
+        addr = (uintptr_t)getAlternate(from_ptrv(*(ptr_t*)from_ptr(a1)));
+    }
+    if(addr<0x10000 || !bridge_can_read_range(addr, sizeof(onebridge_t)))    // too low, that is suspicious
+        return 0;
+    onebridge_t *b = (onebridge_t*)(addr);
+    if(b->CC==0xCC && b->S=='S' && b->C=='C' && b->w!=(wrapper_t)0 && b->f!=(uintptr_t)PltResolver32) {
+        // found !
+        if(retn) *retn = (b->C3==0xC2)?b->N:0;
+        if(calladdress) *calladdress = addr+1;
+        return 1;
+    }
+    return 0;
+#undef PK32
+#undef PK
+}
+#else
+int isNativeCall32(uintptr_t addr, uintptr_t* calladdress, uint16_t* retn)
+{
+    return 0;
+}
+#endif
 
 int isNativeCallInternal(uintptr_t addr, int is32bits, uintptr_t* calladdress, uint16_t* retn)
 {

--- a/src/tools/cleanup.c
+++ b/src/tools/cleanup.c
@@ -78,6 +78,8 @@ void CallAllCleanup(x64emu_t *emu)
     }
     box_free(my_context->cleanups);
     my_context->cleanups = NULL;
+    my_context->clean_sz = 0;
+    my_context->clean_cap = 0;
 }
 
 void CallQuickCleanup(x64emu_t *emu, int status)

--- a/src/tools/cpumask.c
+++ b/src/tools/cpumask.c
@@ -61,7 +61,7 @@ void cpumask_maxcpu(void* mask, uint32_t sz, uint32_t n)
     for(int i=(n+7)/8; i<sz; ++i)
         m[i] = 0;
     // mask individual bits
-    for(int i=(n%8)+1; i<8; ++i)
+    for(int i=(n%8); i<8; ++i)
         m[n/8] &= ~(1<<i);
 }
 


### PR DESCRIPTION
1. In `wrapVulkanSymbol`, the key should be `rname`.

2. In `isNativeCall32`, `a1` holds the address of the GOT entry rather than the actual jump target address stored within it. And move function `bridge_can_read_range` ahead of `isNativeCall32`.

3. Reset `clean_sz` and `clean_cap` after freeing `clean_ups`, so later `atexit` allocate a new list instead of writing through NULL.

4. Clear CPU mask bits starting at MAXCPU.