### PR TITLE
[WRAPPER] Added libcairo.so.2 as one of NEEDED_LIBS for gdk3 (#2136)

### DIFF
--- a/src/wrapped/wrappedgdk3.c
+++ b/src/wrapped/wrappedgdk3.c
@@ -237,6 +237,6 @@ EXPORT uint32_t my3_gdk_seat_grab(x64emu_t* emu, void* seat, void* window, uint3
 
 #define ALTMY my3_
 
-#define NEEDED_LIBS "libgobject-2.0.so.0", "libgio-2.0.so.0", "libgdk_pixbuf-2.0.so.0"
+#define NEEDED_LIBS "libgobject-2.0.so.0", "libgio-2.0.so.0", "libgdk_pixbuf-2.0.so.0", "libcairo.so.2"
 
 #include "wrappedlib_init.h"


### PR DESCRIPTION
libSwell.so of REAPER depends gdk3 and cairo, but cairo is not correctly loaded. It is similar to gtk3.