### PR TITLE
[CMAKE] Disable PIE when fixing Box64 load address

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1387,8 +1387,13 @@ if(NOT NOBOX64)
         # If symbols are missing, try this: target_link_options(${BOX64} PUBLIC -rdynamic)
         if(NOT NOLOADADDR)
             if(CMAKE_C_COMPILER_ID STREQUAL "Clang" OR WITH_MOLD)
-                if(WITH_MOLD) # --image-base requires -no-pie in mold!
-                    set_property(TARGET ${BOX64} APPEND_STRING PROPERTY LINK_FLAGS "-no-pie -lm ")
+                # --image-base alone does not disable PIE with Clang/LLD.
+                # Android requires PIE.
+                if(NOT ANDROID)
+                    target_link_options(${BOX64} PUBLIC -no-pie)
+                endif()
+                if(WITH_MOLD)
+                    set_property(TARGET ${BOX64} APPEND_STRING PROPERTY LINK_FLAGS "-lm ")
                 endif()
                 target_link_options(${BOX64} PUBLIC LINKER:--image-base=${BOX64_ELF_ADDRESS})
             else()


### PR DESCRIPTION
When Box64 is built with Clang on distributions where PIE is enabled by default, the current CMake configuration can produce a PIE executable even though Box64 is linked with `--image-base=0x34800000`.

`--image-base` does not disable PIE with Clang/LLD, so the resulting `ET_DYN` executable can be relocated to a high address at runtime.

This breaks Box32 because some Box32 data structures must be addressable through 32-bit pointers. For example, `wrappedlibc` converts the address of its ctype tables with `to_ptrv()`, which rejects host pointers above 32 bits and aborts.

For reproduction I tested on Debian 13 Arm64 with Clang/LLD:

Both Box64 v0.4.4 branch and latest `main` branch with
`-DARM_DYNAREC=ON
-DBOX32=ON
-DBOX32_BINFMT=ON
-DCMAKE_BUILD_TYPE=RelWithDebInfo`

and the resulting executable is `Type: DYN (Shared object file)` with a preferred load address of `0x34800000`, but is relocated to a high `0xaaaa...` address at runtime. Box32 then aborts during `wrappedlibc_init32()`:

`[BOX32] Warning, pointer 0xaaaa... is not a 32bits value`

The failure was localized with LLDB to:

`box64_abort`
  -> `to_ptrv()`
  -> `ctSetup()`
  -> `wrappedlibc_init32()`

---

Adding `-no-pie` to the link flags changes the executable to `Type: EXEC (Executable file)` and keeps it at the intended `0x34800000` load address, SteamCMD then starts successfully.

So pass `-no-pie` whenever the Clang/mold link path uses the fixed Box64 image base. `NOLOADADDR=ON` remains an explicit opt-out, so builds that request an unfixed load address are unaffected.

Android is explicitly excluded because Android 5.0 and later require position-independent executables. The existing `--image-base` option remains unchanged for Android builds.

Verified as working with Clang/LLD and GCC + ld (GNU ld part is unchanged).