### PR TITLE
[SIGNAL] Preserve SA_RESTART semantics in signal()

### DIFF
--- a/src/libtools/signals.c
+++ b/src/libtools/signals.c
@@ -1436,7 +1436,7 @@ EXPORT sighandler_t my_signal(x64emu_t* emu, int signum, sighandler_t handler)
     my_context->is_sigaction[signum] = 0;
     my_context->restorer[signum] = 0;
     my_context->onstack[signum] = 0;
-    my_context->sigflags[signum] = 0;
+    my_context->sigflags[signum] = SA_RESTART;
     memset(&my_context->sigmask[signum], 0, sizeof(sigset_t));
 
     if(signum==X64_SIGSEGV || signum==X64_SIGBUS || signum==X64_SIGILL || signum==X64_SIGABRT)
@@ -1445,7 +1445,7 @@ EXPORT sighandler_t my_signal(x64emu_t* emu, int signum, sighandler_t handler)
     if(handler!=NULL && handler!=(sighandler_t)1) {
         struct sigaction newact = {0};
         struct sigaction oldact = {0};
-        newact.sa_flags = 0x04;
+        newact.sa_flags = SA_SIGINFO | SA_RESTART;
         newact.sa_sigaction = MY_SIGHANDLER;
         if(sigaction(signal_from_x64(signum), &newact, &oldact)<0)
             return SIG_ERR;


### PR DESCRIPTION
## Summary
Preserve glibc `signal()` BSD semantics by recording `SA_RESTART`.

## Motivation
I tested the LTP support of box64 on RV development board A210 and found that a large number of use cases failed. The reason is that waitpid() was interrupted by the SIGUSR1 signal of the heartbeat handler in the LTP testing framework and returned EINTR.

Glibc's signal() uses BSD semantics and defaults to SA-RETART. Therefore, on native x86_64, after the heartbeat handler returns, waitpid() can be restarted. But on box64, due to the absence of SA-RETART, EINTR was directly returned.

## Test
Before repair
```
./box64 ./accept01
[BOX64] Box64 riscv64 v0.4.5  with Dynarec built on Aug 31 2026 06:11:46
[BOX64] Dynarec for rv64gv_zicbop_zvl128_xtheadba_xtheadbb_xtheadbs_xtheadmempair_xtheadcondmov_xtheadmemidx
[BOX64] Running on - with 8 cores, pagesize: 4096
[BOX64] Will use hardware counter measured at 24.0 MHz emulating 3.0 GHz
[BOX64] Didn't detect 48bits of address space, considering it's 39bits
[BOX64] Counted 30 Env var
[BOX64] Library search path:
[BOX64] Binary search path: ./:bin/:/root/.nvm/versions/node/v24.16.0/bin/:/usr/local/sbin/:/usr/local/bin/:/usr/sbin/:/usr/bin/:/sbin/:/bin/
[BOX64] Looking for /mnt/rtos_ecs/minghq/syscalls/accept/accept01
[BOX64] Rename process to "accept01"
[BOX64] Using native(wrapped) libc.so.6
[BOX64] Using native(wrapped) ld-linux-x86-64.so.2
[BOX64] Using native(wrapped) libpthread.so.0
[BOX64] Using native(wrapped) libdl.so.2
[BOX64] Using native(wrapped) libutil.so.1
[BOX64] Using native(wrapped) librt.so.1
[BOX64] Using native(wrapped) libbsd.so.0
tst_test.c:2047: TINFO: LTP version: 20250930-154-g3e8f1bec5
tst_test.c:2050: TINFO: Tested kernel: 6.6.0 #1 SMP Fri Nov 28 21:58:04 CST 2025 x86_64
tst_kconfig.c:88: TINFO: Parsing kernel config '/proc/config.gz'
tst_test.c:1875: TINFO: Overall timeout per run is 0h 00m 30s
tst_test.c:1927: TBROK: waitpid(12415,0x3f953d8730,0) failed: EINTR (4)

Summary:
passed   0
failed   0
broken   1
skipped  0
warnings 0
accept01.c:91: TPASS: bad file descriptor : EBADF (9)
accept01.c:91: TPASS: invalid socket buffer : EINVAL (22)
accept01.c:91: TPASS: invalid salen : EINVAL (22)
[BOX64] accept01.c:91: TPASS: no queued connections : EINVAL (22)
12410|SIGSEGV @0x34f103ae (???(/mnt/rtos_ecs/minghq/syscalls/accept/accept01+0x7103ae)) (x64pc=0x10001292f/"/mnt/rtos_ecs/minghq/syscalls/accept/accept01/heartbeat_handler + 0xf", rsp=0x3f953d7c08, stack=0x3f94bd9000:0x3f953d9000 own=(nil) fp=0x2), for accessing 0x1c (code=1/prot=0), db=(nil)((nil):(nil)/(nil):(nil)/???:clean, hash:0/0) handler=(nil)
RSP-0x20:0x0000000000000000 RSP-0x18:0x0000000000000000 RSP-0x10:0x0000000000000000 RSP-0x08:0x0000000000000000
RSP+0x00:0x0000000000000000 RSP+0x08:0x0000003f956a3080accept01.c:91: TPASS: UDP accept : EOPNOTSUPP (95)
 RSP+0x10:0x0000000000000000 RSP+0x18:0x0000000000000000
RAX:0x0000000000000000 RCX:0x0000000000000000 RDX:0x0000003f953d7c18 RBX:0x000000000000307f
RSP:0x0000003f953d7c08 RBP:0x0000000000000002 RSI:0x0000003f953d7fe0 RDI:0x000000000000000a
 R8:0x0000000000000000  R9:0xfffffffffffff000 R10:0x00000000000003b7 R11:0x0000000000000000
R12:0x0000000000001000 R13:0x0000003f95697000 R14:0x000000010002d275 R15:0x0000000000000787
ES:0x002b CS:0x0033 SS:0x002b DS:0x002b FS:0x0000 GS:0x0000 FSBASE=0x36bcfd60 GSBASE=(nil)

Segmentation fault
```
After repair
```
./box64-fixsig ./accept01
[BOX64] Box64 riscv64 v0.4.5  with Dynarec built on Aug 31 2026 07:44:13
[BOX64] Dynarec for rv64gv_zicbop_zicond_zvl128_xtheadba_xtheadbb_xtheadbs_xtheadmempair_xtheadcondmov_xtheadmemidx
[BOX64] Running on - with 8 cores, pagesize: 4096
[BOX64] Will use hardware counter measured at 24.0 MHz emulating 3.0 GHz
[BOX64] Didn't detect 48bits of address space, considering it's 39bits
[BOX64] Counted 30 Env var
[BOX64] Library search path:
[BOX64] Binary search path: ./:bin/:/root/.nvm/versions/node/v24.16.0/bin/:/usr/local/sbin/:/usr/local/bin/:/usr/sbin/:/usr/bin/:/sbin/:/bin/
[BOX64] Looking for /mnt/rtos_ecs/minghq/syscalls/accept/accept01
[BOX64] Rename process to "accept01"
[BOX64] Using native(wrapped) libc.so.6
[BOX64] Using native(wrapped) ld-linux-x86-64.so.2
[BOX64] Using native(wrapped) libpthread.so.0
[BOX64] Using native(wrapped) libdl.so.2
[BOX64] Using native(wrapped) libutil.so.1
[BOX64] Using native(wrapped) librt.so.1
[BOX64] Using native(wrapped) libbsd.so.0
tst_test.c:2047: TINFO: LTP version: 20250930-154-g3e8f1bec5
tst_test.c:2050: TINFO: Tested kernel: 6.6.0 #1 SMP Fri Nov 28 21:58:04 CST 2025 x86_64
tst_kconfig.c:88: TINFO: Parsing kernel config '/proc/config.gz'
tst_test.c:1875: TINFO: Overall timeout per run is 0h 00m 30s
accept01.c:91: TPASS: bad file descriptor : EBADF (9)
accept01.c:91: TPASS: invalid socket buffer : EINVAL (22)
accept01.c:91: TPASS: invalid salen : EINVAL (22)
accept01.c:91: TPASS: no queued connections : EINVAL (22)
accept01.c:91: TPASS: UDP accept : EOPNOTSUPP (95)

Summary:
passed   5
failed   0
broken   0
skipped  0
warnings 0
```

## Checklist
    - [x] Tested with `ctest`, 100% pass
    - [x] Rebased on latest `main`