### PR TITLE
[WRAPPER] Limit the maximum length of mmap with MAP_NORESERVE to 96GiB on 39‑bit platforms

### DIFF
--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -3804,6 +3804,22 @@ EXPORT void* my_mmap64(x64emu_t* emu, void *addr, size_t length, int prot, int f
     (void)emu;
     if(BOX64ENV(dynarec_log)>=LOG_DEBUG) {printf_log(LOG_NONE, "mmap64(%p, 0x%zx, 0x%x, 0x%x, %d, %zd) ", addr, length, prot, flags, fd, offset);}
 
+    if(!have48bits && !box64_is32bits) {
+        int mmap_limit_flag = MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE;
+        // Avoid large address-space allocations by V8 sandbox, which will try allocating
+        // 1320/512/256/128 then 64 GiB. In practice, the V8 sandbox does not require such
+        // a large address space.
+        if ((flags & mmap_limit_flag) == mmap_limit_flag &&
+            length > ((size_t)96 << 30) &&
+            !(flags & (MAP_SHARED | MAP_FIXED | MAP_FIXED_NOREPLACE)) &&
+            fd == -1 &&
+            offset == 0) {
+            printf_log(LOG_INFO, "Rejecting mmap of 0x%zx bytes, limit is %d GiB\n", length, 96);
+            errno = ENOMEM;
+            return MAP_FAILED;
+        }
+    }
+
     uintptr_t start = (uintptr_t)addr;
     uintptr_t end = start + length;
     uintptr_t mapped_end = (end + X86_PAGE_SIZE - 1) & ~(X86_PAGE_SIZE - 1);


### PR DESCRIPTION
I am not sure whether this approach is correct, so submit this pr for discussion.


I have recently been debugging the QQ app,  developed by Tencent with hundreds of millions of users in China, and encountered an mmap failure:
```
[BOX64] mmap64(0x86088d9e000, 0xffffff000, 0x0, 0x22, -1, 0) [FATAL:partition_address_space.cc(79)] Check failed: false
```
After investigation, I found that on RISC-V SV39 hardware (which provides a 512 GiB user address space), the V8 sandbox used by QQ reserves a 128 GiB virtual address region. It attempts allocations in descending order: 1320 GiB, 512 GiB, 256 GiB, 128 GiB, 64 GiB and 32 GiB. Later, when the V8 PartitionAlloc module tries to reserve 64 GiB of address space, the mmap call fails and triggers subsequent errors.


To resolve this issue, I added `BOX64_MMAP_LIMIT` to limit the address space size allocated by the V8 sandbox as a workaround. In practice, the V8 sandbox does not actually require such a large address space.