### PR TITLE
[WRAPPER] Fix some errors reported in #4214

### DIFF
--- a/src/libtools/libc_net32.c
+++ b/src/libtools/libc_net32.c
@@ -744,16 +744,19 @@ void libc32_net_init()
 
 int ioctl_cgifconf(x64emu_t* emu, int fd, void* arg)
 {
+    struct ifconf conf;
     i386_ifconf_t *i386_conf = (i386_ifconf_t*)arg;
+    conf.ifc_len = i386_conf->ifc_len;
+    conf.ifc_buf = from_ptrv(i386_conf->i386_ifc_buf);
     if(!i386_conf->i386_ifc_buf)
     {
-        return ioctl(fd, SIOCGIFCONF, i386_conf);
+        int ret = ioctl(fd, SIOCGIFCONF, &conf);
+        if(ret >= 0)
+            i386_conf->ifc_len = conf.ifc_len * sizeof(i386_ifreq_t) / sizeof(struct ifreq);
+        return ret;
     }
     else
     {
-        struct ifconf conf;
-        conf.ifc_len = i386_conf->ifc_len;
-        conf.ifc_buf = from_ptrv(i386_conf->i386_ifc_buf);
         int ret = ioctl(fd, SIOCGIFCONF, &conf);
         if(ret<0) return ret;
         i386_ifreq_t *i386_reqs = (i386_ifreq_t*)conf.ifc_buf;

--- a/src/wrapped/wrappedlibxext.c
+++ b/src/wrapped/wrappedlibxext.c
@@ -308,9 +308,9 @@ static void* find_error_Fct(void* fct)
 // error_string ...
 #define GO(A)   \
 static uintptr_t my_error_string_fct_##A = 0;                               \
-static int my_error_string_##A(void* a, int b, void* c, void* d, int e)     \
+static void* my_error_string_##A(void* a, int b, void* c, void* d, int e)   \
 {                                                                           \
-    return RunFunctionFmt(my_error_string_fct_##A, "pippi", a, b, c, d, e); \
+    return (void *)RunFunctionFmt(my_error_string_fct_##A, "pippi", a, b, c, d, e); \
 }
 SUPER()
 #undef GO

--- a/src/wrapped/wrappedlibxfixes_private.h
+++ b/src/wrapped/wrappedlibxfixes_private.h
@@ -15,7 +15,7 @@ GO(XFixesCreateRegionFromWindow, LFpLi)
 GO(XFixesDestroyPointerBarrier, vFpL)
 GO(XFixesDestroyRegion, vFpL)
 GO(XFixesExpandRegion, vFpLLuuuu)
-DATA(XFixesExtensionInfo, sizeof(void*))    //B
+DATAB(XFixesExtensionInfo, 3 * sizeof(void*))    //B
 DATA(XFixesExtensionName, sizeof(void*))    //D
 GO(XFixesFetchRegion, pFpLp)
 GO(XFixesFetchRegionAndBounds, pFpLpp)

--- a/src/wrapped/wrappedlibxrender_private.h
+++ b/src/wrapped/wrappedlibxrender_private.h
@@ -25,7 +25,7 @@ GO(XRenderCreateLinearGradient, LFppppi)
 GO(XRenderCreatePicture, LFpLpLp)
 GO(XRenderCreateRadialGradient, LFppppi)
 GO(XRenderCreateSolidFill, LFpp)
-DATAB(XRenderExtensionInfo, sizeof(void*))
+DATAB(XRenderExtensionInfo, 3 * sizeof(void*))
 DATA(XRenderExtensionName, sizeof(void*))   //D
 GO(XRenderFillRectangle, vFpiLpiiuu)
 GO(XRenderFillRectangles, vFpiLppi)

--- a/src/wrapped/wrappedlibz.c
+++ b/src/wrapped/wrappedlibz.c
@@ -157,6 +157,7 @@ EXPORT int my_inflateEnd(x64emu_t* emu, void* str)
 {
     wrapper_stream_z(emu, str);
     int r = my->inflateEnd(str);
+    unwrapper_stream_z(emu, str);
     return r;
 }
 
@@ -181,6 +182,7 @@ EXPORT int my_deflateEnd(x64emu_t* emu, void* str)
 {
     wrapper_stream_z(emu, str);
     int r = my->deflateEnd(str);
+    unwrapper_stream_z(emu, str);
     return r;
 }
 

--- a/src/wrapped/wrappedlzma.c
+++ b/src/wrapped/wrappedlzma.c
@@ -257,6 +257,7 @@ EXPORT void my_lzma_end(x64emu_t* emu, lzma_stream_t* stream)
 {
     wrap_alloc_struct(stream->allocator);
     my->lzma_end(stream);
+    unwrap_alloc_struct(stream->allocator);
 }
 
 #include "wrappedlib_init.h"


### PR DESCRIPTION
1. `XFixesExtensionInfo` and `XRenderExtensionInfo` is 24‑bytes in size.

2. The internal `error_string` helper in libXext has a return type of `char *`.

3. Passing an `i386_ifconf_t *` to ioctl results in read overflow.

4. Streams may be reused, so unwrap must still be performed in the `xxx_end` functions of libz and liblzma.