### PR TITLE
[RV64_DYNAREC] Fix VADDSUBPD opcode vector implementation

### DIFF
--- a/src/dynarec/rv64/dynarec_rv64_avx_66_0f_vector.c
+++ b/src/dynarec/rv64/dynarec_rv64_avx_66_0f_vector.c
@@ -856,9 +856,9 @@ uintptr_t dynarec64_AVX_66_0F_vector(dynarec_rv64_t* dyn, uintptr_t addr, uintpt
             VID_V(q2, VECTOR_UNMASKED);
             VAND_VI(q2, q2, 1, VECTOR_UNMASKED);
             VMSEQ_VX(VMASK, q2, xZR, VECTOR_UNMASKED);
-            VFADD_VV(v0, q0, q1, VECTOR_MASKED);
-            VXOR_VI(VMASK, VMASK, 0x1f, VECTOR_UNMASKED);
             VFSUB_VV(v0, q0, q1, VECTOR_MASKED);
+            VXOR_VI(VMASK, VMASK, 0x1f, VECTOR_UNMASKED);
+            VFADD_VV(v0, q0, q1, VECTOR_MASKED);
             PUTGY_vector(v0, VECTOR_SEW64);
             break;
         case 0xD1:


### PR DESCRIPTION
Swap ADD/SUB in the RV64 vector implementation, so even lanes subtract and odd lanes add.

Before:
```
DEST[63:0] := SRC1[63:0] + SRC2[63:0]
DEST[127:64] := SRC1[127:64] - SRC2[127:64]
DEST[191:128] := SRC1[191:128] + SRC2[191:128]
DEST[255:192] := SRC1[255:192] - SRC2[255:192]
```

After:
```
DEST[63:0] := SRC1[63:0] - SRC2[63:0]
DEST[127:64] := SRC1[127:64] + SRC2[127:64]
DEST[191:128] := SRC1[191:128] - SRC2[191:128]
DEST[255:192] := SRC1[255:192] + SRC2[255:192]
```