### PR TITLE
[MMAP] Don't allocate bridge bricks in guest low memory for 64bits guests

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1013,6 +1013,9 @@ int initialize(int argc, const char **argv, char** env, x64emu_t** emulator, elf
         box64_wine = 1;
     }
     // Create a new context
+    #ifdef BOX32
+    box64_is32bits = FileIsX86ELF(prog);
+    #endif
     my_context = NewBox64Context(argc - nextarg);
 
     addLibPaths(my_context);

--- a/src/tools/bridge.c
+++ b/src/tools/bridge.c
@@ -53,7 +53,7 @@ brick_t* NewBrick(void* old, int is32bits)
         if(old)
             old = old + NBRICK * sizeof(onebridge_t);
     }
-    void* ptr = box_mmap(old, NBRICK * sizeof(onebridge_t), PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | ((!is32bits && box64_wine)?0:0x40) | MAP_ANONYMOUS, -1, 0); // 0x40 is MAP_32BIT
+    void* ptr = box_mmap(old, NBRICK * sizeof(onebridge_t), PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | (is32bits ? 0x40 : 0) | MAP_ANONYMOUS, -1, 0); // 0x40 is MAP_32BIT
     if(ptr == MAP_FAILED)
         ptr = box_mmap(NULL, NBRICK * sizeof(onebridge_t), PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | ((!is32bits && box64_wine)?0:0x40) | MAP_ANONYMOUS, -1, 0);
     if(ptr == MAP_FAILED) {


### PR DESCRIPTION
The guest can MAP_FIXED over low addresses, destroying the bridges living there, and even munmap them. Only allocate the bridges low for 32bits guests, which needs the guest bitness to be detected before the context is created.