### PR TITLE
[DYNAREC] Add BOX64_DYNAREC_LDACQ to apply STRONGMEM=4 to selected ranges

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -170,6 +170,12 @@ Enable the emulation of x86 strong memory model. Available in WowBox64.
  * 3: All in 2, plus more memory barriers on a regular basis.
  * 4: Mimic x86 TSO similarly to QEMU's approach, for evaluation purposes.
 
+### BOX64_DYNAREC_LDACQ
+
+Apply BOX64_DYNAREC_STRONGMEM level 4 to selected code ranges only, leaving the rest of the program at the global level.
+
+ * module:XXXX-YYYY[,...]: Basename of a module and the hexadecimal RVA range (inclusive-exclusive) to apply it to.
+
 ### BOX64_DYNAREC_VOLATILE_METADATA
 
 Use volatile metadata parsed from PE files, only valid for 64bit Windows games.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -174,7 +174,10 @@ Enable the emulation of x86 strong memory model. Available in WowBox64.
 
 Apply BOX64_DYNAREC_STRONGMEM level 4 to selected code ranges only, leaving the rest of the program at the global level.
 
- * module:XXXX-YYYY[,...]: Basename of a module and the hexadecimal RVA range (inclusive-exclusive) to apply it to.
+ * 0xXXXXXXXX-0xYYYYYYYY: Define the range of addresses (inclusive-exclusive) to apply it to.
+ * module:XXXX-YYYY: Same, but expressed as an hexadecimal RVA range inside a module, resolved when that module is mapped. Useful when the load address is not fixed.
+
+Several ranges can be given, separated by commas.
 
 ### BOX64_DYNAREC_VOLATILE_METADATA
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -170,7 +170,7 @@ Enable the emulation of x86 strong memory model. Available in WowBox64.
  * 3: All in 2, plus more memory barriers on a regular basis.
  * 4: Mimic x86 TSO similarly to QEMU's approach, for evaluation purposes.
 
-### BOX64_DYNAREC_LDACQ
+### BOX64_DYNAREC_STRONGMEM_RANGE
 
 Apply BOX64_DYNAREC_STRONGMEM level 4 to selected code ranges only, leaving the rest of the program at the global level.
 

--- a/src/dynarec/dynarec_helper.h
+++ b/src/dynarec/dynarec_helper.h
@@ -39,7 +39,7 @@
 #define STRONGMEM_QEMU       4 // The level of a mimic to QEMU's strong memory model
 
 #define STRONGMEM_LEVEL()                                 \
-    (LdAcqRangesContains(ip)                              \
+    (StrongMemRangesContains(ip)                          \
             ? STRONGMEM_QEMU                              \
             : ((box64_wine && VolatileRangesContains(ip)) \
                     ? 0                                   \

--- a/src/dynarec/dynarec_helper.h
+++ b/src/dynarec/dynarec_helper.h
@@ -38,7 +38,12 @@
 #define STRONGMEM_SEQ_WRITE  3 // The level of a barrier at every third memory store will be  put
 #define STRONGMEM_QEMU       4 // The level of a mimic to QEMU's strong memory model
 
-#define STRONGMEM_LEVEL() ((box64_wine && VolatileRangesContains(ip)) ? 0 : BOX64DRENV(dynarec_strongmem))
+#define STRONGMEM_LEVEL()                                 \
+    (LdAcqRangesContains(ip)                              \
+            ? STRONGMEM_QEMU                              \
+            : ((box64_wine && VolatileRangesContains(ip)) \
+                    ? 0                                   \
+                    : BOX64DRENV(dynarec_strongmem)))
 
 #if STEP == 1
 

--- a/src/include/env.h
+++ b/src/include/env.h
@@ -62,7 +62,7 @@ extern char* ftrace_name;
     INTEGER(BOX64_DYNAREC_FASTROUND, dynarec_fastround, 1, 0, 2, 1, 2)           \
     INTEGER(BOX64_DYNAREC_FORWARD, dynarec_forward, 128, 0, 1024, 1, 3)          \
     STRING(BOX64_DYNAREC_GDBJIT, dynarec_gdbjit_str, 0, 0)                       \
-    STRING(BOX64_DYNAREC_LDACQ, dynarec_ldacq, 1, 0)                             \
+    STRING(BOX64_DYNAREC_STRONGMEM_RANGE, dynarec_strongmem_range, 1, 0)          \
     INTEGER(BOX64_DYNAREC_LOG, dynarec_log, 0, 0, 3, 1, 0)                       \
     INTEGER(BOX64_DYNAREC_MISSING, dynarec_missing, 0, 0, 2, 1, 0)               \
     BOOLEAN(BOX64_DYNAREC_NATIVEFLAGS, dynarec_nativeflags, 1, 1, 1)             \

--- a/src/include/env.h
+++ b/src/include/env.h
@@ -62,6 +62,7 @@ extern char* ftrace_name;
     INTEGER(BOX64_DYNAREC_FASTROUND, dynarec_fastround, 1, 0, 2, 1, 2)           \
     INTEGER(BOX64_DYNAREC_FORWARD, dynarec_forward, 128, 0, 1024, 1, 3)          \
     STRING(BOX64_DYNAREC_GDBJIT, dynarec_gdbjit_str, 0, 0)                       \
+    STRING(BOX64_DYNAREC_LDACQ, dynarec_ldacq, 1, 0)                             \
     INTEGER(BOX64_DYNAREC_LOG, dynarec_log, 0, 0, 3, 1, 0)                       \
     INTEGER(BOX64_DYNAREC_MISSING, dynarec_missing, 0, 0, 2, 1, 0)               \
     BOOLEAN(BOX64_DYNAREC_NATIVEFLAGS, dynarec_nativeflags, 1, 1, 1)             \

--- a/src/include/pe_tools.h
+++ b/src/include/pe_tools.h
@@ -11,4 +11,10 @@ int VolatileRangesContains(uintptr_t addr);
 // Check if a given address is contained within the volatile opcode entries.
 int VolatileOpcodesHas(uintptr_t addr);
 
+// Register load-acquire ranges for a module, from a "<module>:<rvaStart>-<rvaEnd>[,...]" spec.
+void RegisterLdAcqRanges(const char* spec, const char* filename, void* addr);
+
+// Check if a given address is contained within the load-acquire ranges.
+int LdAcqRangesContains(uintptr_t addr);
+
 #endif // __PE_TOOLS_H__

--- a/src/include/pe_tools.h
+++ b/src/include/pe_tools.h
@@ -11,10 +11,11 @@ int VolatileRangesContains(uintptr_t addr);
 // Check if a given address is contained within the volatile opcode entries.
 int VolatileOpcodesHas(uintptr_t addr);
 
-// Register load-acquire ranges for a module, from a "<module>:<rvaStart>-<rvaEnd>[,...]" spec.
-void RegisterLdAcqRanges(const char* spec, const char* filename, void* addr);
+// Register strong memory ranges, from a comma separated spec of "<start>-<end>" (plain addresses)
+// and/or "<module>:<rvaStart>-<rvaEnd>" (resolved when that module is mapped) entries.
+void RegisterStrongMemRanges(const char* spec, const char* filename, void* addr);
 
-// Check if a given address is contained within the load-acquire ranges.
-int LdAcqRangesContains(uintptr_t addr);
+// Check if a given address is contained within the strong memory ranges.
+int StrongMemRangesContains(uintptr_t addr);
 
 #endif // __PE_TOOLS_H__

--- a/src/os/os_wine.c
+++ b/src/os/os_wine.c
@@ -301,11 +301,11 @@ int VolatileOpcodesHas(uintptr_t addr)
     return 0;
 }
 
-void RegisterLdAcqRanges(const char* spec, const char* filename, void* addr)
+void RegisterStrongMemRanges(const char* spec, const char* filename, void* addr)
 {
 }
 
-int LdAcqRangesContains(uintptr_t addr)
+int StrongMemRangesContains(uintptr_t addr)
 {
     return 0;
 }

--- a/src/os/os_wine.c
+++ b/src/os/os_wine.c
@@ -301,6 +301,15 @@ int VolatileOpcodesHas(uintptr_t addr)
     return 0;
 }
 
+void RegisterLdAcqRanges(const char* spec, const char* filename, void* addr)
+{
+}
+
+int LdAcqRangesContains(uintptr_t addr)
+{
+    return 0;
+}
+
 void PrintfFtrace(int prefix, const char* fmt, ...)
 {
     static char buf[1024] = { 0 };

--- a/src/tools/env.c
+++ b/src/tools/env.c
@@ -867,6 +867,7 @@ void RecordEnvMappings(uintptr_t addr, size_t length, int fd)
         // First time we see this file
         if (box64_wine && BOX64ENV(unityplayer)) DetectUnityPlayer(lowercase_filename+1);
         if (box64_wine && !box64_is32bits && BOX64ENV(dynarec_volatile_metadata)) ParseVolatileMetadata(fullname, (void*)addr);
+        if (BOX64ENV(dynarec_ldacq)) RegisterLdAcqRanges(BOX64ENV(dynarec_ldacq), fullname, (void*)addr);
         #if defined(DYNAREC) && !defined(WIN32)
         int dynacache = box64env.dynacache;
         if(mapping->env && mapping->env->is_dynacache_overridden)

--- a/src/tools/env.c
+++ b/src/tools/env.c
@@ -867,7 +867,7 @@ void RecordEnvMappings(uintptr_t addr, size_t length, int fd)
         // First time we see this file
         if (box64_wine && BOX64ENV(unityplayer)) DetectUnityPlayer(lowercase_filename+1);
         if (box64_wine && !box64_is32bits && BOX64ENV(dynarec_volatile_metadata)) ParseVolatileMetadata(fullname, (void*)addr);
-        if (BOX64ENV(dynarec_strongmem_range)) RegisterLdAcqRanges(BOX64ENV(dynarec_strongmem_range), fullname, (void*)addr);
+        if (BOX64ENV(dynarec_strongmem_range)) RegisterStrongMemRanges(BOX64ENV(dynarec_strongmem_range), fullname, (void*)addr);
         #if defined(DYNAREC) && !defined(WIN32)
         int dynacache = box64env.dynacache;
         if(mapping->env && mapping->env->is_dynacache_overridden)

--- a/src/tools/env.c
+++ b/src/tools/env.c
@@ -867,7 +867,7 @@ void RecordEnvMappings(uintptr_t addr, size_t length, int fd)
         // First time we see this file
         if (box64_wine && BOX64ENV(unityplayer)) DetectUnityPlayer(lowercase_filename+1);
         if (box64_wine && !box64_is32bits && BOX64ENV(dynarec_volatile_metadata)) ParseVolatileMetadata(fullname, (void*)addr);
-        if (BOX64ENV(dynarec_ldacq)) RegisterLdAcqRanges(BOX64ENV(dynarec_ldacq), fullname, (void*)addr);
+        if (BOX64ENV(dynarec_strongmem_range)) RegisterLdAcqRanges(BOX64ENV(dynarec_strongmem_range), fullname, (void*)addr);
         #if defined(DYNAREC) && !defined(WIN32)
         int dynacache = box64env.dynacache;
         if(mapping->env && mapping->env->is_dynacache_overridden)

--- a/src/tools/pe_tools.c
+++ b/src/tools/pe_tools.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <strings.h>
 #include <unistd.h>
 #include <stddef.h>
 
@@ -324,4 +325,49 @@ int VolatileOpcodesHas(uintptr_t addr)
 {
     if (!volatileOpcodes) return 0;
     return kh_get(volatileopcode, volatileOpcodes, addr) != kh_end(volatileOpcodes);
+}
+
+static rbtree_t* ldacqRanges = NULL; // never freed
+
+void RegisterLdAcqRanges(const char* spec, const char* filename, void* addr)
+{
+    if (!spec || !*spec || !filename) return;
+
+    const char* baseName = strrchr(filename, '/');
+    baseName = baseName ? baseName + 1 : filename;
+    size_t baseLen = strlen(baseName);
+
+    const char* p = spec;
+    while (*p) {
+        while (*p == ',' || *p == ' ') ++p;
+        if (!*p) break;
+
+        const char* colon = strchr(p, ':');
+        const char* comma = strchr(p, ',');
+        if (!colon || (comma && colon > comma)) {
+            p = comma ? comma + 1 : p + strlen(p);
+            continue;
+        }
+        size_t nameLen = (size_t)(colon - p);
+        const char* rest = colon + 1;
+
+        unsigned long long s = 0, e = 0;
+        if (sscanf(rest, "%llx-%llx", &s, &e) == 2 && e > s
+            && nameLen == baseLen && !strncasecmp(baseName, p, nameLen)) {
+            if (!ldacqRanges) ldacqRanges = rbtree_init("ldacqRanges");
+            rb_set(ldacqRanges, (uintptr_t)addr + (uintptr_t)s, (uintptr_t)addr + (uintptr_t)e, 1);
+            printf_log(LOG_INFO, "LDACQ range for %s: %p-%p (rva %llx-%llx)\n",
+                       baseName, (void*)((uintptr_t)addr + (uintptr_t)s),
+                       (void*)((uintptr_t)addr + (uintptr_t)e), s, e);
+        }
+
+        const char* next = strchr(rest, ',');
+        p = next ? next + 1 : rest + strlen(rest);
+    }
+}
+
+int LdAcqRangesContains(uintptr_t addr)
+{
+    if (!ldacqRanges) return 0;
+    return rb_get(ldacqRanges, addr) != 0;
 }

--- a/src/tools/pe_tools.c
+++ b/src/tools/pe_tools.c
@@ -327,47 +327,61 @@ int VolatileOpcodesHas(uintptr_t addr)
     return kh_get(volatileopcode, volatileOpcodes, addr) != kh_end(volatileOpcodes);
 }
 
-static rbtree_t* ldacqRanges = NULL; // never freed
+static rbtree_t* strongMemRanges = NULL; // never freed
 
-void RegisterLdAcqRanges(const char* spec, const char* filename, void* addr)
+void RegisterStrongMemRanges(const char* spec, const char* filename, void* addr)
 {
-    if (!spec || !*spec || !filename) return;
+    static int absolute_done = 0;
 
-    const char* baseName = strrchr(filename, '/');
-    baseName = baseName ? baseName + 1 : filename;
-    size_t baseLen = strlen(baseName);
+    if (!spec || !*spec) return;
+
+    const char* baseName = NULL;
+    size_t baseLen = 0;
+    if (filename) {
+        baseName = strrchr(filename, '/');
+        baseName = baseName ? baseName + 1 : filename;
+        baseLen = strlen(baseName);
+    }
 
     const char* p = spec;
     while (*p) {
         while (*p == ',' || *p == ' ') ++p;
         if (!*p) break;
 
-        const char* colon = strchr(p, ':');
         const char* comma = strchr(p, ',');
-        if (!colon || (comma && colon > comma)) {
-            p = comma ? comma + 1 : p + strlen(p);
-            continue;
-        }
-        size_t nameLen = (size_t)(colon - p);
-        const char* rest = colon + 1;
+        const char* colon = strchr(p, ':');
+        if (colon && comma && colon > comma) colon = NULL; // that colon belongs to a later entry
+        const char* rest = colon ? colon + 1 : p;
 
         unsigned long long s = 0, e = 0;
-        if (sscanf(rest, "%llx-%llx", &s, &e) == 2 && e > s
-            && nameLen == baseLen && !strncasecmp(baseName, p, nameLen)) {
-            if (!ldacqRanges) ldacqRanges = rbtree_init("ldacqRanges");
-            rb_set(ldacqRanges, (uintptr_t)addr + (uintptr_t)s, (uintptr_t)addr + (uintptr_t)e, 1);
-            printf_log(LOG_INFO, "LDACQ range for %s: %p-%p (rva %llx-%llx)\n",
-                       baseName, (void*)((uintptr_t)addr + (uintptr_t)s),
-                       (void*)((uintptr_t)addr + (uintptr_t)e), s, e);
+        if (sscanf(rest, "%llx-%llx", &s, &e) == 2 && e > s) {
+            if (colon) {
+                // "<module>:<rvaStart>-<rvaEnd>": resolved when that module is mapped
+                size_t nameLen = (size_t)(colon - p);
+                if (baseName && nameLen == baseLen && !strncasecmp(baseName, p, nameLen)) {
+                    if (!strongMemRanges) strongMemRanges = rbtree_init("strongMemRanges");
+                    rb_set(strongMemRanges, (uintptr_t)addr + (uintptr_t)s, (uintptr_t)addr + (uintptr_t)e, 1);
+                    printf_log(LOG_INFO, "StrongMem range for %s: %p-%p (rva %llx-%llx)\n",
+                               baseName, (void*)((uintptr_t)addr + (uintptr_t)s),
+                               (void*)((uintptr_t)addr + (uintptr_t)e), s, e);
+                }
+            } else if (!absolute_done) {
+                // "<start>-<end>": plain addresses, module independent, registered once
+                if (!strongMemRanges) strongMemRanges = rbtree_init("strongMemRanges");
+                rb_set(strongMemRanges, (uintptr_t)s, (uintptr_t)e, 1);
+                printf_log(LOG_INFO, "StrongMem range %p-%p\n", (void*)(uintptr_t)s, (void*)(uintptr_t)e);
+            }
         }
 
         const char* next = strchr(rest, ',');
         p = next ? next + 1 : rest + strlen(rest);
     }
+
+    absolute_done = 1;
 }
 
-int LdAcqRangesContains(uintptr_t addr)
+int StrongMemRangesContains(uintptr_t addr)
 {
-    if (!ldacqRanges) return 0;
-    return rb_get(ldacqRanges, addr) != 0;
+    if (!strongMemRanges) return 0;
+    return rb_get(strongMemRanges, addr) != 0;
 }


### PR DESCRIPTION
DISCLAIMER: I have used AI to debug and research a possible solution for Cyberpunk crashing for me on XElite 2 hardware, as well as learning about the codebase.

Crash:
```
EXCEPTION_ACCESS_VIOLATION (0xC0000005)
The thread attempted to write to an inaccessible address at 0x0.

#0 Cyberpunk2077.exe+0x14221a 
#1 Cyberpunk2077.exe+0x14324c
#2 Cyberpunk2077.exe+0x16d50e
#3 Cyberpunk2077.exe+0x1a3abf4
#4 kernel32.dll+0x11649 
```


Example of how I am using it:
```
BOX64_DYNAREC_LDACQ=Cyberpunk2077.exe:142000-144000
```

Ranges desc:
```
RVA	                        function
142190-1422d9	generic ParallelFor executor (where it faulted)
143060-1435d7	job worker main loop + inline ring dequeue
14379c-1437f8	secondary ring pop helper
```

I tried STRONGMEM=4 and it made the launcher unusable FPS-wise.
