### PR TITLE
[WRAPPER] Check the validity of the path before my_execve

### DIFF
--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -2160,6 +2160,26 @@ static long isProcMem(const char* path)
     return 0;
 }
 
+#define MAX_PATH_LENGTH 4096
+static int isPathValid(const char* path)
+{
+    if(!path)
+        return 0;
+    uintptr_t p = (uintptr_t)path;
+    uintptr_t cache_page = (uintptr_t)-1LL;
+    for(size_t i = 0; i < MAX_PATH_LENGTH; ++i) {
+        uintptr_t page = (p + i) & (~(box64_pagesize - 1));
+        if(page != cache_page) {
+            cache_page = page;
+            if(!(getProtection_fast(cache_page) & PROT_READ))
+                return 0;
+        }
+        if(!path[i])
+            return 1;
+    }
+    return 0;
+}
+
 // buf may not end with NULL and prefix must end with NULL.
 static int start_with(char *buf, ssize_t buflen, char *prefix)
 {
@@ -2923,6 +2943,9 @@ EXPORT int32_t my_execv(x64emu_t* emu, const char* path, char* const argv[])
 
 EXPORT int32_t my_execve(x64emu_t* emu, const char* path, char* const argv[], char* const envp[])
 {
+    if(!isPathValid(path))
+        return execve(path, argv, envp);
+
     int self = isProcSelf(path, "exe");
     int x64 = FileIsX64ELF(path);
     int x86 = my_context->box86path?FileIsX86ELF(path):0;


### PR DESCRIPTION
## Summary
Check the validity of the path before my_execve

## Motivation
I tested the LTP support of box64 on RV development board A210 and partial execve testcases will trigger SEGV, such as execve03.

Before calling host execve(), my_execve() will first treat the guest path as a regular C string for user mode detection. But LTP passed in an illegal path parameter, causing the program to crash. Therefore, it is necessary to add a path validity check.

## Test
Before repair
```
sudo ./box64 ./execve03
[BOX64] Box64 riscv64 v0.4.5 e2219d8fa with Dynarec built on Sep  9 2026 06:28:06
[BOX64] Dynarec for rv64gv_zicbop_zvl128_xtheadba_xtheadbb_xtheadbs_xtheadmempair_xtheadcondmov_xtheadmemidx
[BOX64] Running on - with 8 cores, pagesize: 4096
[BOX64] Will use hardware counter measured at 24.0 MHz emulating 3.0 GHz
[BOX64] Didn't detect 48bits of address space, considering it's 39bits
[BOX64] Counted 21 Env var
[BOX64] Library search path:
[BOX64] Binary search path: ./:bin/:/usr/local/sbin/:/usr/local/bin/:/usr/sbin/:/usr/bin/:/sbin/:/bin/
[BOX64] Looking for /mnt/rtos_ecs/minghq/syscalls/execve/execve03
[BOX64] Rename process to "execve03"
[BOX64] Using native(wrapped) libc.so.6
[BOX64] Using native(wrapped) ld-linux-x86-64.so.2
[BOX64] Using native(wrapped) libpthread.so.0
[BOX64] Using native(wrapped) libdl.so.2
[BOX64] Using native(wrapped) libutil.so.1
[BOX64] Using native(wrapped) librt.so.1
[BOX64] Using native(wrapped) libbsd.so.0
tst_tmpdir.c:316: TINFO: Using /tmp/LTP_exezZ6wmZ as tmpdir (tmpfs filesystem)
tst_test.c:2047: TINFO: LTP version: 20250930-154-g3e8f1bec5
tst_test.c:2050: TINFO: Tested kernel: 6.6.0 #1 SMP Fri Nov 28 21:58:04 CST 2025 x86_64
tst_kconfig.c:88: TINFO: Parsing kernel config '/proc/config.gz'
tst_test.c:1875: TINFO: Overall timeout per run is 0h 00m 30s
execve03.c:102: TPASS: execve failed as expected: ENAMETOOLONG (36)
execve03.c:102: TPASS: execve failed as expected: ENOENT (2)
execve03.c:102: TPASS: execve failed as expected: ENOTDIR (20)
[BOX64] 102797|SIGSEGV @0x3f8c2a1eb0 (execve) (x64pc=0x3f8c393cb3/"box64/execve + 0x13", rsp=0x3f8c0c90c8, stack=0x3f8b8ca000:0x3f8c0ca000 own=(nil) fp=0x10003b190), for accessing 0x3f8c387000 (code=2/prot=0), db=(nil)((nil):(nil)/(nil):(nil)/???:clean, hash:0/0) handler=(nil)
RSP-0x20:0x000000010003c400 RSP-0x18:0x0000000000000000 RSP-0x10:0x0000000100012968 RSP-0x08:0x0000000000000000
RSP+0x00:0x0000000100007cc8 RSP+0x08:0x0000003f8c387000 RSP+0x10:0x0000000000000000 RSP+0x18:0x0000000000000000
RAX:0x0000003f8c18bc38 RCX:0x0000000000000000 RDX:0x0000000000000000 RBX:0x0000003f8c18bc38
RSP:0x0000003f8c0c90c8 RBP:0x000000010003b190 RSI:0x0000003f8c0c90d0 RDI:0x0000003f8c387000
 R8:0x0000000000000001  R9:0x0000003f8c18bc38 R10:0x00000000000003c3 R11:0x0000000000000000
R12:0x0000003f8c387000 R13:0x0000000000000000 R14:0x0000000000000000 R15:0x0000000000000000
ES:0x002b CS:0x0033 SS:0x002b DS:0x002b FS:0x0000 GS:0x0000 FSBASE=0x36c07f60 GSBASE=(nil)

tst_test.c:1953: TBROK: Test killed by SIGSEGV!

Summary:
passed   3
failed   0
broken   1
skipped  0
warnings 0
```
After repair
```
sudo ./box64 ./execve03
[BOX64] Box64 riscv64 v0.4.5 e2219d8fa with Dynarec built on Sep  9 2026 09:38:53
[BOX64] Dynarec for rv64gv_zicbop_zicond_zvl128_xtheadba_xtheadbb_xtheadbs_xtheadmempair_xtheadcondmov_xtheadmemidx
[BOX64] Running on - with 8 cores, pagesize: 4096
[BOX64] Will use hardware counter measured at 24.0 MHz emulating 3.0 GHz
[BOX64] Didn't detect 48bits of address space, considering it's 39bits
[BOX64] Counted 21 Env var
[BOX64] Library search path:
[BOX64] Binary search path: ./:bin/:/usr/local/sbin/:/usr/local/bin/:/usr/sbin/:/usr/bin/:/sbin/:/bin/
[BOX64] Looking for /mnt/rtos_ecs/minghq/syscalls/execve/execve03
[BOX64] Rename process to "execve03"
[BOX64] Using native(wrapped) libc.so.6
[BOX64] Using native(wrapped) ld-linux-x86-64.so.2
[BOX64] Using native(wrapped) libpthread.so.0
[BOX64] Using native(wrapped) libdl.so.2
[BOX64] Using native(wrapped) libutil.so.1
[BOX64] Using native(wrapped) librt.so.1
[BOX64] Using native(wrapped) libbsd.so.0
tst_tmpdir.c:316: TINFO: Using /tmp/LTP_exeCECG8r as tmpdir (tmpfs filesystem)
tst_test.c:2047: TINFO: LTP version: 20250930-154-g3e8f1bec5
tst_test.c:2050: TINFO: Tested kernel: 6.6.0 #1 SMP Fri Nov 28 21:58:04 CST 2025 x86_64
tst_kconfig.c:88: TINFO: Parsing kernel config '/proc/config.gz'
tst_test.c:1875: TINFO: Overall timeout per run is 0h 00m 30s
execve03.c:102: TPASS: execve failed as expected: ENAMETOOLONG (36)
execve03.c:102: TPASS: execve failed as expected: ENOENT (2)
execve03.c:102: TPASS: execve failed as expected: ENOTDIR (20)
execve03.c:102: TPASS: execve failed as expected: EFAULT (14)
execve03.c:102: TPASS: execve failed as expected: EACCES (13)
execve03.c:102: TPASS: execve failed as expected: ENOEXEC (8)

Summary:
passed   6
failed   0
broken   0
skipped  0
warnings 0
```

## Checklist
- [x] Tested with `ctest`, 100% pass
- [x] Rebased on latest `main`