### PR TITLE
[RV64_DYNAREC] Fixed PMULDQ vector path using wrong scratch register on VLEN=128

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_660f_vector.c
+++ b/src/dynarec/rv64/dynarec_rv64_660f_vector.c
@@ -669,10 +669,9 @@ uintptr_t dynarec64_660F_vector(dynarec_rv64_t* dyn, uintptr_t addr, uintptr_t i
                         GETGX_vector(v0, 1, VECTOR_SEW32);
                         GETEX_vector(v1, 0, 0, VECTOR_SEW32);
                         d0 = fpu_get_scratch_lmul(dyn, VECTOR_LMUL2);
-                        d1 = fpu_get_scratch(dyn);
                         VWMUL_VV(d0, v0, v1, VECTOR_UNMASKED);
                         SET_ELEMENT_WIDTH(x1, VECTOR_SEW64, 1);
-                        VSLIDEUP_VI(d0, d1, 1, VECTOR_UNMASKED);
+                        VSLIDEUP_VI(d0, d0 + 1, 1, VECTOR_UNMASKED);
                         VMV_V_V(v0, d0);
                     }
                     break;


### PR DESCRIPTION
Problem: PMULDQ instruction produces incorrect DEST[127:64] on VLEN=128 RV64 hardware in vector dynarec path.

Reason: The PMULDQ else branch (vlen < 32) used d1 from fpu_get_scratch() instead of d0 + 1 from the LMUL2 pair in VSLIDEUP_VI, unlike the correct PMULUDQ implementation which uses d0 + 1. This caused DEST[127:64] to read from an uninitialized scratch register.

Fix: Removed d1 = fpu_get_scratch(dyn) and changed VSLIDEUP_VI(d0, d1, 1) to VSLIDEUP_VI(d0, d0 + 1, 1), consistent with PMULUDQ.

Validation: 
- ctest: passed on RV64(c920) hardware.